### PR TITLE
More small map fixes

### DIFF
--- a/code/game/objects/items/devices/radio/radio_tc.dm
+++ b/code/game/objects/items/devices/radio/radio_tc.dm
@@ -1,0 +1,8 @@
+//* Bluespace Radio *//
+/obj/item/device/bluespaceradio/relicbase_prelinked
+	name = "bluespace radio (forbearance)"
+	handset = /obj/item/device/radio/bluespacehandset/linked/relicbase_prelinked
+
+/obj/item/device/radio/bluespacehandset/linked/relicbase_prelinked // Same as Southern Cross. We use their tcomms setup after all
+	bs_tx_preload_id = "Receiver A" //Transmit to a receiver
+	bs_rx_preload_id = "Broadcaster A" //Recveive from a transmitter

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -360,7 +360,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ald" = (
@@ -376,7 +376,7 @@
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aou" = (
@@ -425,7 +425,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "apJ" = (
@@ -436,6 +436,13 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/firstdeck/forestarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"apU" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small/readylight,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aqc" = (
@@ -483,14 +490,14 @@
 "arL" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ata" = (
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/vore/alienanimals/teppi/mutant,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aug" = (
@@ -516,7 +523,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "avp" = (
@@ -867,7 +874,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "axM" = (
@@ -927,7 +934,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aBh" = (
@@ -988,7 +995,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "aEq" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/plating,
@@ -1022,14 +1031,14 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aHz" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aHM" = (
@@ -1078,12 +1087,17 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"aKB" = (
+/turf/simulated/mineral/cave,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "aLc" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aLw" = (
@@ -1192,7 +1206,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aPL" = (
@@ -1236,7 +1250,9 @@
 	})
 "aQy" = (
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "aQP" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight{
@@ -1264,7 +1280,9 @@
 /obj/random/maintenance,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "aRN" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
@@ -1305,6 +1323,15 @@
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"aTf" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aTg" = (
@@ -1414,7 +1441,7 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bae" = (
@@ -1506,7 +1533,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "baP" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/tiled/white,
@@ -1539,7 +1568,7 @@
 	pixel_y = -9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bcf" = (
@@ -1562,7 +1591,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bdb" = (
@@ -1575,7 +1604,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bdf" = (
@@ -1621,7 +1650,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bdB" = (
@@ -1636,7 +1665,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bdZ" = (
@@ -1695,7 +1724,7 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bhE" = (
@@ -1779,7 +1808,7 @@
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bna" = (
@@ -1891,7 +1920,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "btT" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -1914,7 +1945,7 @@
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bwe" = (
@@ -1940,13 +1971,15 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "byH" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /obj/random/multiple/random_size_crate/no_weapons/nofail,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bzQ" = (
@@ -1974,7 +2007,7 @@
 /obj/random/trash,
 /obj/random/mech_toy,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bAK" = (
@@ -2020,7 +2053,7 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bBq" = (
@@ -2055,7 +2088,7 @@
 /obj/random/contraband,
 /obj/random/maintenance/security,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bDq" = (
@@ -2108,7 +2141,7 @@
 /obj/random/trash,
 /obj/random/maintenance/security,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bIS" = (
@@ -2202,7 +2235,7 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bMZ" = (
@@ -2220,14 +2253,14 @@
 /obj/effect/floor_decal/rust,
 /obj/random/mech_toy,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bNZ" = (
 /obj/structure/hull_corner,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bOv" = (
@@ -2249,7 +2282,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bPG" = (
@@ -2299,7 +2332,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bUR" = (
@@ -2307,7 +2340,7 @@
 /obj/item/weapon/bone/skull,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bVi" = (
@@ -2326,7 +2359,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bXG" = (
@@ -2431,7 +2464,7 @@
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/vore/alienanimals/teppi/mutant,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cct" = (
@@ -2478,7 +2511,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "ceo" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small{
@@ -2519,7 +2554,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cfS" = (
@@ -2589,7 +2624,7 @@
 /obj/random/trash,
 /obj/random/medical/lite,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cjU" = (
@@ -2597,14 +2632,14 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ckc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/girder/displaced,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "clX" = (
@@ -2734,7 +2769,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "csM" = (
@@ -2763,7 +2798,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ctT" = (
@@ -2774,7 +2809,9 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "cuB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2790,7 +2827,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cuS" = (
@@ -2798,7 +2835,7 @@
 /obj/random/trash,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cwl" = (
@@ -2808,7 +2845,7 @@
 /obj/random/trash,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cwr" = (
@@ -2822,6 +2859,11 @@
 	},
 /area/shuttle/arrival/station{
 	base_turf = /turf/simulated/floor/tiled/techfloor/grid
+	})
+"cwG" = (
+/turf/simulated/mineral/cave,
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cxc" = (
 /obj/random/trash,
@@ -2930,14 +2972,14 @@
 "cEy" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cEG" = (
-/obj/random/trash_pile,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cEP" = (
@@ -2954,7 +2996,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cFB" = (
@@ -2970,7 +3012,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cFY" = (
@@ -2986,9 +3028,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "cGu" = (
+/obj/effect/floor_decal/rust,
 /obj/random/trash,
-/turf/simulated/wall,
-/area/maintenance/firstdeck/forestarboard{
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cGF" = (
@@ -3015,7 +3058,9 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "cHD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -3100,7 +3145,7 @@
 /obj/random/mob/mouse,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cLi" = (
@@ -3114,7 +3159,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cLs" = (
@@ -3131,6 +3176,16 @@
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"cMD" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small/readylight{
+	dir = 1;
+	light_color = "#AF2A2A"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cNj" = (
@@ -3170,7 +3225,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cPY" = (
@@ -3213,7 +3268,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cTT" = (
@@ -3246,7 +3301,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cXC" = (
@@ -3294,9 +3349,13 @@
 	})
 "daw" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/light/small/readylight,
+/obj/random/trash,
+/obj/random/trash,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "daT" = (
 /obj/structure/girder/reinforced,
 /obj/effect/zone_divider,
@@ -3365,7 +3424,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dbJ" = (
@@ -3398,7 +3457,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dex" = (
@@ -3424,7 +3483,7 @@
 /obj/random/mob/mouse,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dfs" = (
@@ -3443,14 +3502,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dgc" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/catwalk,
-/obj/machinery/light/small/readylight{
-	dir = 1;
-	light_color = "#AF2A2A"
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dgg" = (
@@ -3520,7 +3578,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dlb" = (
@@ -3746,7 +3804,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dsB" = (
@@ -3772,7 +3830,7 @@
 "dsH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dsO" = (
@@ -3780,16 +3838,17 @@
 /obj/structure/catwalk,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dtm" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
-/obj/random/mob/mouse,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "duK" = (
 /turf/unsimulated/wall/cult{
 	desc = "An incredibly durable wall.";
@@ -3804,7 +3863,7 @@
 /obj/random/maintenance/medical,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dvB" = (
@@ -3848,7 +3907,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dws" = (
@@ -3862,7 +3921,7 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dwG" = (
@@ -3939,13 +3998,13 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dBn" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dBw" = (
@@ -3967,11 +4026,21 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "dCM" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/underground/in_da_walls)
+"dDi" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "dDr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -4077,7 +4146,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dKh" = (
@@ -4108,7 +4177,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dKV" = (
@@ -4157,7 +4226,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dPN" = (
@@ -4170,6 +4239,14 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/hallway/primary/firstdeck/auxdockaft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"dQk" = (
+/obj/effect/floor_decal/rust,
+/obj/random/mob/mouse,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dQA" = (
@@ -4228,7 +4305,7 @@
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dSF" = (
@@ -4327,14 +4404,14 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dVe" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dVC" = (
@@ -4369,7 +4446,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dWn" = (
@@ -4397,7 +4474,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dXp" = (
@@ -4453,7 +4530,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eac" = (
@@ -4474,6 +4551,14 @@
 /obj/random/trash,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"eaG" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eaM" = (
@@ -4497,7 +4582,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ebr" = (
@@ -4506,7 +4591,7 @@
 /obj/random/contraband,
 /obj/random/contraband,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ebC" = (
@@ -4587,7 +4672,7 @@
 /obj/effect/floor_decal/rust,
 /obj/item/weapon/digestion_remains/skull/teshari,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "edW" = (
@@ -4648,7 +4733,16 @@
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"ehw" = (
+/obj/effect/zone_divider,
+/obj/random/mob/mouse,
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ehx" = (
@@ -4667,6 +4761,12 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"eig" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "eii" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/flicker{
@@ -4675,7 +4775,7 @@
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/gun/energy/locked/phasegun/rifle/unlocked,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eik" = (
@@ -4693,6 +4793,23 @@
 /obj/effect/step_trigger/tramblock,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/firstdeck/auxdockaft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"ekq" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ekv" = (
@@ -4754,7 +4871,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "epK" = (
@@ -4817,7 +4934,7 @@
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "err" = (
@@ -4834,7 +4951,9 @@
 "erQ" = (
 /obj/random/mob/fish,
 /turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "erV" = (
 /obj/structure/handrail{
 	dir = 4
@@ -4928,7 +5047,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "evg" = (
@@ -4938,7 +5057,7 @@
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "evi" = (
@@ -4946,7 +5065,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "evL" = (
@@ -5001,7 +5120,9 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "eya" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -5056,7 +5177,7 @@
 /obj/random/trash_pile,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eCj" = (
@@ -5064,7 +5185,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/contraband,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eCo" = (
@@ -5215,7 +5336,7 @@
 /obj/effect/zone_divider,
 /obj/random/trash,
 /turf/simulated/wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eHo" = (
@@ -5226,7 +5347,7 @@
 /obj/random/trash,
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eHR" = (
@@ -5328,20 +5449,22 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eMd" = (
 /obj/random/trash,
 /turf/simulated/wall,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eMg" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "eMk" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -5399,7 +5522,7 @@
 	})
 "ePC" = (
 /turf/simulated/open,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ePZ" = (
@@ -5440,6 +5563,13 @@
 	},
 /area/shuttle/escape/station{
 	base_turf = /turf/simulated/floor/tiled/techfloor/grid
+	})
+"eSy" = (
+/obj/effect/floor_decal/rust,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eSF" = (
 /obj/structure/handrail{
@@ -5485,14 +5615,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eUn" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "eVo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -5515,7 +5647,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eVL" = (
@@ -5564,7 +5696,7 @@
 /obj/random/maintenance/medical,
 /obj/item/weapon/storage/box/monkeycubes/sparracubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eXZ" = (
@@ -5585,7 +5717,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eYF" = (
@@ -5679,7 +5811,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fhZ" = (
@@ -5755,7 +5887,7 @@
 /obj/random/plushie,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "flN" = (
@@ -5763,7 +5895,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "flT" = (
@@ -5772,7 +5904,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/humanoidremains,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fmf" = (
@@ -5786,10 +5918,8 @@
 "fmM" = (
 /obj/effect/zone_divider,
 /obj/effect/floor_decal/rust,
-/obj/structure/catwalk,
-/obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fnU" = (
@@ -5841,7 +5971,7 @@
 /obj/structure/catwalk,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fqR" = (
@@ -5851,7 +5981,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "frl" = (
@@ -5874,11 +6004,10 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "frv" = (
-/obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
-/obj/random/flashlight,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "frJ" = (
@@ -5986,7 +6115,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fvU" = (
@@ -6022,7 +6151,7 @@
 /obj/structure/catwalk,
 /obj/random/flashlight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fyD" = (
@@ -6030,7 +6159,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fzp" = (
@@ -6047,7 +6176,9 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "fzz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/firedoor/border_only,
@@ -6083,7 +6214,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fEr" = (
@@ -6092,7 +6223,7 @@
 /obj/random/trash,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fFF" = (
@@ -6143,7 +6274,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fIX" = (
@@ -6214,19 +6345,20 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fLb" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "fLh" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "fLm" = (
 /obj/structure/cable/blue{
 	icon_state = "2-8"
@@ -6243,7 +6375,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fMJ" = (
@@ -6257,7 +6389,7 @@
 "fNq" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fNP" = (
@@ -6284,7 +6416,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fQy" = (
@@ -6346,7 +6478,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fUi" = (
@@ -6363,7 +6495,7 @@
 /obj/random/junk,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fUC" = (
@@ -6371,7 +6503,7 @@
 /obj/random/trash_pile,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fUX" = (
@@ -6429,7 +6561,9 @@
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "fXu" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel,
@@ -6446,7 +6580,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fZm" = (
@@ -6455,7 +6589,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fZK" = (
@@ -6471,7 +6605,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gac" = (
@@ -6491,7 +6625,7 @@
 "gae" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gaw" = (
@@ -6499,7 +6633,9 @@
 /obj/random/maintenance,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gaH" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel,
@@ -6529,7 +6665,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gaS" = (
@@ -6636,7 +6772,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ggv" = (
@@ -6650,7 +6786,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "giW" = (
@@ -6659,7 +6795,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gjJ" = (
@@ -6860,12 +6996,10 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gtt" = (
-/obj/effect/floor_decal/rust,
-/obj/effect/landmark{
-	name = "maint_pred"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/turf/simulated/wall,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gvh" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
@@ -6949,7 +7083,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gyM" = (
@@ -6958,7 +7092,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gzZ" = (
@@ -6981,7 +7115,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gAZ" = (
@@ -7068,7 +7202,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gDv" = (
@@ -7104,10 +7238,10 @@
 	})
 "gEx" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
-	},
-/area/maintenance/firstdeck/aftport)
+/turf/simulated/wall,
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gEP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -7192,7 +7326,7 @@
 /obj/random/maintenance/medical,
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gHj" = (
@@ -7288,7 +7422,7 @@
 	vore_stomach_name = "medihound sleeper"
 	},
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gND" = (
@@ -7355,7 +7489,7 @@
 /obj/random/maintenance,
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gPK" = (
@@ -7462,7 +7596,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gVO" = (
@@ -7516,7 +7650,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gWr" = (
@@ -7564,6 +7698,13 @@
 /area/maintenance/firstdeck/forestarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"gZo" = (
+/obj/effect/zone_divider,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gZA" = (
 /obj/machinery/atmospherics/tvalve/mirrored/bypass{
 	dir = 1
@@ -7607,7 +7748,9 @@
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "hdT" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -7661,7 +7804,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hgm" = (
@@ -7681,7 +7824,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hgI" = (
@@ -7702,7 +7845,7 @@
 /obj/random/maintenance/misc,
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hhk" = (
@@ -7757,7 +7900,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hjT" = (
@@ -7795,7 +7938,9 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "hoc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/wardrobe/white,
@@ -7819,7 +7964,7 @@
 /obj/random/maintenance,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hpj" = (
@@ -7829,7 +7974,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hpR" = (
@@ -7838,7 +7983,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hqB" = (
@@ -7860,7 +8005,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hsy" = (
@@ -8093,7 +8238,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hyL" = (
@@ -8101,7 +8246,9 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "hzd" = (
 /obj/structure/sign/directions/exit,
 /turf/simulated/wall/r_wall,
@@ -8129,7 +8276,7 @@
 /obj/random/maintenance,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hzL" = (
@@ -8186,7 +8333,7 @@
 /obj/effect/floor_decal/rust,
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hBH" = (
@@ -8230,7 +8377,7 @@
 /obj/structure/curtain/open/privacy,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hCM" = (
@@ -8279,7 +8426,9 @@
 "hEq" = (
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "hEw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -8492,7 +8641,7 @@
 /obj/random/junk,
 /obj/item/weapon/digestion_remains/skull/teshari,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hTm" = (
@@ -8535,7 +8684,17 @@
 /obj/structure/curtain/open/privacy,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"hWd" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "hWj" = (
@@ -8627,7 +8786,7 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iap" = (
@@ -8700,7 +8859,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ifC" = (
@@ -8716,7 +8875,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "igD" = (
@@ -8749,7 +8908,9 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "ikR" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/structure/cable/yellow{
@@ -8797,7 +8958,7 @@
 "inE" = (
 /obj/structure/sign/warning/falling,
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "inL" = (
@@ -8906,7 +9067,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "isd" = (
 /obj/structure/grille/rustic{
 	health = 25;
@@ -8917,7 +9080,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "isW" = (
@@ -8962,7 +9125,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "itR" = (
@@ -8980,7 +9143,9 @@
 	},
 /obj/structure/bed/chair/sofa/corner/black,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iwp" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -9038,7 +9203,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iyG" = (
@@ -9051,7 +9216,7 @@
 	},
 /obj/item/weapon/storage/box/monkeycubes/farwacubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iyL" = (
@@ -9082,6 +9247,17 @@
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"izF" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iBa" = (
 /obj/machinery/light/floortube{
 	dir = 4
@@ -9089,6 +9265,14 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/foreport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"iCm" = (
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iCp" = (
@@ -9122,7 +9306,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iDK" = (
@@ -9311,14 +9495,14 @@
 /obj/random/trash,
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iLo" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iLG" = (
@@ -9347,7 +9531,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iMS" = (
@@ -9399,7 +9583,7 @@
 /obj/effect/floor_decal/rust,
 /obj/item/weapon/digestion_remains/skull/teshari,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iOu" = (
@@ -9426,7 +9610,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iQP" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -9446,7 +9632,9 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iRp" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/bench/steel,
@@ -9481,7 +9669,9 @@
 /obj/random/maintenance,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iRC" = (
 /mob/living/simple_mob/vore/alienanimals/teppi/baby,
 /turf/simulated/floor/reinforced,
@@ -9506,13 +9696,15 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iSa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iTh" = (
@@ -9533,7 +9725,9 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iTr" = (
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos)
@@ -9557,23 +9751,37 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iTS" = (
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
+"iUc" = (
+/obj/structure/flora/ausbushes/grassybush{
+	opacity = 1
+	},
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iUW" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iVw" = (
 /obj/effect/floor_decal/rust,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iVR" = (
 /obj/structure/flora/ausbushes/grassybush{
 	opacity = 1
@@ -9586,7 +9794,9 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iYr" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -9594,13 +9804,15 @@
 /obj/random/junk,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iYy" = (
 /obj/effect/zone_divider,
 /obj/effect/floor_decal/rust,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iYV" = (
@@ -9649,7 +9861,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jbA" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -9673,17 +9887,21 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jck" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jcI" = (
 /turf/simulated/open,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jdk" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
@@ -9697,7 +9915,9 @@
 /area/engineering/atmos)
 "jfb" = (
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jfC" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -9722,7 +9942,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jif" = (
@@ -9731,13 +9951,15 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jiS" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jjc" = (
@@ -9747,7 +9969,7 @@
 /turf/simulated/open{
 	outdoors = 1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jjP" = (
@@ -9762,21 +9984,21 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jkd" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jkg" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jkr" = (
@@ -9793,7 +10015,7 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jkU" = (
@@ -9819,7 +10041,7 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jlM" = (
@@ -9831,7 +10053,7 @@
 /obj/random/powercell,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jlP" = (
@@ -9839,7 +10061,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jmd" = (
@@ -9847,7 +10069,7 @@
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jms" = (
@@ -9865,7 +10087,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jmv" = (
@@ -9886,7 +10108,9 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/gun/energy/locked/phasegun/rifle/unlocked,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jmN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9894,7 +10118,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jmY" = (
@@ -9907,7 +10131,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jnC" = (
@@ -9915,7 +10139,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "joa" = (
@@ -9931,7 +10155,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jot" = (
@@ -9941,7 +10165,7 @@
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "joT" = (
@@ -9949,14 +10173,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jpq" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/deck/cards,
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jqg" = (
@@ -9980,7 +10206,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jqt" = (
@@ -10004,7 +10230,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jrC" = (
@@ -10015,7 +10241,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jrH" = (
@@ -10032,7 +10258,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jsH" = (
@@ -10044,7 +10270,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jtd" = (
@@ -10083,7 +10309,7 @@
 /obj/random/trash,
 /obj/random/powercell,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jwJ" = (
@@ -10107,7 +10333,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jwR" = (
@@ -10137,7 +10363,7 @@
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jzl" = (
@@ -10164,7 +10390,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jBv" = (
@@ -10173,13 +10399,15 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jBZ" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jCW" = (
@@ -10194,7 +10422,7 @@
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jEd" = (
@@ -10204,7 +10432,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/mouse,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jFe" = (
@@ -10226,7 +10454,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jHY" = (
@@ -10290,7 +10518,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jMV" = (
@@ -10307,7 +10535,7 @@
 /obj/item/weapon/bone/skull/tajaran,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jNJ" = (
@@ -10340,6 +10568,15 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"jPx" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small/readylight{
+	light_color = "#7F0000"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jPY" = (
 /obj/structure/catwalk,
 /obj/structure/flora/ausbushes/grassybush{
@@ -10348,7 +10585,19 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"jQO" = (
+/obj/structure/flora/ausbushes/grassybush{
+	opacity = 1
+	},
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jRc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -10383,14 +10632,14 @@
 /obj/structure/closet/body_bag,
 /obj/item/weapon/storage/box/monkeycubes/wolpincubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jTm" = (
 /obj/structure/girder/reinforced,
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jTn" = (
@@ -10420,17 +10669,23 @@
 "jUh" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jUq" = (
 /obj/structure/girder/displaced,
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jUP" = (
 /obj/structure/girder,
 /turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jUS" = (
 /obj/item/weapon/flag,
 /obj/machinery/status_display{
@@ -10476,17 +10731,21 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jZt" = (
 /obj/structure/girder/displaced,
 /turf/simulated/floor/water/deep/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jZE" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "jZF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10495,7 +10754,15 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"jZG" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jZI" = (
@@ -10517,7 +10784,7 @@
 /obj/random/powercell,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kax" = (
@@ -10559,7 +10826,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kbU" = (
@@ -10574,7 +10841,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kdu" = (
@@ -10598,13 +10865,13 @@
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kdV" = (
-/obj/random/mob/fish,
-/turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftstarboard{
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "keo" = (
@@ -10615,14 +10882,14 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "key" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "keP" = (
@@ -10634,7 +10901,9 @@
 "kfC" = (
 /obj/random/mob/fish,
 /turf/simulated/floor/water/deep/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kib" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
@@ -10668,7 +10937,7 @@
 "kjT" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kka" = (
@@ -10708,7 +10977,9 @@
 "klf" = (
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "klr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -10764,7 +11035,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ktE" = (
@@ -10848,7 +11119,15 @@
 /obj/random/plushie,
 /obj/item/weapon/digestion_remains/skull/teshari,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"kCv" = (
+/obj/random/trash_pile,
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kDI" = (
@@ -10927,7 +11206,7 @@
 /obj/random/trash,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kIF" = (
@@ -11060,6 +11339,16 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"kTx" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/machinery/light/small/readylight{
+	light_color = "#7F0000"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kTP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -11080,6 +11369,13 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmos)
+"kWb" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/table/steel,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kYw" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
@@ -11121,7 +11417,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lcm" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel,
@@ -11267,7 +11565,9 @@
 "loF" = (
 /obj/random/trash,
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "loS" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = null
@@ -11382,25 +11682,26 @@
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/civilian/sauna/cryosauna)
 "lCi" = (
-/obj/machinery/crystal/ice,
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
-	},
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lDE" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lED" = (
-/obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
-/obj/machinery/light/small/readylight{
-	dir = 1;
-	light_color = "#AF2A2A"
-	},
+/obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lGF" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/bed/chair{
@@ -11415,7 +11716,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lHA" = (
@@ -11444,6 +11745,17 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/hallway/primary/firstdeck/auxdockaft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"lKH" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/machinery/light/small/readylight{
+	dir = 8;
+	light_color = "#AF2A2A"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lMA" = (
@@ -11506,7 +11818,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lSe" = (
@@ -11520,7 +11832,9 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lUp" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
@@ -11553,7 +11867,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "maf" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -11577,7 +11893,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mbW" = (
@@ -11585,6 +11901,15 @@
 /obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"mcw" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/mob/mouse,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mdj" = (
@@ -11606,7 +11931,7 @@
 /obj/structure/catwalk,
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mgS" = (
@@ -11673,7 +11998,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mnJ" = (
@@ -11687,7 +12012,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mnT" = (
@@ -11705,6 +12030,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna/cryosauna)
+"moL" = (
+/obj/random/trash_pile,
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "mqn" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -11723,7 +12057,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "mss" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -11756,7 +12092,7 @@
 "mvT" = (
 /obj/effect/zone_divider,
 /turf/simulated/wall/thull,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mwe" = (
@@ -11886,7 +12222,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mBf" = (
@@ -11962,7 +12298,7 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mCG" = (
@@ -12028,7 +12364,7 @@
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/vore/alienanimals/teppi/mutant,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mEH" = (
@@ -12081,6 +12417,11 @@
 	outdoors = 1
 	},
 /area/surface/underground/in_da_walls)
+"mHt" = (
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "mJb" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -12088,6 +12429,14 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"mJo" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mKz" = (
@@ -12104,7 +12453,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mKA" = (
@@ -12113,7 +12462,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mKF" = (
@@ -12124,7 +12473,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "mMP" = (
 /obj/machinery/shieldwallgen{
 	anchored = 1;
@@ -12253,7 +12604,7 @@
 /obj/random/maintenance,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mRx" = (
@@ -12372,7 +12723,9 @@
 /obj/item/clothing/under/swimsuit/white,
 /obj/item/clothing/under/bathrobe,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nbD" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance,
@@ -12411,7 +12764,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/girder/displaced,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ndY" = (
@@ -12486,6 +12839,14 @@
 /area/rnd/xenobiology{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"nin" = (
+/obj/effect/floor_decal/rust,
+/obj/random/obstruction,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nko" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -12552,7 +12913,7 @@
 "nnX" = (
 /obj/effect/zone_divider,
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "npz" = (
@@ -12598,7 +12959,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nsF" = (
@@ -12686,7 +13047,7 @@
 /obj/structure/catwalk,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nwY" = (
@@ -12695,7 +13056,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nxC" = (
@@ -12829,6 +13190,14 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"nGZ" = (
+/obj/effect/zone_divider,
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nJB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12850,9 +13219,19 @@
 /area/rnd/xenobiology{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"nKa" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nKj" = (
 /turf/simulated/wall,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nKt" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -12954,7 +13333,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nQM" = (
@@ -12970,7 +13349,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "nQX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -12998,7 +13379,7 @@
 /obj/random/plushie,
 /obj/item/weapon/digestion_remains/skull/teshari,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nUQ" = (
@@ -13023,7 +13404,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nZT" = (
@@ -13073,7 +13454,9 @@
 /obj/structure/catwalk,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "obA" = (
 /obj/structure/table/glass,
 /obj/item/weapon/weldingtool,
@@ -13133,7 +13516,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "odS" = (
@@ -13232,7 +13615,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "olN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -13248,7 +13633,15 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"omg" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "omh" = (
@@ -13334,7 +13727,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "osi" = (
@@ -13437,7 +13830,7 @@
 	pixel_x = 21
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ovx" = (
@@ -13458,7 +13851,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "owd" = (
@@ -13471,7 +13864,9 @@
 /obj/item/clothing/under/cheongsam/black,
 /obj/item/clothing/under/cheongsam,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "oxp" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -13548,7 +13943,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ozT" = (
@@ -13577,7 +13972,7 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "oBq" = (
@@ -13593,7 +13988,9 @@
 	})
 "oFd" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "oFf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -13677,7 +14074,7 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "oLK" = (
@@ -13696,7 +14093,9 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "oMP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -13718,7 +14117,7 @@
 /obj/item/weapon/bone/skull/unathi,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "oQB" = (
@@ -13817,7 +14216,9 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "oVo" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/rust,
@@ -13895,7 +14296,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "oXQ" = (
@@ -13916,7 +14317,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pbQ" = (
@@ -14261,7 +14662,9 @@
 /obj/structure/catwalk,
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "pvn" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -14272,7 +14675,7 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/weapon/storage/box/monkeycubes/farwacubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pvA" = (
@@ -14314,7 +14717,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pxt" = (
@@ -14445,7 +14848,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "pCU" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "N2 to Connector"
@@ -14471,7 +14876,7 @@
 	light_color = "#AF2A2A"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pIb" = (
@@ -14631,19 +15036,23 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pOC" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "pPb" = (
 /obj/effect/zone_divider,
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "pPr" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -14742,7 +15151,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pTQ" = (
@@ -14771,6 +15180,14 @@
 /obj/item/weapon/melee/baton/slime/loaded,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"pWx" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pXe" = (
@@ -14846,7 +15263,7 @@
 "qax" = (
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qbZ" = (
@@ -14863,7 +15280,7 @@
 /obj/structure/table/steel,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qfR" = (
@@ -14876,7 +15293,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qgr" = (
@@ -14947,7 +15364,7 @@
 /obj/structure/barricade,
 /obj/machinery/door/airlock/maintenance/medical,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qjQ" = (
@@ -15083,7 +15500,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qrJ" = (
@@ -15109,7 +15526,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qvv" = (
@@ -15137,7 +15554,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qyh" = (
@@ -15147,7 +15564,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qyF" = (
@@ -15175,7 +15592,7 @@
 /obj/effect/floor_decal/rust,
 /mob/living/carbon/human/wolpin,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qyN" = (
@@ -15272,7 +15689,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qFk" = (
@@ -15292,13 +15709,13 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qFD" = (
 /obj/effect/zone_divider,
 /turf/simulated/wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qHe" = (
@@ -15382,7 +15799,9 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "qMh" = (
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmos)
@@ -15399,7 +15818,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qNr" = (
@@ -15448,7 +15867,9 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "qQi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
@@ -15535,6 +15956,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
+"qWX" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "qXA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15613,7 +16040,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rcL" = (
@@ -15623,6 +16050,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"rcV" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "rdS" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled{
 	anchored = 1
@@ -15693,7 +16128,7 @@
 	},
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rir" = (
@@ -15767,7 +16202,7 @@
 /obj/structure/closet/crate,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rlb" = (
@@ -15830,7 +16265,7 @@
 /obj/item/weapon/storage/box/monkeycubes/farwacubes,
 /obj/item/weapon/storage/box/monkeycubes/stokcubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "roq" = (
@@ -15840,6 +16275,15 @@
 /obj/random/contraband,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"ror" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/landmark{
+	name = "maint_pred"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rpV" = (
@@ -15864,7 +16308,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rtE" = (
@@ -15923,7 +16367,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "rxm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -16108,7 +16554,7 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rMr" = (
@@ -16117,7 +16563,7 @@
 /obj/random/maintenance,
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rMC" = (
@@ -16285,7 +16731,7 @@
 	icon_state = "16-0"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rSX" = (
@@ -16299,7 +16745,7 @@
 	},
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rVP" = (
@@ -16323,7 +16769,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rXg" = (
@@ -16363,7 +16809,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rYH" = (
@@ -16379,7 +16825,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust/color_rusted,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sap" = (
@@ -16396,7 +16842,9 @@
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sby" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
@@ -16413,7 +16861,7 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sfB" = (
@@ -16431,7 +16879,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sgb" = (
@@ -16441,7 +16889,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sgO" = (
@@ -16492,7 +16940,7 @@
 /obj/random/trash_pile,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "siw" = (
@@ -16556,7 +17004,9 @@
 /obj/machinery/light/small,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "smX" = (
 /obj/machinery/atmospherics/valve/digital/open{
 	name = "Mixed Air Outlet Valve"
@@ -16589,7 +17039,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sqw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -16620,7 +17072,7 @@
 /obj/random/trash,
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sss" = (
@@ -16650,7 +17102,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "suA" = (
@@ -16741,7 +17193,9 @@
 /obj/structure/catwalk,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sCh" = (
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/vore/alienanimals/teppi/mutant,
@@ -16855,7 +17309,7 @@
 /obj/random/maintenance/misc,
 /obj/item/weapon/storage/box/monkeycubes/wolpincubes,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sIo" = (
@@ -16863,6 +17317,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"sIA" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sJk" = (
@@ -16888,6 +17349,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"sKs" = (
+/obj/effect/zone_divider,
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sKG" = (
@@ -17014,7 +17483,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sTQ" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -17044,7 +17515,7 @@
 /obj/random/tool,
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sUR" = (
@@ -17054,6 +17525,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"sVk" = (
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sVH" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -17110,7 +17589,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tbw" = (
@@ -17119,13 +17598,13 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tbR" = (
 /obj/machinery/door/airlock/angled_tgmc/wide/generic,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tdg" = (
@@ -17174,7 +17653,7 @@
 	light_color = "#7F0000"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tfO" = (
@@ -17182,7 +17661,7 @@
 /obj/machinery/light/small/readylight,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tfY" = (
@@ -17306,7 +17785,7 @@
 /obj/random/maintenance/misc,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tnG" = (
@@ -17348,7 +17827,9 @@
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tpo" = (
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
@@ -17401,7 +17882,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "trO" = (
@@ -17458,7 +17939,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ttV" = (
@@ -17552,6 +18033,14 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"txE" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/mob/mouse,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tAy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -17594,7 +18083,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tHm" = (
@@ -17676,7 +18165,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tMM" = (
@@ -17757,6 +18246,14 @@
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"tPZ" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tRy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -17826,7 +18323,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tVV" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4
@@ -17851,7 +18350,9 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tWC" = (
 /obj/effect/zone_divider,
 /turf/simulated/mineral/cave,
@@ -17871,7 +18372,7 @@
 	},
 /obj/random/plushie,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tWI" = (
@@ -17895,7 +18396,7 @@
 /obj/random/maintenance,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tXq" = (
@@ -17946,7 +18447,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tZG" = (
@@ -17971,7 +18472,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uaP" = (
@@ -18059,14 +18560,14 @@
 /obj/random/maintenance/medical,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uip" = (
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/vore/otie/red/chubby,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ujN" = (
@@ -18084,7 +18585,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ulR" = (
@@ -18272,6 +18773,14 @@
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"uyK" = (
+/obj/random/trash,
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "uzz" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -18438,7 +18947,7 @@
 	pixel_y = -9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uHE" = (
@@ -18658,7 +19167,7 @@
 /obj/effect/zone_divider,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uWC" = (
@@ -18690,7 +19199,9 @@
 /obj/random/maintenance,
 /obj/machinery/light/small/readylight,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "uWQ" = (
 /turf/simulated/wall,
 /area/maintenance/firstdeck{
@@ -18855,7 +19366,7 @@
 /area/engineering/atmos)
 "vhO" = (
 /turf/simulated/mineral/cave,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "viX" = (
@@ -18933,7 +19444,9 @@
 "vnu" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vnI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19002,7 +19515,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vqY" = (
@@ -19052,7 +19565,15 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"vtq" = (
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vtG" = (
 /obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
 	frequency = 1379;
@@ -19095,7 +19616,9 @@
 	})
 "vuS" = (
 /turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vuU" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/reinforced/airless,
@@ -19131,7 +19654,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vwt" = (
@@ -19166,7 +19689,7 @@
 /obj/random/maintenance,
 /obj/item/weapon/storage/box/monkeycubes/sarucubes,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vCP" = (
@@ -19174,7 +19697,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vFN" = (
@@ -19209,7 +19732,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vGF" = (
@@ -19310,7 +19833,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vMP" = (
@@ -19329,7 +19852,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vPh" = (
@@ -19344,7 +19867,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/forestarboard{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vQj" = (
@@ -19385,7 +19908,7 @@
 	pixel_y = -21
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vRD" = (
@@ -19449,7 +19972,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vVB" = (
@@ -19458,7 +19981,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vVH" = (
@@ -19487,7 +20010,7 @@
 	icon_state = "maglevup";
 	name = "maglev rails"
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vWy" = (
@@ -19550,7 +20073,9 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vYa" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -19821,12 +20346,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna/cryosauna)
-"wtp" = (
-/obj/machinery/crystal,
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
+"wsG" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small/readylight{
+	dir = 1;
+	light_color = "#AF2A2A"
 	},
+/turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"wtp" = (
+/obj/effect/zone_divider,
+/turf/simulated/wall,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wtS" = (
@@ -19914,7 +20448,9 @@
 	})
 "wxL" = (
 /turf/simulated/floor/water/deep/indoors,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "wxT" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -19982,7 +20518,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wAI" = (
@@ -20154,7 +20690,9 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "wGk" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -20175,6 +20713,14 @@
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"wGG" = (
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "wGY" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -20186,7 +20732,7 @@
 "wIC" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wIY" = (
@@ -20273,7 +20819,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wNw" = (
@@ -20282,7 +20828,7 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wOb" = (
@@ -20330,7 +20876,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wOE" = (
@@ -20396,7 +20942,9 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "wUB" = (
 /obj/structure/handrail{
 	dir = 4
@@ -20410,7 +20958,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "wVh" = (
@@ -20559,7 +21107,7 @@
 	},
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xde" = (
@@ -20761,7 +21309,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/salvageable/console_os,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xkz" = (
@@ -20851,7 +21399,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xpO" = (
@@ -20927,7 +21475,7 @@
 	})
 "xuQ" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xvy" = (
@@ -20962,7 +21510,7 @@
 /obj/random/powercell,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xvO" = (
@@ -21035,7 +21583,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xzV" = (
@@ -21064,7 +21612,15 @@
 /obj/effect/gibspawner/human,
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"xAA" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xAU" = (
@@ -21108,7 +21664,9 @@
 /obj/item/clothing/under/dress/twopiece,
 /obj/item/clothing/under/sexymime/dress,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "xBC" = (
 /obj/structure/sign/directions/stairs_up{
 	dir = 4;
@@ -21307,7 +21865,7 @@
 "xJC" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xKt" = (
@@ -21338,7 +21896,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xNi" = (
@@ -21465,7 +22023,9 @@
 /obj/structure/girder/displaced,
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "xSG" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage{
@@ -21609,7 +22169,9 @@
 	},
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "xWZ" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -21640,7 +22202,9 @@
 	})
 "xXD" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "xXH" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -21703,7 +22267,9 @@
 /obj/item/weapon/gun/energy/locked/phasegun/rifle/unlocked,
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aftstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "yap" = (
 /obj/random/trash,
 /turf/simulated/wall,
@@ -21721,7 +22287,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ybb" = (
@@ -21729,7 +22295,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "ybf" = (
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Toxins Gas Storage";
@@ -21788,8 +22356,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "yeb" = (
-/turf/simulated/floor/water/indoors,
-/area/maintenance/firstdeck/aftstarboard{
+/turf/simulated/floor/outdoors/rocks/caves{
+	outdoors = -1
+	},
+/area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "yfK" = (
@@ -21797,7 +22367,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "yfS" = (
@@ -21903,7 +22473,7 @@
 /area/engineering/atmos)
 "yhL" = (
 /turf/simulated/wall/thull,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "yhQ" = (
@@ -21943,7 +22513,7 @@
 /area/surface/underground/in_da_walls)
 "yiI" = (
 /turf/simulated/wall,
-/area/maintenance/firstdeck/aftstarboard{
+/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "yiZ" = (
@@ -32421,13 +32991,13 @@ gae
 lJk
 lJk
 lJk
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
+eig
+eig
+eig
+eig
+eig
+eig
+eig
 tHm
 tHm
 tHm
@@ -32666,25 +33236,25 @@ lJk
 lJk
 lll
 rlb
-uwR
-xVr
-xVr
-xVr
-xVr
-uwR
-uwR
+eig
+xSY
+xSY
+xSY
+xSY
+eig
+eig
 pNK
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
+eig
+eig
+eig
+eig
+eig
+eig
+eig
+eig
+eig
+eig
+eig
 tHm
 dCM
 tHm
@@ -32922,23 +33492,23 @@ lll
 lll
 lll
 lll
-uwR
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-uwR
+eig
+xSY
+xSY
+xSY
+xSY
+xSY
+xSY
+eig
 pNK
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
-uwR
+eig
+eig
+eig
+eig
+eig
+eig
+eig
+eig
 lJk
 lJk
 lJk
@@ -33179,13 +33749,13 @@ lll
 lll
 lll
 lll
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-uwR
+xSY
+xSY
+xSY
+xSY
+xSY
+xSY
+eig
 rlb
 awp
 lJk
@@ -33436,11 +34006,11 @@ lJk
 rlb
 rlb
 rlb
-uwR
+eig
 rlb
-xVr
-xVr
-xVr
+xSY
+xSY
+xSY
 rlb
 rlb
 rlb
@@ -36808,7 +37378,7 @@ xuQ
 xuQ
 xuQ
 xuQ
-skh
+mHt
 gae
 gae
 gae
@@ -37320,10 +37890,10 @@ yhL
 yhL
 tMj
 yhL
-skh
+mHt
 tbR
 yhL
-skh
+mHt
 tbR
 yhL
 lRw
@@ -38862,10 +39432,10 @@ yhL
 yhL
 tMj
 yhL
-skh
+mHt
 tbR
 yhL
-skh
+mHt
 tbR
 yhL
 tMj
@@ -39629,7 +40199,7 @@ xuQ
 jkd
 jkd
 jkd
-uwR
+eig
 jBZ
 jkd
 jkd
@@ -39889,7 +40459,7 @@ jot
 jkg
 jkg
 jGU
-uwR
+eig
 jZF
 keo
 xuQ
@@ -40915,7 +41485,7 @@ xuQ
 xuQ
 xuQ
 xuQ
-fow
+hWd
 xuQ
 xuQ
 xuQ
@@ -41171,9 +41741,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -41428,9 +41998,9 @@ rlb
 rlb
 rlb
 yiI
-qRI
-whL
-whL
+wsG
+frv
+frv
 yiI
 rlb
 rlb
@@ -41685,9 +42255,9 @@ rlb
 rlb
 rlb
 yiI
-iwU
-whL
-whL
+dtm
+frv
+frv
 yiI
 rlb
 rlb
@@ -41942,9 +42512,9 @@ rlb
 rlb
 sQg
 yiI
-whL
+frv
 mEj
-whL
+frv
 yiI
 rlb
 rlb
@@ -42199,9 +42769,9 @@ rlb
 sQg
 crS
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -42456,9 +43026,9 @@ crS
 crS
 crS
 yiI
-whL
-jFe
-whL
+frv
+txE
+frv
 yiI
 rlb
 rlb
@@ -42713,9 +43283,9 @@ crS
 crS
 crS
 gae
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -42970,9 +43540,9 @@ crS
 crS
 crS
 gae
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -43226,10 +43796,10 @@ rlb
 rlb
 crS
 crS
-uwR
-whL
-iwU
-whL
+eig
+frv
+dtm
+frv
 yiI
 rlb
 rlb
@@ -43484,9 +44054,9 @@ rlb
 sQg
 crS
 gae
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -43741,9 +44311,9 @@ rlb
 rlb
 crS
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -43998,9 +44568,9 @@ rlb
 rlb
 sQg
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -44255,9 +44825,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -44512,9 +45082,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-iwU
-iwU
+frv
+dtm
+dtm
 yiI
 rlb
 rlb
@@ -44769,9 +45339,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -45014,7 +45584,7 @@ rlb
 rlb
 rlb
 lJk
-dgg
+ror
 qax
 jjc
 lJk
@@ -45026,9 +45596,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -45283,9 +45853,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -45529,8 +46099,8 @@ lJk
 lJk
 lJk
 eii
-uwR
-uwR
+eig
+eig
 lJk
 rlb
 rlb
@@ -45540,9 +46110,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -45783,7 +46353,7 @@ lJk
 awp
 jck
 jhr
-uwR
+eig
 lJk
 dBe
 lJk
@@ -45797,9 +46367,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-muz
-iwU
+frv
+eaG
+dtm
 yiI
 rlb
 rlb
@@ -46040,8 +46610,8 @@ key
 eYl
 key
 key
-uwR
-uwR
+eig
+eig
 key
 rlb
 rlb
@@ -46054,9 +46624,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -46286,19 +46856,19 @@ lll
 lll
 lll
 lll
-uwR
-uwR
+eig
+eig
 key
-uwR
+eig
 key
 vOB
 ovc
-uwR
+eig
 itI
-uwR
-uwR
-uwR
-uwR
+eig
+eig
+eig
+eig
 key
 rlb
 rlb
@@ -46311,9 +46881,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -46550,13 +47120,13 @@ tWC
 qFD
 qFD
 qFD
-fow
+hWd
 qFD
 qFD
 qFD
 eGu
 qFD
-thW
+iCm
 awp
 tWC
 tWC
@@ -46568,9 +47138,9 @@ tWC
 tWC
 tWC
 qFD
-thW
-thW
-thW
+iCm
+iCm
+iCm
 qFD
 tWC
 tWC
@@ -46812,8 +47382,8 @@ iYy
 cuG
 tfO
 yiI
-yld
-whL
+aKB
+frv
 rlb
 rlb
 rlb
@@ -46825,9 +47395,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -47067,10 +47637,10 @@ cuG
 aLc
 hSn
 cuG
-uwR
+eig
 yiI
-yld
-whL
+aKB
+frv
 xSY
 rlb
 rlb
@@ -47082,9 +47652,9 @@ rlb
 rlb
 rlb
 yiI
-qRI
-whL
-mJb
+wsG
+frv
+mcw
 yiI
 rlb
 rlb
@@ -47326,8 +47896,8 @@ ovy
 flH
 bbP
 yiI
-xVr
-whL
+xSY
+frv
 rQr
 rlb
 rlb
@@ -47339,9 +47909,9 @@ rlb
 rlb
 rlb
 yiI
-iwU
-whL
-iwU
+dtm
+frv
+dtm
 yiI
 rlb
 rlb
@@ -47580,13 +48150,13 @@ trz
 jiS
 uip
 jrC
-uwR
+eig
 iUW
 yiI
-qnR
-whL
+rQr
+frv
 xSY
-xVr
+xSY
 rlb
 rlb
 rlb
@@ -47596,9 +48166,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -47840,11 +48410,11 @@ nwY
 key
 aAn
 yiI
-xVr
-whL
+xSY
+frv
 rlb
-xVr
-qnR
+xSY
+rQr
 rlb
 rlb
 rlb
@@ -47853,9 +48423,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -48098,10 +48668,10 @@ oLv
 nTU
 yiI
 yiI
-fow
+hWd
 lJk
-xVr
-xVr
+xSY
+xSY
 rlb
 rlb
 rlb
@@ -48110,9 +48680,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -48350,15 +48920,15 @@ yiI
 tWG
 iUW
 ktq
-uWB
+gZo
 jiS
 jnC
 yiI
-xVr
-iwU
+xSY
+dtm
 rlb
 rlb
-xVr
+xSY
 rlb
 rlb
 rlb
@@ -48367,9 +48937,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -48599,8 +49169,8 @@ ykN
 ykN
 ykN
 ykN
-xVr
-qnR
+xSY
+rQr
 yis
 rlb
 yiI
@@ -48611,11 +49181,11 @@ qFD
 yiI
 yiI
 yiI
-xVr
-whL
+xSY
+frv
 rlb
-viX
-xVr
+fJC
+xSY
 rlb
 rlb
 rlb
@@ -48624,9 +49194,9 @@ rlb
 rlb
 rlb
 yiI
-whL
-whL
-whL
+frv
+frv
+frv
 yiI
 rlb
 rlb
@@ -48740,52 +49310,52 @@ rlb
 rlb
 rlb
 lJk
-dWn
-xNp
-brm
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-dWn
-dWn
-dWn
-dWn
-xNp
-xNp
-xNp
-xNp
-xNp
-bKN
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-dWn
-xNp
-dWn
-dWn
-xNp
-xNp
-xNp
-xNp
-xNp
-dWn
-aXv
-xNp
-xNp
-xNp
-xNp
-dKV
+cGu
+kdV
+dgc
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+cGu
+cGu
+cGu
+cGu
+kdV
+kdV
+kdV
+kdV
+kdV
+nGZ
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+cGu
+kdV
+cGu
+cGu
+kdV
+kdV
+kdV
+kdV
+kdV
+cGu
+lED
+kdV
+kdV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -48799,9 +49369,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-jZI
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -48857,10 +49427,10 @@ rlb
 rlb
 rlb
 yis
-xVr
-qnR
-xVr
-qnR
+yeb
+uyK
+yeb
+uyK
 rlb
 rlb
 rlb
@@ -48868,11 +49438,11 @@ tWC
 rlb
 rlb
 rlb
-fJC
-whL
-xVr
-qnR
-xVr
+nKa
+eMg
+yeb
+uyK
+yeb
 rlb
 rlb
 rlb
@@ -48880,11 +49450,11 @@ rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-gae
+nKj
+eMg
+eMg
+eMg
+jUh
 rlb
 rlb
 yis
@@ -48997,52 +49567,52 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dbC
-dKV
-dKV
-dKV
-dKV
-dKV
+kdV
+kdV
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+wtp
+gtt
+gtt
+gtt
+gtt
+gtt
 aHz
 ebj
 ebr
-dKV
-dKV
-dKV
-cXC
-ddT
-cXC
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-brm
-brm
-dKV
-dKV
+gtt
+gtt
+gtt
+cEy
+fLb
+cEy
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+dgc
+dgc
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -49056,9 +49626,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-fmf
-fmf
+lCi
+jZG
+jZG
 rlb
 rlb
 rlb
@@ -49117,7 +49687,7 @@ rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
@@ -49126,22 +49696,22 @@ rlb
 rlb
 rlb
 rlb
-whL
+eMg
 rlb
-xVr
-xVr
-rlb
-rlb
+yeb
+yeb
 rlb
 rlb
 rlb
 rlb
 rlb
-yiI
-whL
-muz
-whL
-uwR
+rlb
+rlb
+nKj
+eMg
+jbp
+eMg
+vnu
 ipe
 ipe
 ipe
@@ -49254,9 +49824,9 @@ rlb
 rlb
 rlb
 lJk
-dWn
-xNp
-dKV
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -49279,26 +49849,26 @@ rlb
 rlb
 rlb
 rlb
-dKV
-dKV
-dKV
-dKV
-dKV
+gtt
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
-dsF
-ajN
-ajN
-rlb
-rlb
-rlb
+eva
+cEG
+cEG
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
-dKV
+rlb
+rlb
+rlb
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -49313,9 +49883,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
+lCi
 mgE
-fmf
+jZG
 rlb
 rlb
 rlb
@@ -49374,31 +49944,31 @@ rlb
 rlb
 rlb
 rlb
-xVr
-xVr
-xVr
-viX
+yeb
+yeb
+yeb
+nKa
 tWC
 rlb
 rlb
 rlb
 rlb
-whL
+eMg
 rlb
 rlb
-qnR
-rlb
-rlb
-rlb
+uyK
 rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-gae
+rlb
+rlb
+rlb
+nKj
+eMg
+eMg
+eMg
+jUh
 ipe
 ipe
 ipe
@@ -49511,9 +50081,9 @@ rlb
 rlb
 lJk
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -49544,18 +50114,18 @@ rlb
 rlb
 rlb
 rlb
-ajN
-ajN
+cEG
+cEG
 rlb
 rlb
 rlb
 rlb
 rlb
 rlb
-dKV
-jZI
+gtt
+lCi
 kIr
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -49570,9 +50140,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-jZI
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -49632,18 +50202,18 @@ rlb
 lJk
 lJk
 rlb
-qnR
-xVr
-qnR
-itR
-xVr
+uyK
+yeb
+uyK
+wLH
+yeb
 rlb
 rlb
 lJk
-prS
+hdO
 lJk
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
@@ -49651,11 +50221,11 @@ rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-iwU
-gae
+nKj
+eMg
+eMg
+bxS
+jUh
 rlb
 yis
 ipe
@@ -49768,9 +50338,9 @@ rlb
 rlb
 lJk
 hgc
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -49802,17 +50372,17 @@ rlb
 rlb
 rlb
 rlb
-ajN
-ajN
+cEG
+cEG
 rlb
 rlb
 rlb
 rlb
 rlb
-cXC
-jZI
+cEy
+lCi
 kIr
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -49827,9 +50397,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-jZI
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -49888,19 +50458,19 @@ rlb
 rlb
 lJk
 vVf
-uwR
-uwR
-uwR
-uwR
+vnu
+vnu
+vnu
+vnu
 uWB
-uwR
-uwR
-uwR
-uwR
-uwR
-qnR
-xVr
-qnR
+vnu
+vnu
+vnu
+vnu
+vnu
+uyK
+yeb
+uyK
 rlb
 rlb
 rlb
@@ -49908,11 +50478,11 @@ rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -50025,9 +50595,9 @@ rlb
 rlb
 lJk
 hgm
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -50060,16 +50630,16 @@ rlb
 rlb
 rlb
 rlb
-ajN
-ajN
+cEG
+cEG
 yis
 rlb
 rlb
 rlb
-cXC
-jZI
-jZI
-dKV
+cEy
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -50084,9 +50654,9 @@ rlb
 tWC
 rlb
 lJk
-jZI
-jZI
-fmf
+lCi
+lCi
+jZG
 lJk
 rlb
 rlb
@@ -50144,32 +50714,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
-iUW
-uwR
-uwR
-uwR
+vnu
+toV
+vnu
+vnu
+vnu
 uWB
-uwR
-uwR
+vnu
+vnu
 vVf
-uwR
-uwR
+vnu
+vnu
 rlb
 rlb
-xVr
-xVr
-rlb
-rlb
-rlb
+yeb
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+rlb
+rlb
+rlb
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -50282,9 +50852,9 @@ rlb
 rlb
 lJk
 hgc
-dWn
-xNp
-dKV
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -50318,15 +50888,15 @@ rlb
 rlb
 rlb
 rlb
-ajN
-ajN
-ajN
+cEG
+cEG
+cEG
 rlb
 rlb
-dKV
-jZI
-jZI
-dKV
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -50341,9 +50911,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-jZI
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -50401,32 +50971,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
+vnu
 iLo
-yiI
-yiI
-yiI
-qFD
-yiI
-yiI
-yiI
-yiI
-fow
+nKj
+nKj
+nKj
+gEx
+nKj
+nKj
+nKj
+nKj
+olx
 lJk
 rlb
-qnR
-xVr
+uyK
+yeb
 uaH
 rlb
 rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -50539,9 +51109,9 @@ rlb
 rlb
 lJk
 sIm
-xNp
-aXv
-dKV
+kdV
+lED
+gtt
 rlb
 rlb
 rlb
@@ -50577,13 +51147,13 @@ rlb
 rlb
 yis
 rlb
-ajN
-ajN
-ajN
-ddT
-jZI
-jZI
-dKV
+cEG
+cEG
+cEG
+fLb
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -50598,8 +51168,8 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
+lCi
+lCi
 fqN
 rlb
 rlb
@@ -50658,32 +51228,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
-uwR
-yiI
+vnu
+vnu
+nKj
 qcN
 quJ
 vCP
 quJ
-jlg
-uwR
-uwR
-uwR
+ekq
+vnu
+vnu
+vnu
 lJk
 rlb
 rlb
-xVr
-xVr
-xVr
-qnR
+yeb
+yeb
+yeb
+uyK
 rlb
 rlb
 rlb
-yiI
-whL
-muz
-whL
-yiI
+nKj
+eMg
+jbp
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -50796,9 +51366,9 @@ rlb
 rlb
 lJk
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -50837,10 +51407,10 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
-cXC
+gtt
+lCi
+lCi
+cEy
 rlb
 rlb
 rlb
@@ -50854,10 +51424,10 @@ rlb
 rlb
 tWC
 rlb
-doR
-jZI
-jZI
-jZI
+dDi
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -50915,32 +51485,32 @@ yis
 rlb
 rlb
 rlb
-uwR
-vOB
-yiI
-uwR
-uwR
+vnu
+iVw
+nKj
+vnu
+vnu
 uWB
-uwR
-uwR
-uwR
-uwR
-uwR
+vnu
+vnu
+vnu
+vnu
+vnu
 lJk
 rlb
 rlb
-xVr
+yeb
 rlb
-xVr
-xVr
+yeb
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -51053,9 +51623,9 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -51094,27 +51664,27 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
-ddT
-ajN
+gtt
+lCi
+lCi
+fLb
+cEG
 rlb
 rlb
 rlb
 rlb
 rlb
 rlb
-ajN
-ajN
-ajN
-ajN
-cHS
-ajN
-ajN
-jZI
-jZI
-fmf
+cEG
+cEG
+cEG
+cEG
+sKs
+cEG
+cEG
+lCi
+lCi
+jZG
 rlb
 rlb
 rlb
@@ -51172,32 +51742,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
-uwR
-fow
-uwR
-uwR
+vnu
+vnu
+olx
+vnu
+vnu
 uWB
-uwR
-vOB
-uwR
-uwR
-uwR
+vnu
+iVw
+vnu
+vnu
+vnu
 lJk
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
-xVr
+yeb
 vVB
 rlb
 rlb
-yiI
-whL
-whL
-muz
-yiI
+nKj
+eMg
+eMg
+jbp
+nKj
 rlb
 rlb
 rlb
@@ -51310,9 +51880,9 @@ rlb
 rlb
 rlb
 lJk
-dWn
-xNp
-dKV
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -51351,26 +51921,26 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
+gtt
+lCi
 kIr
-cXC
-ajN
-ajN
-ajN
-ajN
-ajN
-ajN
-ajN
-ajN
-ajN
+cEy
+cEG
+cEG
+cEG
+cEG
+cEG
+cEG
+cEG
+cEG
+cEG
 rlb
 rlb
 tWC
 rlb
 rlb
-jZI
-jZI
+lCi
+lCi
 mgE
 rlb
 rlb
@@ -51429,11 +51999,11 @@ pyL
 rlb
 rlb
 rlb
-uwR
-iUW
-yiI
+vnu
+toV
+nKj
 nYV
-uwR
+vnu
 uWB
 mCD
 bBf
@@ -51443,18 +52013,18 @@ fKT
 lJk
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-iwU
-whL
-yiI
+nKj
+eMg
+bxS
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -51567,9 +52137,9 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -51608,18 +52178,18 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
-cXC
+gtt
+lCi
+lCi
+cEy
 rlb
 rlb
-ajN
-ajN
+cEG
+cEG
 vhO
-ajN
-ajN
-ajN
+cEG
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -51628,8 +52198,8 @@ rlb
 lJk
 pFn
 mgE
-jZI
-kSl
+lCi
+kWb
 uWQ
 rlb
 uWQ
@@ -51686,32 +52256,32 @@ pyL
 rlb
 rlb
 rlb
-uwR
-uwR
-yiI
-yiI
-yiI
-qFD
-yiI
-yiI
-yiI
-yiI
-yiI
+vnu
+vnu
+nKj
+nKj
+nKj
+gEx
+nKj
+nKj
+nKj
+nKj
+nKj
 lJk
 rlb
 rlb
-xVr
+yeb
 rlb
-xVr
-xVr
+yeb
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -51824,9 +52394,9 @@ rlb
 rlb
 rlb
 lJk
-vQU
-xNp
-dKV
+cMD
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -51865,28 +52435,28 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
-dKV
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
-dKV
-dKV
-dKV
-dKV
-ajN
+gtt
+gtt
+gtt
+gtt
+cEG
 rlb
 rlb
 rlb
 tWC
 rlb
 rlb
-jZI
-xNp
-jZI
-xNp
+lCi
+kdV
+lCi
+kdV
 tCN
 ycA
 tCN
@@ -51943,8 +52513,8 @@ pyL
 rlb
 rlb
 rlb
-uwR
-uwR
+vnu
+vnu
 rlb
 rlb
 rlb
@@ -51957,18 +52527,18 @@ rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 hrH
-xVr
+yeb
 rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -52081,9 +52651,9 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -52122,28 +52692,28 @@ rlb
 rlb
 rlb
 rlb
-cXC
-jZI
-jZI
-dKV
+cEy
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
-dKV
-gaS
-xNp
-xNp
-ajN
+gtt
+sIA
+kdV
+kdV
+cEG
 rlb
 rlb
 rlb
 tWC
 rlb
 lJk
-fmf
-jZI
-jZI
-gaS
+jZG
+lCi
+lCi
+sIA
 uWQ
 rlb
 uWQ
@@ -52200,8 +52770,8 @@ pyL
 rlb
 rlb
 rlb
-uwR
-iUW
+vnu
+toV
 rlb
 rlb
 rlb
@@ -52214,18 +52784,18 @@ rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
-qnR
-rlb
-rlb
+uyK
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+rlb
+rlb
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -52338,17 +52908,17 @@ rlb
 rlb
 rlb
 lJk
-xNp
-dWn
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
-dKV
+kdV
+cGu
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -52379,27 +52949,27 @@ rlb
 rlb
 rlb
 rlb
-dKV
-jZI
+gtt
+lCi
 kIr
-cXC
+cEy
 rlb
 rlb
 rlb
-dKV
-dWp
-bLi
-xNp
-gaS
+gtt
+dwn
+eSy
+kdV
+sIA
 lJk
 rlb
 rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-xNp
+lCi
+lCi
+kdV
 rlb
 rlb
 rlb
@@ -52457,8 +53027,8 @@ pyL
 rlb
 rlb
 rlb
-iUW
-uwR
+toV
+vnu
 rlb
 rlb
 rlb
@@ -52470,19 +53040,19 @@ rlb
 rlb
 rlb
 rlb
-xVr
-xVr
+yeb
+yeb
 rlb
-xVr
-xVr
+yeb
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -52595,17 +53165,17 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 hgI
-bAf
-dWn
-kSl
-kSl
-xNp
+wGG
+cGu
+kWb
+kWb
+kdV
 jms
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -52635,18 +53205,18 @@ rlb
 rlb
 rlb
 rlb
-dKV
-dKV
-jZI
+gtt
+gtt
+lCi
 vRt
-dKV
-dKV
+gtt
+gtt
 rlb
 rlb
-dKV
-gaS
-gaS
-gaS
+gtt
+sIA
+sIA
+sIA
 vhO
 lJk
 rlb
@@ -52654,9 +53224,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-aXv
-fmf
+lCi
+lED
+jZG
 rlb
 rlb
 rlb
@@ -52714,7 +53284,7 @@ yis
 rlb
 rlb
 lJk
-uwR
+vnu
 iLo
 lJk
 rlb
@@ -52725,21 +53295,21 @@ rlb
 rlb
 rlb
 rlb
-xVr
-xVr
+yeb
+yeb
 uka
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-yiI
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -52760,8 +53330,8 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -52852,17 +53422,17 @@ rlb
 rlb
 rlb
 lJk
-xNp
-xNp
-dKV
-xNp
+kdV
+kdV
+gtt
+kdV
 bAs
-bGy
+cuS
 bHC
-dWn
+cGu
 bAs
 teu
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -52892,28 +53462,28 @@ rlb
 rlb
 rlb
 rlb
-dKV
+gtt
 eAS
-jZI
-jZI
+lCi
+lCi
 avk
-dKV
+gtt
 rlb
 rlb
-dKV
-dKV
-dKV
-dKV
-dKV
+gtt
+gtt
+gtt
+gtt
+gtt
 lJk
 rlb
 rlb
 tWC
 rlb
 rlb
-xNp
-xNp
-jZI
+kdV
+kdV
+lCi
 rlb
 rlb
 rlb
@@ -52972,7 +53542,7 @@ qqe
 xSY
 xSY
 ata
-uwR
+vnu
 rlb
 rlb
 rlb
@@ -52981,22 +53551,22 @@ rlb
 rlb
 rlb
 rlb
-xVr
-xVr
-xVr
-viX
+yeb
+yeb
+yeb
+nKa
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
-yiI
-whL
-iwU
-prS
-yiI
+nKj
+eMg
+bxS
+hdO
+nKj
 rlb
 rlb
 rlb
@@ -53017,10 +53587,10 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -53109,17 +53679,17 @@ rlb
 rlb
 rlb
 lJk
-xNp
-dWn
-brm
-xNp
-xNp
-xNp
-bIS
-xNp
+kdV
+cGu
+dgc
+kdV
+kdV
+kdV
+rcV
+kdV
 cjP
-xNp
-dKV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -53149,12 +53719,12 @@ rlb
 rlb
 rlb
 rlb
-dKV
-xNp
-jZI
-jZI
+gtt
+kdV
+lCi
+lCi
 aHz
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -53168,9 +53738,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-xNp
-jZI
+lCi
+kdV
+lCi
 rlb
 rlb
 rlb
@@ -53228,8 +53798,8 @@ yis
 rlb
 rlb
 lJk
-uwR
-iUW
+vnu
+toV
 lJk
 rlb
 rlb
@@ -53238,22 +53808,22 @@ rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
 rlb
-gae
-uwR
-whL
-whL
-yiI
+jUh
+vnu
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -53275,9 +53845,9 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -53366,17 +53936,17 @@ rlb
 rlb
 rlb
 lJk
-xNp
-dWn
-dKV
-xNp
-dWn
-xNp
-dWn
+kdV
+cGu
+gtt
+kdV
+cGu
+kdV
+cGu
 bNp
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -53406,12 +53976,12 @@ rlb
 rlb
 rlb
 rlb
-dKV
+gtt
 eCj
-jZI
+lCi
 kIr
 eAS
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -53425,10 +53995,10 @@ rlb
 tWC
 rlb
 rlb
-jZI
+lCi
 mgE
-jZI
-dKV
+lCi
+gtt
 uWQ
 rlb
 rlb
@@ -53485,32 +54055,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
-uwR
+vnu
+vnu
 rlb
 rlb
 rlb
 tWC
 rlb
 rlb
-xVr
-xVr
-xVr
-xVr
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
-xVr
-xVr
+yeb
+yeb
 jAU
-uwR
-whL
-yiI
+vnu
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -53531,11 +54101,11 @@ rlb
 rlb
 rlb
 rlb
-wtp
-xSY
-xSY
-xSY
-xSY
+ybb
+yeb
+yeb
+yeb
+yeb
 ifw
 rlb
 rlb
@@ -53623,17 +54193,17 @@ rlb
 rlb
 lJk
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 dUW
 bCM
-dWn
-dWn
-aXv
-dWn
-xNp
-dKV
+cGu
+cGu
+lED
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -53663,12 +54233,12 @@ avp
 rlb
 rlb
 rlb
-dKV
-xNp
+gtt
+kdV
 cLh
-jZI
+lCi
 eLZ
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -53682,9 +54252,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-fmf
+lCi
+lCi
+jZG
 fIU
 uWQ
 rlb
@@ -53742,32 +54312,32 @@ rlb
 rlb
 rlb
 rlb
-uwR
-uwR
+vnu
+vnu
 rlb
 rlb
 rlb
 tWC
 rlb
 rlb
-xVr
+yeb
 uaH
-xVr
-xVr
+yeb
+yeb
 rlb
 rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
 rlb
-xVr
+yeb
 jsA
-uwR
-whL
-whL
-yiI
+vnu
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -53788,12 +54358,12 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -53880,17 +54450,17 @@ rlb
 rlb
 lJk
 avk
-xNp
-dWn
-dKV
+kdV
+cGu
+gtt
 byH
-dWn
-xNp
-xNp
-xNp
+cGu
+kdV
+kdV
+kdV
 bNp
 bHC
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -53920,12 +54490,12 @@ avp
 avp
 rlb
 rlb
-dKV
-xNp
-jZI
-jZI
-edW
-dKV
+gtt
+kdV
+lCi
+lCi
+jPx
+gtt
 rlb
 rlb
 rlb
@@ -53939,9 +54509,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
-jZI
-jZI
+lCi
+lCi
+lCi
 fLJ
 uWQ
 rlb
@@ -53998,33 +54568,33 @@ rlb
 rlb
 rlb
 rlb
-xVr
-uwR
-uwR
-xVr
-xVr
-xVr
-itR
-xVr
-xVr
-xVr
-qnR
-xVr
-qnR
-xVr
+yeb
+vnu
+vnu
+yeb
+yeb
+yeb
+wLH
+yeb
+yeb
+yeb
+uyK
+yeb
+uyK
+yeb
 hrH
-xVr
-xVr
+yeb
+yeb
 rlb
-xVr
+yeb
 rlb
-xVr
-xVr
-gae
-whL
-whL
-whL
-yiI
+yeb
+yeb
+jUh
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -54046,11 +54616,11 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -54137,17 +54707,17 @@ rlb
 rlb
 lJk
 aHz
-xNp
-mxq
-dKV
-dKV
-dKV
-dKV
-brm
-dKV
-dKV
-dKV
-dKV
+kdV
+apU
+gtt
+gtt
+gtt
+gtt
+dgc
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -54177,12 +54747,12 @@ avp
 avp
 rlb
 rlb
-dKV
-dWp
-jZI
+gtt
+dwn
+lCi
 kIr
 egA
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -54196,9 +54766,9 @@ rlb
 tWC
 rlb
 rlb
-jZI
+lCi
 fxi
-jZI
+lCi
 fQk
 uWQ
 rlb
@@ -54255,10 +54825,10 @@ rlb
 rlb
 rlb
 rlb
-xVr
-uwR
-iUW
-xVr
+yeb
+vnu
+toV
+yeb
 rlb
 rlb
 tWC
@@ -54268,20 +54838,20 @@ rlb
 rlb
 rlb
 rlb
-xVr
-xVr
-xVr
-xVr
-xVr
-qnR
-xVr
-xVr
-xVr
-yiI
-whL
-jFe
-whL
-yiI
+yeb
+yeb
+yeb
+yeb
+yeb
+uyK
+yeb
+yeb
+yeb
+nKj
+eMg
+mLF
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -54302,14 +54872,14 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -54394,17 +54964,17 @@ rlb
 rlb
 lJk
 lJk
-xNp
-dWn
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
-xNp
+kdV
+cGu
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
+kdV
 ctH
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -54434,12 +55004,12 @@ avp
 avp
 rlb
 rlb
-dKV
-dWp
-jZI
-jZI
+gtt
+dwn
+lCi
+lCi
 eAS
-dKV
+gtt
 rlb
 rlb
 rlb
@@ -54453,10 +55023,10 @@ rlb
 tWC
 rlb
 lJk
-jZI
-jZI
-jZI
-dKV
+lCi
+lCi
+lCi
+gtt
 uWQ
 rlb
 rlb
@@ -54512,11 +55082,11 @@ rlb
 rlb
 rlb
 tbw
-xVr
-uwR
-uwR
-xVr
-xVr
+yeb
+vnu
+vnu
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -54528,17 +55098,17 @@ rlb
 rlb
 rlb
 rlb
-xVr
+yeb
 rlb
-xVr
-xVr
-qnR
-qnR
-yiI
-whL
-whL
-whL
-yiI
+yeb
+yeb
+uyK
+uyK
+nKj
+eMg
+eMg
+eMg
+nKj
 rlb
 rlb
 rlb
@@ -54560,13 +55130,13 @@ rlb
 rlb
 rlb
 ifw
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -54651,17 +55221,17 @@ tWC
 tWC
 tWC
 awp
-xUV
-xUV
-xUV
-xUV
-xUV
-xUV
-xUV
-xUV
-xUV
-xUV
-dbC
+fmM
+fmM
+fmM
+fmM
+fmM
+fmM
+fmM
+fmM
+fmM
+fmM
+wtp
 tWC
 tWC
 tWC
@@ -54691,12 +55261,12 @@ avp
 avp
 tWC
 tWC
-dbC
-dbC
+wtp
+wtp
 fyD
 fyD
-dbC
-dbC
+wtp
+wtp
 tWC
 tWC
 tWC
@@ -54710,7 +55280,7 @@ tWC
 tWC
 tWC
 tWC
-fmM
+nwH
 fyD
 fyD
 tWC
@@ -54768,12 +55338,12 @@ qyY
 qyY
 tWC
 uWA
-itR
+wLH
 wNw
 uWB
 uWB
-itR
-itR
+wLH
+wLH
 tWC
 tWC
 tWC
@@ -54791,10 +55361,10 @@ tWC
 tWC
 tWC
 tWC
-qFD
+gEx
 stb
-thW
-thW
+sVk
+sVk
 jTm
 tWC
 tWC
@@ -54916,9 +55486,9 @@ lJk
 lJk
 lJk
 lJk
-xNp
-xNp
-dKV
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -54949,9 +55519,9 @@ avp
 rlb
 rlb
 rlb
-dKV
-jZI
-jZI
+gtt
+lCi
+lCi
 eMd
 rlb
 rlb
@@ -54968,8 +55538,8 @@ tWC
 rlb
 rlb
 fqN
-jZI
-jZI
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -55025,12 +55595,12 @@ pyL
 pyL
 pyL
 bdI
-xVr
-xVr
-uwR
-uwR
-xVr
-xVr
+yeb
+yeb
+vnu
+vnu
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -55048,15 +55618,15 @@ rlb
 rlb
 rlb
 rlb
-yiI
-whL
-whL
-whL
-uwR
-xVr
-xVr
-xVr
-xVr
+nKj
+eMg
+eMg
+eMg
+vnu
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -55075,12 +55645,12 @@ rlb
 rlb
 rlb
 rlb
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -55173,9 +55743,9 @@ rlb
 rlb
 rlb
 lJk
-ebi
-wvW
-bot
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -55206,10 +55776,10 @@ avp
 rlb
 rlb
 rlb
-bot
-hIQ
-kbU
-bot
+gtt
+kIr
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -55224,9 +55794,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -55283,11 +55853,11 @@ rlb
 rlb
 yis
 rlb
-gjO
+yeb
 vnu
 vnu
-gjO
-gjO
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -55299,23 +55869,23 @@ rlb
 rlb
 rlb
 rlb
-xuQ
-xuQ
-xuQ
-xuQ
-xuQ
-xuQ
-yiI
-whL
-iwU
-whL
-uwR
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
+oFd
+oFd
+oFd
+oFd
+oFd
+oFd
+nKj
+eMg
+bxS
+eMg
+vnu
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -55325,19 +55895,19 @@ rlb
 rlb
 rlb
 rlb
-xSY
-gjO
-gjO
-gjO
-gjO
-gjO
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
-xSY
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -55430,9 +56000,9 @@ rlb
 rlb
 rlb
 lJk
-ebi
-wvW
-bot
+cGu
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -55463,10 +56033,10 @@ avp
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -55481,9 +56051,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kay
-jRc
+lCi
+xAA
+jZG
 rlb
 rlb
 rlb
@@ -55540,11 +56110,11 @@ rlb
 rlb
 rlb
 rlb
-gjO
+yeb
 vnu
 vnu
-gjO
-gjO
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -55568,32 +56138,32 @@ eMg
 eMg
 jUh
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gEx
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+wLH
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -55687,9 +56257,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-wvW
-bot
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -55720,10 +56290,10 @@ avp
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -55738,9 +56308,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -55797,11 +56367,11 @@ rlb
 rlb
 rlb
 rlb
-tDw
+cwG
 vnu
 toV
-gjO
-gjO
+yeb
+yeb
 rlb
 tWC
 rlb
@@ -55826,20 +56396,20 @@ eMg
 jUh
 rlb
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
-gEx
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
+yeb
+wLH
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -55847,10 +56417,10 @@ rlb
 rlb
 rlb
 tVC
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
 ybb
 rlb
 rlb
@@ -55944,9 +56514,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-ebi
-bot
+kdV
+cGu
+gtt
 rlb
 rlb
 rlb
@@ -55977,10 +56547,10 @@ avp
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -55995,9 +56565,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -56057,7 +56627,7 @@ rlb
 rlb
 vnu
 vnu
-gjO
+yeb
 rlb
 rlb
 tWC
@@ -56104,10 +56674,10 @@ rlb
 rlb
 rlb
 mqY
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -56201,10 +56771,10 @@ rlb
 rlb
 rlb
 lJk
-wvW
-ebi
+kdV
+cGu
 cEy
-jKT
+cEG
 rlb
 rlb
 rlb
@@ -56234,10 +56804,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-dgc
-hIQ
-bot
+gtt
+pFn
+kIr
+gtt
 rlb
 rlb
 rlb
@@ -56252,9 +56822,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 fUn
 rlb
 rlb
@@ -56361,9 +56931,9 @@ rlb
 rlb
 rlb
 vrN
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -56458,11 +57028,11 @@ rlb
 rlb
 rlb
 lJk
-wvW
-ebi
+kdV
+cGu
 cEy
-jKT
-jKT
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -56491,10 +57061,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -56509,9 +57079,9 @@ rlb
 tWC
 rlb
 lJk
-dgc
-jRc
-kbU
+pFn
+jZG
+lCi
 dwn
 fVt
 uWQ
@@ -56593,7 +57163,7 @@ xXD
 oFd
 eMg
 eMg
-oUG
+omg
 lJk
 rlb
 rlb
@@ -56619,7 +57189,7 @@ rlb
 rlb
 rlb
 rlb
-gjO
+yeb
 rlb
 rlb
 rlb
@@ -56715,11 +57285,11 @@ rlb
 rlb
 rlb
 lJk
-wvW
-wvW
-wvW
-jKT
-jKT
+kdV
+kdV
+kdV
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -56748,10 +57318,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -56766,10 +57336,10 @@ rlb
 tWC
 rlb
 rlb
-frv
-kbU
-kbU
-kbU
+fxi
+lCi
+lCi
+lCi
 wFq
 lmS
 wFq
@@ -56876,7 +57446,7 @@ rlb
 rlb
 rlb
 rlb
-lCi
+ifw
 rlb
 rlb
 rlb
@@ -56972,12 +57542,12 @@ rlb
 rlb
 rlb
 lJk
-ebi
+cGu
 cuS
-bot
-jKT
-jKT
-jKT
+gtt
+cEG
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -57005,10 +57575,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-hIQ
-kbU
-bot
+gtt
+kIr
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -57023,10 +57593,10 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
-jRc
+lCi
+lCi
+lCi
+jZG
 wFq
 lmS
 wFq
@@ -57229,12 +57799,12 @@ rlb
 rlb
 rlb
 lJk
-bFH
-wvW
-bot
-jKT
-jKT
-jKT
+tPZ
+kdV
+gtt
+cEG
+cEG
+cEG
 yis
 rlb
 rlb
@@ -57262,10 +57832,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -57280,9 +57850,9 @@ rlb
 tWC
 rlb
 lJk
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 fUC
 rlb
 lJk
@@ -57486,14 +58056,14 @@ rlb
 rlb
 rlb
 lJk
-wvW
-ebi
-bot
+kdV
+cGu
+gtt
 rlb
-jKT
+cEG
 cTP
-jKT
-jKT
+cEG
+cEG
 rlb
 rlb
 yis
@@ -57519,10 +58089,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -57537,9 +58107,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-jRc
-kay
+lCi
+jZG
+xAA
 rlb
 rlb
 rlb
@@ -57743,20 +58313,20 @@ rlb
 rlb
 rlb
 lJk
-bFH
-ebi
-bot
+tPZ
+cGu
+gtt
 rlb
-jKT
+cEG
 yis
 rlb
-jKT
-jKT
-jKT
-jKT
-jKT
-dpC
-jKT
+cEG
+cEG
+cEG
+cEG
+cEG
+ehw
+cEG
 rlb
 rlb
 rlb
@@ -57776,10 +58346,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-hIQ
-kbU
-bot
+gtt
+kIr
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -57794,9 +58364,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
+lCi
 fEr
-kay
+xAA
 rlb
 rlb
 rlb
@@ -58000,10 +58570,10 @@ rlb
 rlb
 rlb
 lJk
-wvW
-wvW
-bot
-bot
+kdV
+kdV
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -58012,9 +58582,9 @@ rlb
 rlb
 yis
 rlb
-tAO
-jKT
-jKT
+sKs
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -58034,9 +58604,9 @@ rlb
 rlb
 rlb
 cEy
-kbU
-kbU
-bot
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -58051,9 +58621,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-jRc
-kbU
+lCi
+jZG
+lCi
 rlb
 rlb
 rlb
@@ -58257,10 +58827,10 @@ yis
 rlb
 rlb
 lJk
-wvW
-bFH
+kdV
+tPZ
 anM
-bot
+gtt
 rlb
 rlb
 rlb
@@ -58271,8 +58841,8 @@ rlb
 rlb
 tWC
 rlb
-jKT
-jKT
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -58290,17 +58860,17 @@ rlb
 rlb
 rlb
 rlb
-bot
-wXR
-kbU
-bot
+gtt
+kCv
+lCi
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
-bot
-bot
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -58308,9 +58878,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-kbU
-kbU
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -58515,9 +59085,9 @@ ipe
 ipe
 lJk
 hyg
-ebi
-cEG
-bot
+cGu
+eAS
+gtt
 rlb
 rlb
 rlb
@@ -58529,7 +59099,7 @@ rlb
 tWC
 rlb
 rlb
-jKT
+cEG
 cTP
 rlb
 rlb
@@ -58547,17 +59117,17 @@ rlb
 rlb
 rlb
 eva
-bot
-kbU
-hIQ
-bot
+gtt
+lCi
+kIr
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
+gtt
 ePC
-bot
+gtt
 rlb
 rlb
 rlb
@@ -58565,9 +59135,9 @@ rlb
 tWC
 rlb
 rlb
-kbU
-jRc
-kbU
+lCi
+jZG
+lCi
 rlb
 rlb
 rlb
@@ -58627,8 +59197,8 @@ iRP
 nKj
 vnu
 vnu
-gjO
-gjO
+yeb
+yeb
 yis
 tWC
 rlb
@@ -58771,10 +59341,10 @@ ipe
 ipe
 ipe
 lJk
-wvW
-ebi
-bot
-bot
+kdV
+cGu
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -58786,9 +59356,9 @@ rlb
 tWC
 rlb
 rlb
-jKT
-jKT
-jKT
+cEG
+cEG
+cEG
 rlb
 rlb
 rlb
@@ -58801,29 +59371,29 @@ rlb
 rlb
 rlb
 rlb
-jKT
+cEG
 cTP
 evi
 cEy
-lzT
-kbU
-bot
+dQk
+lCi
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
+gtt
 ePC
-bot
-bot
+gtt
+gtt
 rlb
 rlb
 rlb
 tWC
 rlb
 rlb
-kbU
-jRc
+lCi
+jZG
 dsO
 lJk
 lJk
@@ -58884,18 +59454,18 @@ iTh
 nKj
 iVw
 toV
-gjO
-gjO
-gjO
-gEx
+yeb
+yeb
+yeb
+wLH
 rlb
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
 rlb
 rlb
-uWC
-uWC
+nKa
+nKa
 oFd
 oFd
 oFd
@@ -58904,13 +59474,13 @@ oFd
 oFd
 loF
 oFd
-lcb
+pWx
 eMg
 eMg
 jUq
 vuS
 vuS
-kdV
+erQ
 rlb
 rlb
 rlb
@@ -59028,9 +59598,9 @@ ipe
 rlb
 rlb
 lJk
-wvW
-ebi
-bot
+kdV
+cGu
+gtt
 rlb
 rlb
 rlb
@@ -59044,9 +59614,9 @@ tWC
 rlb
 rlb
 rlb
-jKT
-jKT
-jKT
+cEG
+cEG
+cEG
 yis
 rlb
 rlb
@@ -59055,21 +59625,21 @@ rlb
 rlb
 rlb
 rlb
-jKT
-jKT
-jKT
-jKT
-jKT
-jKT
-aLw
-kbU
-kbU
-bot
+cEG
+cEG
+cEG
+cEG
+cEG
+cEG
+fLb
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
+gtt
 ggc
 gyJ
 fNq
@@ -59078,10 +59648,10 @@ rlb
 rlb
 tWC
 rlb
-bot
-bot
+gtt
+gtt
 dPr
-bot
+gtt
 lJk
 rlb
 rlb
@@ -59142,17 +59712,17 @@ nKj
 vnu
 vnu
 rlb
-gjO
-gjO
-gEx
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+wLH
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -59167,7 +59737,7 @@ jPY
 vuS
 vuS
 wxL
-yeb
+vuS
 rlb
 rlb
 rlb
@@ -59285,9 +59855,9 @@ yis
 rlb
 rlb
 lJk
-jKU
-bFH
-bot
+lED
+tPZ
+gtt
 rlb
 rlb
 rlb
@@ -59303,25 +59873,25 @@ rlb
 rlb
 rlb
 rlb
-jKT
-jKT
-jKT
-jKT
-jKT
+cEG
+cEG
+cEG
+cEG
+cEG
 cTP
 cTP
-jKT
-jKT
-jKT
+cEG
+cEG
+cEG
 cTP
-jKT
-jKT
-jKT
-jKT
-aLw
-kbU
-pzE
-bot
+cEG
+cEG
+cEG
+cEG
+fLb
+lCi
+kTx
+gtt
 rlb
 rlb
 rlb
@@ -59329,16 +59899,16 @@ rlb
 fNq
 ggv
 gyM
-bot
+gtt
 hjj
-nqu
-wvW
-tLk
-kdu
-bot
-kbU
-kbU
-kbU
+fQk
+kdV
+fmM
+sIA
+gtt
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -59402,14 +59972,14 @@ rlb
 yis
 rlb
 tWC
-gjO
-gjO
+yeb
+yeb
 yis
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
+yeb
 yis
 rlb
 rlb
@@ -59424,7 +59994,7 @@ pOC
 jUP
 jZt
 wxL
-yeb
+vuS
 rlb
 rlb
 rlb
@@ -59542,9 +60112,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-bFH
-bot
+kdV
+tPZ
+gtt
 rlb
 rlb
 rlb
@@ -59566,36 +60136,36 @@ rlb
 rlb
 rlb
 rlb
-bot
-bot
-bot
-bot
-bot
-bot
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
 rlb
-jKT
-jKT
+cEG
+cEG
 cEy
-hIQ
-kbU
-bot
+kIr
+lCi
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
+gtt
 giW
 gAU
-jSk
-wvW
-wvW
-wvW
-tLk
-wvW
-jSk
-kbU
-kbU
-kbU
+dgc
+kdV
+kdV
+kdV
+fmM
+kdV
+dgc
+lCi
+lCi
+lCi
 rlb
 rlb
 rlb
@@ -59662,12 +60232,12 @@ tWC
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -59800,8 +60370,8 @@ rlb
 rlb
 lJk
 cbW
-wvW
-bot
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -59823,35 +60393,35 @@ rlb
 rlb
 rlb
 rlb
-bot
+gtt
 rLT
 kjT
 kjT
 kjT
-bot
+gtt
 rlb
 rlb
 eva
-bot
-kbU
-kbU
-bot
+gtt
+lCi
+lCi
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
-bot
-bot
-bot
-kdu
+gtt
+gtt
+gtt
+gtt
+sIA
 hyg
-wvW
-tLk
-kdu
-bot
-kbU
-kbU
+kdV
+fmM
+sIA
+gtt
+lCi
+lCi
 sip
 rlb
 rlb
@@ -59923,8 +60493,8 @@ rlb
 rlb
 rlb
 yis
-gjO
-gjO
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -60056,9 +60626,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-wvW
-bot
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -60080,19 +60650,19 @@ rlb
 rlb
 rlb
 rlb
-bot
+gtt
 rLT
 kjT
 kjT
 kjT
-bot
+gtt
 rlb
 rlb
 rlb
-bot
-kbU
-hIQ
-bot
+gtt
+lCi
+kIr
+gtt
 rlb
 rlb
 rlb
@@ -60100,15 +60670,15 @@ rlb
 rlb
 rlb
 rlb
-bot
-bot
-wvW
-wvW
-bOv
-bot
-bot
-bot
-jSk
+gtt
+gtt
+kdV
+kdV
+wtp
+gtt
+gtt
+gtt
+dgc
 lJk
 lJk
 rlb
@@ -60177,12 +60747,12 @@ rlb
 rlb
 rlb
 rlb
-uWC
-gjO
-gjO
-gjO
-gjO
-gjO
+nKa
+yeb
+yeb
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -60313,9 +60883,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-jKU
-bot
+kdV
+lED
+gtt
 rlb
 rlb
 rlb
@@ -60337,36 +60907,36 @@ rlb
 rlb
 rlb
 rlb
-bot
+gtt
 fvP
 kjT
 vQg
 vQg
-bot
+gtt
 rlb
 rlb
 rlb
-bot
-hIQ
-lzT
-bot
-rlb
-rlb
-rlb
-rlb
+gtt
+kIr
+dQk
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
-wvW
-wvW
-bOv
 rlb
 rlb
-kIc
-kbU
-kdu
+rlb
+rlb
+gtt
+kdV
+kdV
+wtp
+rlb
+rlb
+lKH
+lCi
+sIA
 rlb
 rlb
 rlb
@@ -60434,12 +61004,12 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+yeb
+yeb
 yis
 rlb
-gjO
-gjO
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -60570,9 +61140,9 @@ rlb
 rlb
 rlb
 lJk
-wvW
-wvW
-bot
+kdV
+kdV
+gtt
 rlb
 rlb
 rlb
@@ -60584,46 +61154,46 @@ rlb
 rlb
 tWC
 rlb
-bot
-bot
-bot
-bot
-bot
-bot
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
+gtt
 aHh
 kjT
 kjT
 kjT
-bot
+gtt
 rlb
 rlb
 rlb
-bot
-kbU
-hIQ
-bot
-rlb
-rlb
-rlb
-rlb
+gtt
+lCi
+kIr
+gtt
 rlb
 rlb
 rlb
 rlb
-bot
-wvW
-wvW
-bOv
 rlb
 rlb
-kbU
-kbU
-kdu
+rlb
+rlb
+gtt
+kdV
+kdV
+wtp
+rlb
+rlb
+lCi
+lCi
+sIA
 rlb
 rlb
 rlb
@@ -60679,7 +61249,7 @@ gbb
 tCN
 ycA
 vnu
-daw
+iLo
 lJk
 vnu
 nQU
@@ -60691,12 +61261,12 @@ rlb
 rlb
 rlb
 rlb
-gjO
+yeb
 rlb
 rlb
 rlb
-gjO
-gjO
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -60827,59 +61397,59 @@ rlb
 rlb
 rlb
 lJk
-jSk
-jSk
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bOv
-bot
-bot
+dgc
+dgc
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+wtp
+gtt
+gtt
 dsH
 dBn
 dsH
 dSm
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-eik
-bot
-bot
-bot
-bot
-bot
-bot
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+izF
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
 dPr
 dPr
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-wvW
-wvW
-bOv
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+kdV
+kdV
+wtp
 rlb
 rlb
-lzT
-kbU
+dQk
+lCi
 rlb
 rlb
 rlb
@@ -60948,19 +61518,19 @@ rlb
 rlb
 rlb
 yis
-gjO
+yeb
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
 rlb
 lJk
-iVR
+jQO
 tWe
 pOC
 vuS
@@ -61084,59 +61654,59 @@ rlb
 rlb
 rlb
 lJk
-kbU
-hIQ
+lCi
+kIr
 cEP
-lzT
-kbU
-kbU
-kbU
-jSk
-kbU
-kIc
-kbU
-kbU
-wJj
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-jRc
-kbU
-kIc
-wXR
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
+dQk
+lCi
+lCi
+lCi
+dgc
+lCi
+lKH
+lCi
+lCi
+fyD
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+jZG
+lCi
+lKH
+kCv
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
 cjU
-kbU
-kbU
-kbU
-jRc
-kbU
-kbU
-jRc
-kbU
-kbU
-kbU
-kbU
-kIc
-kbU
-kbU
-bOv
+lCi
+lCi
+lCi
+jZG
+lCi
+lCi
+jZG
+lCi
+lCi
+lCi
+lCi
+lKH
+lCi
+lCi
+wtp
 rlb
 rlb
-wvW
-kbU
+kdV
+lCi
 rlb
 rlb
 rlb
@@ -61200,18 +61770,18 @@ vnu
 rlb
 rlb
 rlb
-gEx
+wLH
 rlb
 rlb
 rlb
-gjO
-gjO
+yeb
+yeb
 yis
 rlb
 rlb
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -61342,58 +61912,58 @@ rlb
 rlb
 lJk
 cjU
-dHH
-kbU
-kbU
-dHH
-hIQ
-kbU
-jSk
-gmf
-kbU
-kbU
-kbU
+daw
+lCi
+lCi
+daw
+kIr
+lCi
+dgc
+nin
+lCi
+lCi
+lCi
 nwH
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-jRc
-kbU
-kbU
-kbU
-kbU
-jRc
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-kbU
-wXR
-bOv
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+jZG
+lCi
+lCi
+lCi
+lCi
+jZG
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+lCi
+kCv
+wtp
 rlb
-kdu
-jKT
-wvW
+sIA
+cEG
+kdV
 rlb
 rlb
 rlb
@@ -61456,19 +62026,19 @@ vnu
 vnu
 rlb
 rlb
-gjO
+yeb
 awp
 lJk
 lJk
 rlb
-gjO
+yeb
 rlb
 rlb
 rlb
 rlb
-uWC
-gjO
-gjO
+nKa
+yeb
+yeb
 yis
 rlb
 rlb
@@ -61598,59 +62168,59 @@ rlb
 rlb
 rlb
 lJk
-kbU
+lCi
 cwl
-cGu
+eMd
 cPW
-kbU
-hIQ
-kbU
-bot
-bot
-bot
-bot
-bot
-bOv
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-jSk
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-ehx
+lCi
+kIr
+lCi
+gtt
+gtt
+gtt
+gtt
+gtt
+wtp
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+dgc
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+qWX
 nrE
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bot
-bOv
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
+wtp
 rlb
-jKT
-wvW
-wvW
+cEG
+kdV
+kdV
 rlb
 rlb
 rlb
@@ -61713,19 +62283,19 @@ ikC
 vnu
 lJk
 lJk
-gjO
+yeb
 awp
 jcI
 lJk
 rlb
-gjO
+yeb
 rlb
 rlb
 rlb
 rlb
 rlb
 yis
-gjO
+yeb
 rlb
 rlb
 rlb
@@ -61855,32 +62425,32 @@ rlb
 rlb
 rlb
 lJk
-kbU
-hIQ
+lCi
+kIr
 cjU
-kbU
-lzT
-cyY
+lCi
+dQk
+moL
 tmG
-bot
+gtt
 rlb
 rlb
 rlb
 rlb
 tWC
-bot
+gtt
 csn
-aLw
-aLw
-aLw
-aLw
-aLw
-aLw
+fLb
+fLb
+fLb
+fLb
+fLb
+fLb
 csn
-bot
+gtt
 csn
-kbU
-bot
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -61888,10 +62458,10 @@ rlb
 rlb
 rlb
 rlb
-bot
-bot
-bot
-bot
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
@@ -61904,10 +62474,10 @@ rlb
 rlb
 rlb
 tWC
-jKT
-bot
-wvW
-kbU
+cEG
+gtt
+kdV
+lCi
 lJk
 rlb
 rlb
@@ -61975,14 +62545,14 @@ awp
 jcI
 lJk
 lJk
-jif
+aTf
 lJk
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
+yeb
+yeb
+yeb
 rlb
 rlb
 rlb
@@ -62112,32 +62682,32 @@ rlb
 rlb
 rlb
 lJk
-dHH
-kbU
-kbU
-hIQ
-kbU
-kbU
+daw
+lCi
+lCi
+kIr
+lCi
+lCi
 dfj
-bot
+gtt
 rlb
 rlb
 rlb
 rlb
 tWC
-bot
+gtt
 csn
-aLw
-tnG
-aLw
-aLw
-aLw
-aLw
-aLw
-eik
-jRc
-kbU
-bot
+fLb
+vtq
+fLb
+fLb
+fLb
+fLb
+fLb
+izF
+jZG
+lCi
+gtt
 rlb
 rlb
 rlb
@@ -62161,10 +62731,10 @@ rlb
 rlb
 rlb
 tWC
-jKT
+cEG
 flN
-wvW
-wvW
+kdV
+kdV
 rlb
 rlb
 rlb
@@ -62369,32 +62939,32 @@ rlb
 rlb
 rlb
 lJk
-kbU
-kbU
+lCi
+lCi
 cLi
 igA
 tYI
 cXq
 ozM
-bot
+gtt
 rlb
 rlb
 rlb
 rlb
 tWC
-bot
-aLw
-aLw
-tnG
-aLw
-aLw
-aLw
-aLw
-aLw
-bot
-lWM
-lWM
-bot
+gtt
+fLb
+fLb
+vtq
+fLb
+fLb
+fLb
+fLb
+fLb
+gtt
+mJo
+mJo
+gtt
 rlb
 rlb
 rlb
@@ -62418,10 +62988,10 @@ rlb
 rlb
 rlb
 tWC
-jKT
-jKT
-jKT
-wvW
+cEG
+cEG
+cEG
+kdV
 rlb
 rlb
 rlb
@@ -62626,32 +63196,32 @@ rlb
 rlb
 rlb
 lJk
-jSk
-jSk
-bot
-bot
-bot
-bot
-bot
-bot
+dgc
+dgc
+gtt
+gtt
+gtt
+gtt
+gtt
+gtt
 rlb
 rlb
 rlb
 rlb
 tWC
-bot
-aLw
-tnG
-aLw
-aLw
-ehx
-aLw
-aLw
-aLw
-bot
-kbU
-pzE
-bot
+gtt
+fLb
+vtq
+fLb
+fLb
+qWX
+fLb
+fLb
+fLb
+gtt
+lCi
+kTx
+gtt
 rlb
 rlb
 rlb
@@ -62674,11 +63244,11 @@ rlb
 rlb
 rlb
 rlb
-tAO
-jKT
-jKT
-wvW
-kbU
+sKs
+cEG
+cEG
+kdV
+lCi
 rlb
 rlb
 rlb
@@ -62759,7 +63329,7 @@ rlb
 rlb
 rlb
 lJk
-oUG
+omg
 eMg
 eMg
 lJk
@@ -63016,9 +63586,9 @@ tWC
 tWC
 tWC
 awp
-fLb
-fLb
-fLb
+thW
+thW
+thW
 awp
 tWC
 tWC
@@ -63273,9 +63843,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -63514,9 +64084,9 @@ rlb
 rlb
 was
 xRN
-gtt
-vnu
-vnu
+dgg
+uwR
+uwR
 eUn
 was
 rlb
@@ -63530,9 +64100,9 @@ rlb
 rlb
 rlb
 lJk
-lED
-eMg
-jbp
+qRI
+whL
+muz
 lJk
 rlb
 rlb
@@ -63787,9 +64357,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -64030,7 +64600,7 @@ rlb
 tWC
 rlb
 rlb
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -64044,9 +64614,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -64287,8 +64857,8 @@ rlb
 tWC
 rlb
 rlb
-gjO
-uWC
+xVr
+viX
 rlb
 rlb
 rlb
@@ -64301,9 +64871,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -64544,8 +65114,8 @@ rlb
 tWC
 rlb
 yis
-gjO
-gjO
+xVr
+xVr
 yis
 rlb
 rlb
@@ -64558,9 +65128,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -64801,8 +65371,8 @@ rlb
 tWC
 rlb
 rlb
-gjO
-gjO
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -64815,9 +65385,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -65058,7 +65628,7 @@ rlb
 tWC
 rlb
 rlb
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -65072,9 +65642,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -65314,8 +65884,8 @@ rlb
 rlb
 tWC
 rlb
-tDw
-bMl
+yld
+qnR
 rlb
 rlb
 rlb
@@ -65329,9 +65899,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -65571,8 +66141,8 @@ rlb
 rlb
 tWC
 rlb
-gjO
-bMl
+xVr
+qnR
 rlb
 rlb
 rlb
@@ -65586,9 +66156,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -65828,8 +66398,8 @@ rlb
 rlb
 tWC
 yis
-gjO
-gjO
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -65843,9 +66413,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-mLF
-eMg
+whL
+jFe
+whL
 lJk
 rlb
 rlb
@@ -66084,8 +66654,8 @@ rlb
 rlb
 rlb
 tWC
-gjO
-gjO
+xVr
+xVr
 yis
 rlb
 rlb
@@ -66100,9 +66670,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -66332,17 +66902,17 @@ rlb
 gjO
 gjO
 gjO
-gjO
-uWC
+xVr
+viX
 rlb
 rlb
 yis
 rlb
 rlb
 yis
-gEx
-gjO
-gjO
+itR
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -66357,9 +66927,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -66589,17 +67159,17 @@ rlb
 yis
 gjO
 gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gjO
-gEx
-gjO
-gjO
+xVr
+xVr
+xVr
+xVr
+xVr
+xVr
+xVr
+xVr
+itR
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -66614,9 +67184,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-bxS
+whL
+whL
+iwU
 lJk
 rlb
 rlb
@@ -66846,14 +67416,14 @@ rlb
 rlb
 gjO
 bMl
-bMl
-gjO
-gjO
-gjO
+qnR
+xVr
+xVr
+xVr
 yis
-gjO
-gjO
-gjO
+xVr
+xVr
+xVr
 tWC
 rlb
 rlb
@@ -66872,8 +67442,8 @@ rlb
 rlb
 lJk
 lcb
-eMg
-hdO
+whL
+prS
 lJk
 rlb
 rlb
@@ -67103,13 +67673,13 @@ rlb
 rlb
 rlb
 gjO
-gjO
-gjO
-gjO
+xVr
+xVr
+xVr
 rlb
 rlb
 rlb
-gjO
+xVr
 yis
 tWC
 rlb
@@ -67129,8 +67699,8 @@ rlb
 rlb
 lJk
 lcb
-eMg
-eMg
+whL
+whL
 lJk
 rlb
 rlb
@@ -67360,13 +67930,13 @@ rlb
 rlb
 rlb
 gjO
-gjO
-bMl
-bMl
+xVr
+qnR
+qnR
 rlb
 rlb
-gjO
-gjO
+xVr
+xVr
 rlb
 tWC
 rlb
@@ -67385,9 +67955,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -67618,11 +68188,11 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
+xVr
+xVr
+xVr
+xVr
+xVr
 rlb
 rlb
 tWC
@@ -67642,9 +68212,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
+whL
 lcb
-eMg
+whL
 lJk
 rlb
 rlb
@@ -67876,9 +68446,9 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
-iVR
+xVr
+xVr
+iUc
 rlb
 rlb
 rlb
@@ -67899,9 +68469,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -68132,8 +68702,8 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -68156,9 +68726,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -68389,8 +68959,8 @@ rlb
 rlb
 rlb
 rlb
-gjO
-bMl
+xVr
+qnR
 rlb
 rlb
 rlb
@@ -68413,9 +68983,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-bxS
-eMg
+whL
+iwU
+whL
 lJk
 rlb
 rlb
@@ -68646,8 +69216,8 @@ rlb
 rlb
 rlb
 crS
-bMl
-gjO
+qnR
+xVr
 rlb
 rlb
 rlb
@@ -68670,9 +69240,9 @@ rlb
 rlb
 rlb
 lJk
-bxS
-eMg
-eMg
+iwU
+whL
+whL
 lJk
 rlb
 rlb
@@ -68902,8 +69472,8 @@ rlb
 rlb
 rlb
 yis
-bMl
-gjO
+qnR
+xVr
 yis
 rlb
 rlb
@@ -68927,9 +69497,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -69159,8 +69729,8 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xVr
+xVr
 rlb
 rlb
 rlb
@@ -69184,9 +69754,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -69416,7 +69986,7 @@ rlb
 rlb
 rlb
 xtj
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -69441,9 +70011,9 @@ rlb
 rlb
 rlb
 lJk
-dtm
-eMg
-eMg
+mJb
+whL
+whL
 lJk
 rlb
 rlb
@@ -69673,8 +70243,8 @@ rlb
 rlb
 rlb
 xtj
-gjO
-uWC
+xVr
+viX
 rlb
 rlb
 rlb
@@ -69698,9 +70268,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -69930,8 +70500,8 @@ rlb
 rlb
 rlb
 xtj
-gjO
-uWC
+xVr
+viX
 rlb
 rlb
 rlb
@@ -69955,9 +70525,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -70187,7 +70757,7 @@ rlb
 rlb
 rlb
 pZy
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -70212,9 +70782,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -70444,8 +71014,8 @@ rlb
 rlb
 rlb
 xtj
-bMl
-bMl
+qnR
+qnR
 rlb
 rlb
 rlb
@@ -70469,9 +71039,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -70701,7 +71271,7 @@ rlb
 rlb
 rlb
 xtj
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -70726,9 +71296,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-bxS
-eMg
+whL
+iwU
+whL
 lJk
 rlb
 rlb
@@ -70958,7 +71528,7 @@ rlb
 rlb
 rlb
 xtj
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -70983,9 +71553,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -71215,7 +71785,7 @@ tWC
 tWC
 tWC
 pJl
-gEx
+itR
 tWC
 tWC
 tWC
@@ -71240,9 +71810,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -71472,7 +72042,7 @@ rlb
 rlb
 yis
 xtj
-gjO
+xVr
 rlb
 rlb
 rlb
@@ -71497,9 +72067,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -71729,7 +72299,7 @@ rlb
 rlb
 gcj
 pZy
-gjO
+xVr
 yis
 rlb
 rlb
@@ -71754,9 +72324,9 @@ rlb
 rlb
 rlb
 lJk
-lED
-eMg
-eMg
+qRI
+whL
+whL
 lJk
 rlb
 rlb
@@ -72011,9 +72581,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -72268,9 +72838,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -72525,9 +73095,9 @@ rlb
 rlb
 rlb
 lJk
-eMg
-eMg
-eMg
+whL
+whL
+whL
 lJk
 rlb
 rlb
@@ -72783,8 +73353,8 @@ lJk
 lJk
 was
 sbg
-eMg
-eMg
+whL
+whL
 was
 rlb
 rlb
@@ -73038,9 +73608,9 @@ hnE
 lUf
 oMo
 lUf
-olx
-eMg
-jfb
+fow
+whL
+skh
 oUG
 was
 rlb
@@ -73297,8 +73867,8 @@ lUf
 lUf
 was
 lcb
-eMg
-eMg
+whL
+whL
 was
 rlb
 rlb

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -2215,11 +2215,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bMl" = (
-/obj/random/trash,
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
-/area/maintenance/firstdeck/aftport)
+/obj/structure/cable/blue{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/forestarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "bMN" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloorblack{
@@ -2808,6 +2816,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -5119,6 +5130,9 @@
 	pixel_y = 32
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -5738,7 +5752,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "eZZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -6808,10 +6824,14 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna/cryosauna)
 "gjO" = (
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/blue{
+	icon_state = "1-4"
 	},
-/area/maintenance/firstdeck/aftport)
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gjT" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -9425,7 +9445,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iJd" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -9782,14 +9804,6 @@
 /area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"iVR" = (
-/obj/structure/flora/ausbushes/grassybush{
-	opacity = 1
-	},
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
-	},
-/area/maintenance/firstdeck/aftport)
 "iWz" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -11109,6 +11123,9 @@
 	},
 /obj/structure/barricade,
 /obj/effect/floor_decal/rust,
+/obj/structure/cable/blue{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -11221,6 +11238,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "0-4"
+	},
+/obj/structure/cable/blue{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
@@ -16347,7 +16367,9 @@
 /turf/simulated/floor/outdoors/rocks/caves{
 	outdoors = -1
 	},
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "rvk" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -18077,7 +18099,9 @@
 	})
 "tDw" = (
 /turf/simulated/mineral/cave,
-/area/maintenance/firstdeck/aftport)
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tEe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -19171,11 +19195,14 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uWC" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/outdoors/rocks/caves{
-	outdoors = -1
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/blue{
+	icon_state = "2-8"
 	},
-/area/maintenance/firstdeck/aftport)
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/forestarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "uWH" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -22168,6 +22195,14 @@
 	light_color = "#AF2A2A"
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -63813,8 +63848,8 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -64070,8 +64105,8 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -64327,8 +64362,8 @@ rlb
 rlb
 rlb
 yis
-bMl
-gjO
+pZy
+xtj
 rlb
 rlb
 rlb
@@ -64582,8 +64617,8 @@ rlb
 rlb
 rlb
 rlb
-uWC
-gjO
+gcj
+xtj
 ruY
 yis
 rlb
@@ -64837,10 +64872,10 @@ rlb
 rlb
 rlb
 rlb
-uWC
-gjO
-gjO
-gjO
+gcj
+xtj
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -65093,11 +65128,11 @@ rlb
 rlb
 yis
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
+xtj
+xtj
+xtj
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -65350,11 +65385,11 @@ rlb
 xtj
 xtj
 xtj
-bMl
-gjO
-bMl
-gjO
-gjO
+pZy
+xtj
+pZy
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -65607,11 +65642,11 @@ xtj
 xtj
 pZy
 ohT
-iVR
-iVR
-gjO
-bMl
-gjO
+ohT
+ohT
+xtj
+pZy
+xtj
 yis
 rlb
 rlb
@@ -65864,12 +65899,12 @@ xtj
 xtj
 yis
 rlb
-iVR
+ohT
 tDw
-iVR
-iVR
-gjO
-gjO
+ohT
+ohT
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -66120,14 +66155,14 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xtj
+xtj
 rlb
 rlb
 yis
-iVR
-gjO
-gjO
+ohT
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -66376,17 +66411,17 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
-gjO
-gjO
+xtj
+xtj
+xtj
+xtj
+xtj
 rlb
 rlb
 rlb
-bMl
-gjO
-gjO
+pZy
+xtj
+xtj
 rlb
 rlb
 rlb
@@ -66632,18 +66667,18 @@ rlb
 rlb
 rlb
 eYO
-gjO
-gjO
-gjO
-bMl
-gjO
-gjO
-gjO
+xtj
+xtj
+xtj
+pZy
+xtj
+xtj
+xtj
 rlb
 rlb
 rlb
-gjO
-bMl
+xtj
+pZy
 yis
 rlb
 rlb
@@ -66890,18 +66925,18 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
-bMl
-gjO
-gjO
+xtj
+xtj
+xtj
+pZy
+xtj
+xtj
 rlb
 rlb
 rlb
-gjO
-gjO
-gjO
+xtj
+xtj
+xtj
 xVr
 viX
 rlb
@@ -67147,18 +67182,18 @@ rlb
 rlb
 rlb
 rlb
-gjO
-gjO
+xtj
+xtj
 yis
-bMl
-gjO
-bMl
+pZy
+xtj
+pZy
 rlb
 rlb
 rlb
 yis
-gjO
-gjO
+xtj
+xtj
 xVr
 xVr
 xVr
@@ -67404,18 +67439,18 @@ rlb
 rlb
 rlb
 rlb
-uWC
-gjO
-gjO
-bMl
-bMl
-gjO
+gcj
+xtj
+xtj
+pZy
+pZy
+xtj
 rlb
 rlb
 rlb
 rlb
-gjO
-bMl
+xtj
+pZy
 qnR
 xVr
 xVr
@@ -67662,17 +67697,17 @@ rlb
 rlb
 rlb
 rlb
-uWC
-gjO
-gjO
-gjO
-gjO
+gcj
+xtj
+xtj
+xtj
+xtj
 rlb
 rlb
 rlb
 rlb
 rlb
-gjO
+xtj
 xVr
 xVr
 xVr
@@ -67929,7 +67964,7 @@ rlb
 rlb
 rlb
 rlb
-gjO
+xtj
 xVr
 qnR
 qnR
@@ -70189,7 +70224,7 @@ bot
 kdu
 ezy
 wvW
-ezy
+bMl
 kxy
 kFQ
 ldS
@@ -70446,9 +70481,9 @@ bot
 dzk
 wvW
 wvW
-wvW
+uWC
 kzR
-wgL
+gjO
 wgL
 lsr
 kxy
@@ -71990,9 +72025,9 @@ rlb
 rlb
 rlb
 rlb
-lJk
-dCM
-lJk
+tJc
+wgL
+tJc
 rlb
 rlb
 rlb
@@ -72248,8 +72283,8 @@ bot
 bot
 tJc
 tJc
-dCM
-lJk
+wgL
+tJc
 rlb
 rlb
 rlb
@@ -72505,8 +72540,8 @@ kbU
 kbU
 htr
 tJc
-dCM
-lJk
+wgL
+tJc
 rlb
 rlb
 rlb
@@ -72762,8 +72797,8 @@ kbU
 kbU
 hJq
 huA
-dCM
-lJk
+wgL
+tJc
 rlb
 rlb
 rlb
@@ -73019,8 +73054,8 @@ bot
 jRc
 hJq
 tJc
-dCM
-lJk
+wgL
+tJc
 rlb
 rlb
 rlb
@@ -73276,8 +73311,8 @@ bot
 kbU
 hJq
 tJc
-lJk
-lJk
+tJc
+tJc
 rlb
 rlb
 rlb

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -3782,16 +3782,23 @@
 /area/expoutpost/prep/recovery)
 "bYO" = (
 /obj/structure/table/sifwoodentable,
-/obj/item/weapon/storage/box/cdeathalarm_kit,
 /obj/item/weapon/storage/box/cdeathalarm_kit{
-	pixel_x = 5;
-	pixel_y = 5
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/weapon/storage/box/cdeathalarm_kit{
+	pixel_x = -8;
+	pixel_y = 7
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 10
+	},
+/obj/item/device/bluespaceradio/relicbase_prelinked{
+	pixel_x = 9;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
@@ -5739,6 +5746,7 @@
 	req_one_access = null
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
 "cHF" = (
@@ -7866,6 +7874,7 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/bmarble,
 /area/quartermaster/delivery)
 "dAw" = (
@@ -27438,6 +27447,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "lOQ" = (
@@ -34609,6 +34619,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
 "pbo" = (
@@ -35178,6 +35189,7 @@
 	req_one_access = list(11)
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/substation/engineering)
 "ppX" = (
@@ -54097,6 +54109,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "wVI" = (

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -6906,10 +6906,15 @@
 "nj" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/cable/green,
 /obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
 	pixel_y = -24
 	},
-/obj/structure/cable/green,
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "nk" = (
@@ -9131,9 +9136,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/rust,
-/obj/machinery/power/apc/hyper{
-	pixel_y = -24
-	},
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "qW" = (
@@ -10948,6 +10950,11 @@
 	c_tag = "CIV - Hangar Pad 4 Southeast";
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -11503,6 +11510,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "vy" = (
@@ -11738,11 +11746,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
-"vW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/space,
-/area/medical/virology)
 "vX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -19346,6 +19349,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -24149,6 +24153,7 @@
 	name = "Club"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/bar)
 "Tz" = (
@@ -24169,6 +24174,7 @@
 /obj/machinery/door/airlock{
 	name = "Club"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/bar)
 "TB" = (
@@ -69427,7 +69433,7 @@ gQ
 tR
 Dq
 fW
-vW
+xa
 xA
 yL
 SS

--- a/maps/relic_base/relicbase_areas.dm
+++ b/maps/relic_base/relicbase_areas.dm
@@ -734,28 +734,36 @@ z
 	name = "Maintenance Level - Central"
 	icon_state = "maintcentral"
 
+/area/maintenance/firstdeck/aft
+	name = "Maintenance Level - South"
+	icon_state = "amaint"
+
 /area/maintenance/firstdeck/aftstarboard
-	name = "Maintenance Level - Southwest"
+	name = "Maintenance Level - Southeast"
 	icon_state = "asmaint"
 
 /area/maintenance/firstdeck/aftport
-	name = "Maintenance Level - Southeast"
+	name = "Maintenance Level - Southwest"
 	icon_state = "apmaint"
 
+/area/maintenance/firstdeck/fore
+	name = "Maintenance Level - North"
+	icon_state = "fmaint"
+
 /area/maintenance/firstdeck/forestarboard
-	name = "Maintenance Level - Northwest"
+	name = "Maintenance Level - Northeast"
 	icon_state = "fsmaint"
 
 /area/maintenance/firstdeck/foreport
-	name = "Maintenance Level - Northeast"
+	name = "Maintenance Level - Northwest"
 	icon_state = "fpmaint"
 
 /area/maintenance/firstdeck/centralstarboard
-	name = "Maintenance Level - West"
+	name = "Maintenance Level - East"
 	icon_state = "smaint"
 
 /area/maintenance/firstdeck/centralport
-	name = "Maintenance Level - East"
+	name = "Maintenance Level - West"
 	icon_state = "pmaint"
 
 /area/maintenance/substation/firstdeck

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1369,6 +1369,7 @@
 #include "code\game\objects\items\devices\radio\jammer_vr.dm"
 #include "code\game\objects\items\devices\radio\radio.dm"
 #include "code\game\objects\items\devices\radio\radio_ch.dm"
+#include "code\game\objects\items\devices\radio\radio_tc.dm"
 #include "code\game\objects\items\devices\radio\radio_vr.dm"
 #include "code\game\objects\items\devices\radio\radio_yw.dm"
 #include "code\game\objects\items\devices\radio\radiopack.dm"


### PR DESCRIPTION

## About The Pull Request

Just a couple of small, misc fixes. For the tiny fans, I only added them to side exits and substations, following how other substations and exits have been set.

- Adds tiny fans to cargo and engineering substation, one cargo exit near the elevator, atmos storage, the autoresleever room, medical solars, and club.
- Fixes an accidental space tile in virology (whoooops!).
- Unlocks Ursula's APC.
- Moves an APC in one of the derelict shuttles.
- Adjust underground west and east sides. Adds north, east, south, and west areas as well.
## Changelog
:cl:
maptweak: Fixed accidental space tile in virology (whoops!)
maptweak: Added a few more tiny fans.
maptweak: Adjusted underground areas
maptweak: Unlocks Ursula's APC
/:cl:
