### PR TITLE
Enables mercs_altevian.dm and applies heartbreaker values

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_altevian.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_altevian.dm
@@ -24,7 +24,7 @@
 	attack_sharp = TRUE
 	attack_edge = 1
 	attacktext = list("slashed")
-	armor = list(melee = 90, bullet = 90, laser = 90, energy = 90, bomb = 90, bio = 100, rad = 100)			//matches stats of suit they drop. Basically tank. Rat tank. Ratank.
+	armor = list(melee = 70, bullet = 70, laser = 70, energy = 30, bomb = 80, bio = 100, rad = 40)			//matches stats of suit they drop. Basically tank. Rat tank. Ratank.
 
 	corpse = /obj/effect/landmark/mobcorpse/altevian
 	loot_list = list(/obj/item/weapon/melee/energy/sword/altevian = 100)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3371,6 +3371,7 @@
 #include "code\modules\mob\living\simple_mob\subtypes\humanoid\possessed_ch.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\humanoid\russian.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\humanoid\mercs\mercs.dm"
+#include "code\modules\mob\living\simple_mob\subtypes\humanoid\mercs\mercs_altevian.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\humanoid\mercs\mercs_ch.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\humanoid\mercs\mercs_vr.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\illusion\illusion.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Nerf Altevian guard armor to match the armor they drop and re-enable them.
<!-- Describe The Pull Request. -->

## Changelog


:cl:
add: Added Altevian guard event NPCs
/:cl: