### PR TITLE
Improvements for OM shuttles! 

### DIFF
--- a/maps/relic_base/overmap/shuttles.dm
+++ b/maps/relic_base/overmap/shuttles.dm
@@ -4,6 +4,7 @@
 	name = "Stargazer"
 	warmup_time = 1
 	current_location = "stargazer_dock"
+	docking_controller_tag = "stargazer"
 	shuttle_area = /area/shuttle/stargazer
 	fuel_consumption = 2
 	move_direction = NORTH
@@ -25,6 +26,7 @@
 	name = "Baby_mammoth"
 	warmup_time = 5
 	current_location = "baby_mammoth_dock"
+	docking_controller_tag = "baby_mammoth"
 	shuttle_area = /area/shuttle/baby_mammoth
 	fuel_consumption = 5
 	move_direction = NORTH
@@ -46,6 +48,7 @@
 	name = "Ursula"
 	warmup_time = 2
 	current_location = "ursula_dock"
+	docking_controller_tag = "ursula"
 	shuttle_area = /area/shuttle/ursula
 	fuel_consumption = 3
 	move_direction = NORTH
@@ -67,6 +70,7 @@
 	name = "Needle"
 	warmup_time = 0
 	current_location = "needle_dock"
+	docking_controller_tag = "needle"
 	shuttle_area = /area/shuttle/needle
 	fuel_consumption = 1
 	move_direction = NORTH
@@ -88,6 +92,7 @@
 	name = "Echidna"
 	warmup_time = 4
 	current_location = "echidna_dock"
+	docking_controller_tag = "echidna"
 	shuttle_area = /area/shuttle/echidna
 	fuel_consumption = 2
 	move_direction = NORTH

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -11619,7 +11619,8 @@
 	base_area = /area/surface/outpost/main/landing/one;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "needle_dock";
-	name = "Needle Dock"
+	name = "Needle Dock";
+	docking_controller = "needle_dock"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -25600,7 +25601,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
-/area/engineering/external_lights)
+/area/surface/outpost/main/landing/one)
 "lhZ" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -30102,7 +30103,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
-/area/engineering/external_lights)
+/area/surface/outpost/main/landing/one)
 "nfR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45012,8 +45013,13 @@
 	c_tag = "CIV - Hangar Pad 1 Southwest";
 	dir = 4
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	pixel_x = -26;
+	frequency = 1380;
+	id_tag = "needle_dock"
+	},
 /turf/simulated/floor/reinforced,
-/area/engineering/external_lights)
+/area/surface/outpost/main/landing/one)
 "tGh" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Civ Bar/Kitchen East 2";
@@ -53529,7 +53535,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
-/area/engineering/external_lights)
+/area/surface/outpost/main/landing/one)
 "xcK" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -2713,6 +2713,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"bvT" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/hull_corner,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/two)
 "bxS" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -4354,6 +4372,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
+"clS" = (
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/rplastihull,
+/area/surface/outpost/main/landing/two)
 "clX" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -5768,6 +5794,17 @@
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
+"cIR" = (
+/obj/structure/cable/heavyduty{
+	d2 = 0;
+	dir = 0;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/blue,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "cIY" = (
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -7228,6 +7265,10 @@
 	dir = 8
 	},
 /obj/random/trash_pile,
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "16-0"
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/main/landing/two)
 "dpN" = (
@@ -8539,6 +8580,18 @@
 	outdoors = -1
 	},
 /area/surface/outside/plains/outpost)
+"dOM" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerjade-on";
+	picked_color = "Jade"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "dOO" = (
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Armory Exterior";
@@ -9139,6 +9192,11 @@
 "dZU" = (
 /obj/structure/railing/grey{
 	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/plains/outpost)
@@ -10636,9 +10694,6 @@
 /area/engineering/hallway/engineer_hallway)
 "eFF" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/power/apc/hyper{
-	pixel_y = -24
-	},
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
@@ -11482,6 +11537,11 @@
 /turf/simulated/wall/r_wall,
 /area/server)
 "eXH" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "eYj" = (
@@ -11575,6 +11635,11 @@
 /obj/structure/closet/walllocker_double/hydrant/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -11676,6 +11741,11 @@
 	dir = 4
 	},
 /obj/structure/railing/grey,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/plains/outpost)
 "fbA" = (
@@ -12282,6 +12352,26 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/chapel/main)
+"fnu" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "fnx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -12652,6 +12742,23 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"fwr" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "fwx" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/tiled/white,
@@ -12702,6 +12809,11 @@
 "fyn" = (
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
@@ -16652,6 +16764,14 @@
 "hiU" = (
 /turf/simulated/wall,
 /area/surface/outside/plains/outpost)
+"hjg" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "hji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -18491,6 +18611,11 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "hWR" = (
@@ -18505,6 +18630,11 @@
 	dir = 1
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "hXm" = (
@@ -18521,6 +18651,11 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/two)
 "hXw" = (
@@ -18770,6 +18905,17 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/mininglockerroom)
+"ibF" = (
+/obj/effect/floor_decal/steeldecal/monofloor{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/two)
 "ibM" = (
 /obj/structure/loot_pile/maint/trash,
 /turf/simulated/floor/plating,
@@ -22576,6 +22722,14 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/rnd/research)
+"jPZ" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/rplastihull,
+/area/surface/outpost/main/landing/two)
 "jQf" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment,
@@ -26277,6 +26431,17 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
+"lvG" = (
+/obj/effect/floor_decal/steeldecal/monofloor{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "lvY" = (
 /obj/item/weapon/flag,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -27681,6 +27846,22 @@
 /obj/structure/dogbed,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
+"mgb" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "mgl" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -28510,6 +28691,14 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/lobby)
+"mzg" = (
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/outside/plains/outpost)
 "mzt" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
@@ -29846,6 +30035,16 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
+"naq" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "nar" = (
 /obj/effect/floor_decal/milspec/color/black,
 /obj/random/obstruction,
@@ -30101,6 +30300,17 @@
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 1 Southeast";
 	dir = 8
+	},
+/obj/structure/cable/blue,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
@@ -30994,6 +31204,19 @@
 	outdoors = 1
 	},
 /area/surface/outside/path/plains)
+"nDx" = (
+/obj/effect/floor_decal/stairs/dark_stairs{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "nDK" = (
 /obj/structure/table/woodentable,
 /obj/machinery/librarycomp,
@@ -33493,6 +33716,11 @@
 	pixel_y = -26;
 	specialfunctions = 4
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "oQE" = (
@@ -33575,6 +33803,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/needle)
@@ -35673,6 +35905,11 @@
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 2 Southwest";
 	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/two)
@@ -41138,6 +41375,15 @@
 	c_tag = "CIV - Hangar Pad 2 Southeast";
 	dir = 8
 	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/two)
 "sch" = (
@@ -41859,6 +42105,23 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/water/atoll,
 /area/surface/outside/plains/outpost)
+"ssk" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "ssv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42646,6 +42909,23 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"sIs" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "sIw" = (
 /obj/structure/table/marble,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -42692,6 +42972,14 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/bmarble,
 /area/surface/outpost/main/dorms/dorm_9)
+"sJV" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/surface/outpost/main/landing/one)
 "sKd" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -45018,6 +45306,11 @@
 	frequency = 1380;
 	id_tag = "needle_dock"
 	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "tGh" = (
@@ -46442,6 +46735,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"uoq" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	picked_color = "Burgundy"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "uos" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -48244,6 +48549,18 @@
 "uVH" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/foyer)
+"uWh" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "uWo" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
@@ -48681,6 +48998,19 @@
 /obj/machinery/chemical_synthesizer,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"vdD" = (
+/obj/effect/floor_decal/stairs/dark_stairs{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "vdF" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -51807,6 +52137,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
+"won" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "wor" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -52889,6 +53236,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7)
+"wLG" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/surface/outpost/main/landing/one)
 "wLM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -97339,12 +97703,12 @@ bkT
 bkT
 bkT
 bzZ
-bzZ
+wLG
 fyn
 fyn
 fyn
-bzZ
-bzZ
+ssk
+fwr
 bkT
 aUl
 wQh
@@ -97596,12 +97960,12 @@ xVX
 xVX
 xVX
 xVX
+hjg
 xVX
 xVX
 xVX
 xVX
-xVX
-bCk
+uoq
 tGe
 ilH
 rLe
@@ -98630,7 +98994,7 @@ szI
 hcr
 hcr
 wwo
-bkT
+sJV
 ipR
 rLe
 lgs
@@ -98887,7 +99251,7 @@ sYY
 hcr
 hcr
 hcr
-bkT
+sJV
 ipR
 rLe
 lgs
@@ -99144,7 +99508,7 @@ tAl
 hcr
 hcr
 hcr
-bkT
+sJV
 ipR
 rLe
 lgs
@@ -100171,7 +100535,7 @@ xVX
 xVX
 xVX
 xVX
-bAq
+dOM
 nfJ
 ilH
 rLe
@@ -100426,9 +100790,9 @@ bCM
 bCM
 fAA
 fAA
-fAA
-bCM
-bCM
+lvG
+sIs
+won
 bkT
 aUl
 rLe
@@ -100683,7 +101047,7 @@ eCt
 faW
 fBc
 fBc
-fBc
+vdD
 hcM
 tdE
 aUl
@@ -100937,17 +101301,17 @@ rLe
 rLe
 rLe
 eEw
-eEw
-hZu
-hZu
-hZu
-hZu
-hZu
-hZu
-hZu
-hZu
-hZu
-hZu
+mzg
+naq
+naq
+fnu
+naq
+naq
+naq
+naq
+naq
+naq
+cIR
 hZu
 yeV
 kPi
@@ -101191,20 +101555,20 @@ xpb
 xpb
 cHG
 djz
-djz
+mgb
 dZU
 dZU
 fby
 fxH
 fxH
-fxH
+nDx
 hev
 hzs
 aUl
 aUl
 rLe
 rLe
-jaB
+uWh
 jIj
 lBW
 pRx
@@ -101454,9 +101818,9 @@ bEa
 cIt
 bFL
 gam
-gam
-cIt
-bFL
+ibF
+bvT
+jPZ
 bmJ
 aUl
 rLe
@@ -101713,7 +102077,7 @@ qAn
 bFI
 cqf
 bFL
-bFL
+clS
 pLS
 ilH
 rLe

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -11542,6 +11542,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "eYj" = (
@@ -11633,13 +11636,13 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/walllocker_double/hydrant/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 6
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -11660,6 +11663,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/needle)
@@ -11686,6 +11698,11 @@
 	landmark_tag = "needle_dock";
 	name = "Needle Dock";
 	docking_controller = "needle_dock"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -12944,6 +12961,9 @@
 /area/surface/outside/plains/outpost)
 "fAc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/needle)
 "fAd" = (
@@ -18046,6 +18066,38 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
+"hHl" = (
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	coverlocked = 0
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/device/t_scanner,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/goggles,
+/obj/item/clothing/glasses/goggles,
+/obj/item/device/geiger,
+/obj/item/device/multitool,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/tank/phoron,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/shuttle/needle)
 "hHp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -23603,6 +23655,21 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/rnd/research)
+"kkl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/power/smes/buildable/power_shuttle{
+	charge = 4e+006;
+	input_attempt = 1;
+	inputting = 1;
+	outputting = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/shuttle/needle)
 "kkn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/milspec,
@@ -26720,6 +26787,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"lDi" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/needle)
 "lDj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -33798,15 +33876,17 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/obj/machinery/power/apc/hyper{
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/structure/cable/blue{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/needle)
@@ -34416,9 +34496,15 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = -28
+/obj/machinery/power/terminal,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/needle)
@@ -34512,6 +34598,11 @@
 	master_tag = "needle";
 	name = "interior access button";
 	pixel_y = 26
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -35492,6 +35583,11 @@
 	master_tag = "needle";
 	name = "exterior access button";
 	pixel_y = 26
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
@@ -39208,9 +39304,8 @@
 "rfg" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/atmospherics/portables_connector{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "rfp" = (
@@ -41032,24 +41127,11 @@
 /turf/simulated/floor,
 /area/surface/outpost/civilian/fishing)
 "rRT" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/engineering,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/glass,
-/obj/item/weapon/tank/phoron,
-/obj/item/weapon/tank/phoron,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/device/multitool,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/device/geiger,
-/obj/item/clothing/glasses/goggles,
-/obj/item/clothing/glasses/goggles,
-/obj/item/device/t_scanner,
-/obj/item/clothing/glasses/welding,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/light,
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "rSf" = (
@@ -98989,7 +99071,7 @@ dDy
 dXx
 eBf
 oRv
-fAg
+hHl
 szI
 hcr
 hcr
@@ -99501,9 +99583,9 @@ cGZ
 dhb
 dEI
 dYW
-eBf
+lDi
 peo
-fAg
+kkl
 tAl
 hcr
 hcr

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -10235,6 +10235,11 @@
 	c_tag = "CIV - Hangar Pad 3 Southwest";
 	dir = 4
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	pixel_x = -26;
+	frequency = 1380;
+	id_tag = "ursula_dock"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -21034,6 +21039,12 @@
 "OR" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	pixel_y = 26;
+	id_tag = "hangar_3";
+	tag_door = "hangar_3_door";
+	frequency = 1380
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -85,12 +85,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -233,6 +234,25 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/ai)
+"aA" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "aB" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -356,20 +376,6 @@
 "aQ" = (
 /turf/simulated/wall/durasteel,
 /area/ai)
-"aR" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerjade-on";
-	picked_color = "Jade"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing/three)
 "aS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -1813,20 +1819,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
-"dI" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on";
-	picked_color = "Burgundy"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "dJ" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI - Exterior Southeast";
@@ -2496,6 +2488,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
 "eT" = (
@@ -2507,8 +2502,14 @@
 	opacity = 1
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
@@ -4907,6 +4908,16 @@
 "jI" = (
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
+"jJ" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "jK" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -5256,6 +5267,11 @@
 	tag_interior_door = "ursula_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "kt" = (
@@ -6861,15 +6877,15 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "nv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -6989,6 +7005,11 @@
 	docking_controller = "ursula_dock";
 	landmark_tag = "ursula_dock";
 	name = "Ursula Dock"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
@@ -8106,6 +8127,25 @@
 /obj/item/weapon/folder/red,
 /turf/simulated/floor/tiled/dark,
 /area/security/main)
+"pC" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "pD" = (
 /obj/structure/toilet,
 /turf/simulated/floor/tiled/freezer,
@@ -8628,6 +8668,11 @@
 	locked = 1;
 	name = "External Access"
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "qz" = (
@@ -8779,29 +8824,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
-"qM" = (
-/obj/effect/floor_decal/emblem/black,
-/turf/simulated/wall/rplastihull,
-/area/surface/outside/plains/outpost)
-"qN" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
+"qL" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerjade-on";
+	picked_color = "Jade"
 	},
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techmaint{
+/turf/simulated/floor/reinforced{
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing/three)
+"qM" = (
+/obj/effect/floor_decal/emblem/black,
+/turf/simulated/wall/rplastihull,
+/area/surface/outside/plains/outpost)
 "qO" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Library North 5";
@@ -10399,7 +10439,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outpost/main/landing/three)
 "tZ" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -10819,21 +10859,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/outpost/main/teleporter)
 "uN" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techmaint{
+/turf/simulated/floor/reinforced{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -11107,21 +11141,19 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "vo" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	picked_color = "Burgundy"
 	},
-/obj/structure/railing,
-/obj/structure/catwalk,
-/obj/structure/lattice,
 /obj/structure/cable/blue{
-	d2 = 2;
-	icon_state = "32-2";
-	d1 = 32
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/open{
+/turf/simulated/floor/reinforced{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/surface/outside/plains/outpost)
 "vp" = (
 /obj/machinery/light/no_nightshift,
 /turf/simulated/floor/glass/reinforced{
@@ -11269,6 +11301,11 @@
 	master_tag = "ursula";
 	name = "interior access button";
 	pixel_y = 26
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
@@ -11574,25 +11611,6 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/heads/sc/sd)
-"wq" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing/three)
 "ws" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -11898,19 +11916,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"wQ" = (
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "wR" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced,
@@ -12247,18 +12252,18 @@
 /area/library_conference_room)
 "xy" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
+	dir = 9
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/danger{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -12856,7 +12861,7 @@
 /turf/simulated/floor/reinforced{
 	outdoors = 1
 	},
-/area/surface/outpost/main/landing/three)
+/area/surface/outside/plains/outpost)
 "yI" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Vault East";
@@ -13337,16 +13342,6 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
-"zK" = (
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "zL" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -17313,16 +17308,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
-"Hl" = (
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "Hm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -18014,25 +17999,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
-"IE" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing/three)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18893,7 +18859,15 @@
 	dir = 1;
 	opacity = 1
 	},
-/obj/machinery/power/smes/buildable/power_shuttle,
+/obj/machinery/power/smes/buildable/power_shuttle{
+	charge = 4e+006;
+	input_attempt = 1;
+	inputting = 1;
+	outputting = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "Kw" = (
@@ -19993,6 +19967,25 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
+"Mx" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "My" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -22571,13 +22564,13 @@
 	dir = 1;
 	opacity = 1
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/port_gen/pacman,
 /obj/item/stack/material/phoron{
 	amount = 10
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
@@ -22605,6 +22598,25 @@
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
+"RC" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "RD" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet/geo,
@@ -22858,11 +22870,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
 "Sf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 1;
 	pixel_x = 25;
@@ -22873,6 +22880,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -24384,20 +24396,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
-"Vf" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on";
-	picked_color = "Burgundy"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/reinforced{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing/three)
 "Vg" = (
 /turf/simulated/wall/wood,
 /area/library_conference_room)
@@ -24787,6 +24785,16 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/quartermaster/qm)
+"Wa" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "Wb" = (
 /obj/item/device/geiger/wall/north,
 /turf/simulated/floor/tiled/techmaint{
@@ -25385,6 +25393,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
+"Xr" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	picked_color = "Burgundy"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "Xs" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -25766,28 +25788,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -26370,6 +26380,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"ZE" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "32-2";
+	d1 = 32
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost/sky)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66737,12 +66763,12 @@ hO
 lO
 lO
 lO
-xy
-IE
-IE
-IE
-IE
-IE
+Mx
+tY
+tY
+tY
+tY
+tY
 tu
 gc
 fO
@@ -66994,13 +67020,13 @@ gQ
 gQ
 gQ
 gQ
-yH
+Wa
 gQ
 gQ
 gQ
 gQ
 gQ
-Vf
+Xr
 tQ
 ON
 zv
@@ -69570,7 +69596,7 @@ gQ
 gQ
 gQ
 gQ
-aR
+qL
 ue
 ON
 zv
@@ -69822,11 +69848,11 @@ hQ
 hQ
 hQ
 hQ
-qN
-wq
-wq
-wq
-wq
+pC
+xy
+xy
+xy
+xy
 tv
 gc
 fO
@@ -70079,7 +70105,7 @@ fW
 qC
 lX
 lX
-Hl
+yH
 Dq
 fW
 fW
@@ -70336,7 +70362,7 @@ zv
 tU
 lX
 lX
-Hl
+yH
 ON
 zv
 zv
@@ -70590,10 +70616,10 @@ EG
 EG
 EG
 EG
-vo
-zK
-zK
-wQ
+ZE
+jJ
+jJ
+uN
 zb
 EG
 EG
@@ -70850,11 +70876,11 @@ Lp
 Lp
 Lp
 Lp
-uN
-tY
-tY
-tY
-tY
+RC
+aA
+aA
+aA
+aA
 tw
 fO
 fO
@@ -71112,7 +71138,7 @@ qM
 ht
 ht
 sR
-dI
+vo
 ug
 ON
 zv

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -356,6 +356,20 @@
 "aQ" = (
 /turf/simulated/wall/durasteel,
 /area/ai)
+"aR" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerjade-on";
+	picked_color = "Jade"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "aS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -1799,6 +1813,20 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
+"dI" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	picked_color = "Burgundy"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "dJ" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI - Exterior Southeast";
@@ -8755,6 +8783,25 @@
 /obj/effect/floor_decal/emblem/black,
 /turf/simulated/wall/rplastihull,
 /area/surface/outside/plains/outpost)
+"qN" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "qO" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Library North 5";
@@ -10015,6 +10062,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/structure/cable/blue{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10030,6 +10080,11 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10045,6 +10100,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/structure/cable/blue{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10240,6 +10298,9 @@
 	frequency = 1380;
 	id_tag = "ursula_dock"
 	},
+/obj/structure/cable/blue{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10250,6 +10311,11 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10278,6 +10344,11 @@
 "tV" = (
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 1
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/reinforced{
 	outdoors = 1
@@ -10312,17 +10383,23 @@
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
 "tY" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
 /obj/structure/cable/blue{
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outpost/main/landing/three)
+/area/surface/outside/plains/outpost)
 "tZ" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -10382,6 +10459,11 @@
 	c_tag = "CIV - Hangar Pad 3 Southeast";
 	dir = 8
 	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10408,6 +10490,9 @@
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 4 Southwest";
 	dir = 4
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -10443,6 +10528,11 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -10462,7 +10552,9 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/cable/blue{
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -10727,21 +10819,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/outpost/main/teleporter)
 "uN" = (
-/obj/structure/lattice,
-/obj/structure/railing{
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/blue{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/surface/outside/plains/outpost)
 "uO" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/light/no_nightshift{
@@ -11012,17 +11107,16 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "vo" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/grille,
 /obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
+	d2 = 2;
+	icon_state = "32-2";
+	d1 = 32
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -11326,10 +11420,7 @@
 "vW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
+/turf/space,
 /area/medical/virology)
 "vX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -11483,6 +11574,25 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/heads/sc/sd)
+"wq" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "ws" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -11788,6 +11898,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"wQ" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "wR" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced,
@@ -12101,9 +12224,6 @@
 /area/medical/virology)
 "xw" = (
 /obj/item/weapon/storage/box/cups,
-/obj/structure/cable/blue{
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
@@ -12126,19 +12246,27 @@
 /turf/simulated/floor/carpet/blue2,
 /area/library_conference_room)
 "xy" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "xz" = (
 /obj/structure/table/glass,
 /obj/item/roller,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
@@ -12155,9 +12283,6 @@
 /area/medical/virology)
 "xA" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
@@ -12724,10 +12849,14 @@
 /area/medical/virology)
 "yH" = (
 /obj/structure/cable/blue{
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "yI" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Vault East";
@@ -13208,6 +13337,16 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
+"zK" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "zL" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -13387,9 +13526,6 @@
 /area/medical/virology)
 "Af" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -13969,9 +14105,6 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
 	},
 /obj/structure/cable/blue{
 	d2 = 8;
@@ -17180,6 +17313,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
+"Hl" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Hm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -17871,6 +18014,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
+"IE" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20368,6 +20530,11 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/zone_divider,
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -24217,6 +24384,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
+"Vf" = (
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	picked_color = "Burgundy"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing/three)
 "Vg" = (
 /turf/simulated/wall/wood,
 /area/library_conference_room)
@@ -66556,12 +66737,12 @@ hO
 lO
 lO
 lO
-hO
-hO
-hO
-hO
-hO
-hO
+xy
+IE
+IE
+IE
+IE
+IE
 tu
 gc
 fO
@@ -66813,13 +66994,13 @@ gQ
 gQ
 gQ
 gQ
+yH
 gQ
 gQ
 gQ
 gQ
 gQ
-gQ
-gZ
+Vf
 tQ
 ON
 zv
@@ -67853,7 +68034,7 @@ yF
 zv
 vT
 xw
-yH
+yD
 Af
 Bp
 CH
@@ -68109,7 +68290,7 @@ tV
 yF
 vl
 vT
-xy
+xa
 yK
 xa
 vT
@@ -68619,9 +68800,9 @@ jZ
 jZ
 gQ
 gQ
-tY
-uN
-vo
+tR
+Dq
+fW
 vW
 xA
 yL
@@ -69389,7 +69570,7 @@ gQ
 gQ
 gQ
 gQ
-gM
+aR
 ue
 ON
 zv
@@ -69641,11 +69822,11 @@ hQ
 hQ
 hQ
 hQ
-hQ
-hQ
-hQ
-hQ
-hQ
+qN
+wq
+wq
+wq
+wq
 tv
 gc
 fO
@@ -69898,7 +70079,7 @@ fW
 qC
 lX
 lX
-lX
+Hl
 Dq
 fW
 fW
@@ -70155,7 +70336,7 @@ zv
 tU
 lX
 lX
-lX
+Hl
 ON
 zv
 zv
@@ -70409,10 +70590,10 @@ EG
 EG
 EG
 EG
-OY
-lX
-lX
-lX
+vo
+zK
+zK
+wQ
 zb
 EG
 EG
@@ -70669,11 +70850,11 @@ Lp
 Lp
 Lp
 Lp
-Lp
-Lp
-Lp
-Lp
-Lp
+uN
+tY
+tY
+tY
+tY
 tw
 fO
 fO
@@ -70931,7 +71112,7 @@ qM
 ht
 ht
 sR
-hv
+dI
 ug
 ON
 zv
@@ -71189,7 +71370,7 @@ rX
 ht
 sS
 lX
-vC
+um
 ON
 zv
 zv
@@ -71446,7 +71627,7 @@ ht
 ht
 lX
 sU
-vC
+um
 ON
 zv
 zv
@@ -71703,7 +71884,7 @@ pi
 pi
 lX
 tz
-vC
+um
 ON
 zv
 zv
@@ -72217,7 +72398,7 @@ ht
 ht
 sV
 lX
-vC
+um
 ON
 zv
 zv
@@ -72474,7 +72655,7 @@ qM
 pi
 sX
 tD
-vC
+um
 ON
 zv
 zv

--- a/maps/relic_base/relicbase-8.dmm
+++ b/maps/relic_base/relicbase-8.dmm
@@ -1328,6 +1328,11 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "echidna_dock";
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "fG" = (
@@ -2465,6 +2470,11 @@
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "stargazer_dock";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
@@ -4553,6 +4563,11 @@
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "baby_mammoth_dock";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
@@ -11602,7 +11617,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "shuttle4_pump"
+	id_tag = "baby_mammoth_pump"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/shuttle/plating,
@@ -12114,14 +12129,14 @@
 "JB" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
-	id_tag = "shuttle4_pump"
+	id_tag = "baby_mammoth_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
-	id_tag = "shuttle4_sensor";
+	id_tag = "baby_mammoth_sensor";
 	pixel_y = 28
 	},
 /turf/simulated/shuttle/plating,
@@ -12143,12 +12158,6 @@
 /turf/simulated/shuttle/wall/voidcraft/no_join,
 /area/shuttle/echidna)
 "Ke" = (
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 1;
-	icon_state = "door_locked";
-	id_tag = "echidna_inner";
-	locked = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -12156,6 +12165,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_inner";
+	name = "Internal Access"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
@@ -12295,7 +12309,8 @@
 	base_area = /area/expoutpost/hangarsix;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "echidna_dock";
-	name = "Echidna Dock"
+	name = "Echidna Dock";
+	docking_controller = "echidna_dock"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
@@ -12306,7 +12321,7 @@
 "LR" = (
 /obj/machinery/shuttle_sensor{
 	dir = 5;
-	id_tag = "shuttle4sens_exp"
+	id_tag = "baby_mammoth_sensor"
 	},
 /turf/simulated/shuttle/wall/voidcraft/lightblue,
 /area/shuttle/baby_mammoth)
@@ -12423,13 +12438,13 @@
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
-	master_tag = "shuttle4_shuttle";
+	master_tag = "baby_mammoth";
 	name = "interior access button";
 	pixel_y = 26
 	},
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "shuttle4_inner";
+	id_tag = "baby_mammoth_inner";
 	locked = 1;
 	name = "Internal Access"
 	},
@@ -12482,7 +12497,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "shuttle4_pump"
+	id_tag = "baby_mammoth_pump"
 	},
 /obj/machinery/light,
 /turf/simulated/shuttle/plating,
@@ -12551,7 +12566,8 @@
 	base_area = /area/expoutpost/hangartwo;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "baby_mammoth_dock";
-	name = "Baby_Mammoth Dock"
+	name = "Baby_Mammoth Dock";
+	docking_controller = "baby_mammoth_dock"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -12703,14 +12719,14 @@
 "Qj" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
-	id_tag = "shuttle4_outer";
+	id_tag = "baby_mammoth_outer";
 	locked = 1;
 	name = "External Access"
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1380;
-	master_tag = "shuttle4_shuttle";
+	master_tag = "baby_mammoth";
 	name = "exterior access button";
 	pixel_y = 26
 	},
@@ -12858,19 +12874,19 @@
 "Rp" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
-	id_tag = "shuttle4_pump"
+	id_tag = "baby_mammoth_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
-	id_tag = "shuttle4_shuttle";
+	id_tag = "baby_mammoth";
 	pixel_y = 26;
-	tag_airpump = "shuttle4_pump";
-	tag_chamber_sensor = "shuttle4_sensor";
-	tag_exterior_door = "shuttle4_outer";
-	tag_interior_door = "shuttle4_inner"
+	tag_airpump = "baby_mammoth_pump";
+	tag_chamber_sensor = "baby_mammoth_sensor";
+	tag_exterior_door = "baby_mammoth_outer";
+	tag_interior_door = "baby_mammoth_inner"
 	},
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -25;
@@ -13021,18 +13037,17 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/echidna)
 "Tv" = (
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 1;
-	icon_state = "door_locked";
-	id_tag = "echidna_outer";
-	locked = 1
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_outer";
+	name = "Internal Access"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "TA" = (
@@ -13145,6 +13160,11 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_inner";
+	name = "Internal Access"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "UX" = (
@@ -13194,7 +13214,8 @@
 	base_area = /area/expoutpost/hangarfour;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "stargazer_dock";
-	name = "Stargazer Dock"
+	name = "Stargazer Dock";
+	docking_controller = "stargazer_dock"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/stargazer)
@@ -13515,6 +13536,11 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_outer";
+	name = "Internal Access"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "Zo" = (


### PR DESCRIPTION

## About The Pull Request

- Adds shuttle docking controller to all OM shuttles and the explo shuttle. All start docked now.
- Adds wiring to charge the Needle and Ursula OM shuttles in Forbearance.
- Minor improvements to some of the OM shuttles:
  - Forbearance OM shuttles start with their APC unlocked.
  - Needle received a SMES and another phoron canister, inspired by current CHOMP's Needle.
  - Ursula had some minor wiring changes. APC charges from SMES now.
  - Echidna airlock fixed, inspired by current CHOMP's Echidna.
  - Baby_mammoth airlock fixed.
## Changelog
:cl:
maptweak: Added wiring to charge OM shuttles docked in Forbearance
maptweak: All shuttles can and start docked.
maptweak: Minor improvements to some of the OM shuttles.
/:cl:
