### PR TITLE
Engineering Upgrades/Optimisations to map

### DIFF
--- a/maps/relic_base/relicbase-1.dmm
+++ b/maps/relic_base/relicbase-1.dmm
@@ -3804,13 +3804,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/underground/catacombs)
-"Bo" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/underground/catacombs)
 "Bp" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table,
@@ -35128,7 +35121,7 @@ Fu
 tw
 Qg
 ZY
-au
+iJ
 iJ
 iJ
 ZY
@@ -35385,8 +35378,8 @@ QL
 Em
 ZY
 kM
-Bo
-Bo
+ao
+ao
 iJ
 ZY
 Tc
@@ -35641,8 +35634,8 @@ Tc
 HS
 iJ
 Wh
-iJ
-iJ
+oQ
+au
 iJ
 iJ
 ZY

--- a/maps/relic_base/relicbase-1.dmm
+++ b/maps/relic_base/relicbase-1.dmm
@@ -3065,7 +3065,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -5295,6 +5295,8 @@
 /area/maintenance/underground/catacombs)
 "MQ" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,

--- a/maps/relic_base/relicbase-10.dmm
+++ b/maps/relic_base/relicbase-10.dmm
@@ -18,7 +18,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -114,7 +114,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -324,7 +324,7 @@
 	dir = 4
 	},
 /obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/green,
+/obj/structure/cable,
 /obj/item/stack/material/phoron{
 	amount = 10
 	},

--- a/maps/relic_base/relicbase-10.dmm
+++ b/maps/relic_base/relicbase-10.dmm
@@ -19,6 +19,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -36,7 +38,9 @@
 /area/surface/outpost/wall)
 "cW" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outpost/wall/checkpoint)
@@ -107,10 +111,11 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -190,7 +195,9 @@
 /area/surface/outpost/wall/checkpoint)
 "wp" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/surface/outpost/mining_main/exterior{
@@ -198,7 +205,9 @@
 	})
 "zE" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/surface/outpost/mining_main/exterior{
@@ -221,7 +230,9 @@
 	})
 "Cs" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/light{
 	dir = 4
@@ -278,7 +289,9 @@
 	name = "Wilderness Containment"
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outpost/wall/checkpoint)
@@ -351,7 +364,9 @@
 /area/surface/outpost/wall/checkpoint)
 "MF" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -369,7 +384,9 @@
 	})
 "Ox" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/surface/outside/wilderness/mountains)
@@ -383,7 +400,9 @@
 	})
 "PZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -419,7 +438,8 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/asteroid_steel,

--- a/maps/relic_base/relicbase-11.dmm
+++ b/maps/relic_base/relicbase-11.dmm
@@ -156,7 +156,7 @@
 "aE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -205,7 +205,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -232,7 +232,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "aZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -284,7 +284,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/aftdock)
 "bk" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -344,7 +344,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -399,7 +399,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/stargazer)
 "bB" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -498,17 +498,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/telecomms)
 "bS" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -525,7 +525,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -634,7 +634,7 @@
 	pixel_x = 12;
 	pixel_y = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -654,7 +654,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hallwayaftport)
 "cl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -737,7 +737,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/wreck/ufoship)
 "cL" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -758,7 +758,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/stargazer)
 "cO" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -814,7 +814,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/aftdock)
 "de" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -901,7 +901,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -918,7 +918,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarfour)
 "dx" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -989,12 +989,12 @@
 /turf/simulated/wall,
 /area/maintenance/solars/expportsolar)
 "dF" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -1051,7 +1051,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
 "dQ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -1165,7 +1165,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1373,7 +1373,7 @@
 	input_level = 150000;
 	output_level = 100000
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -1542,7 +1542,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
 "fU" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -1566,7 +1566,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "fZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -1578,7 +1578,7 @@
 /turf/simulated/floor/bluegrid,
 /area/maintenance/expoutpost/telecomms)
 "gb" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1603,7 +1603,7 @@
 	dir = 5
 	},
 /obj/machinery/power/terminal,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1623,7 +1623,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangerhall)
 "gi" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -1750,7 +1750,7 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/hangartwo)
 "gW" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1770,7 +1770,7 @@
 /area/expoutpost/hallwayaftport)
 "ha" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1803,7 +1803,7 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1895,7 +1895,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1919,7 +1919,7 @@
 /area/expoutpost/hangartwo)
 "hE" = (
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1934,7 +1934,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangerhall)
 "hI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2273,7 +2273,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
 "iZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -2300,7 +2300,7 @@
 	req_access = list();
 	req_one_access = list(11,24)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2327,7 +2327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2376,7 +2376,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2407,7 +2407,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarsix)
 "jw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2467,7 +2467,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
 "jH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2556,7 +2556,7 @@
 /turf/simulated/floor/airless,
 /area/expoutpost/hangerhall)
 "jV" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2623,12 +2623,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarthree)
 "kl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -2679,7 +2679,7 @@
 /turf/simulated/floor/wood/sif,
 /area/maintenance/expoutpost/outerportmaint)
 "ky" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2687,7 +2687,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/atmospherics)
 "kF" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2738,12 +2738,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarsix)
 "kP" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -2762,7 +2762,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2854,7 +2854,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -2884,7 +2884,7 @@
 "lu" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3048,7 +3048,7 @@
 /area/expoutpost/aftdock)
 "md" = (
 /obj/machinery/atmospherics/portables_connector,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -3081,7 +3081,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "mo" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3253,7 +3253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3267,7 +3267,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/shuttle)
 "mZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3281,7 +3281,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "na" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3335,7 +3335,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarsix)
 "nl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -3347,7 +3347,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3364,7 +3364,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "nn" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3372,12 +3372,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerstarboardmaint)
 "nr" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -3433,7 +3433,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -3481,7 +3481,7 @@
 	req_access = list(17,43);
 	req_one_access = list(17)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3502,12 +3502,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -3534,7 +3534,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/expoutpost/gateway)
 "nR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3582,7 +3582,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "nV" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3602,7 +3602,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 21
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/machinery/camera/network/carrier{
 	c_tag = "CAR - Port Solars";
 	dir = 1
@@ -3632,12 +3632,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -3716,7 +3716,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/prep)
 "op" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3738,7 +3738,7 @@
 	dir = 2;
 	name = "Hangar Two"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3751,7 +3751,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -3791,7 +3791,7 @@
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/baby_mammoth)
 "oK" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3858,12 +3858,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "oZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -3903,12 +3903,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/innerstarboardmaint)
 "pe" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -3928,7 +3928,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerportmaint)
 "pl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3957,7 +3957,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "pn" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3996,7 +3996,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4027,14 +4027,14 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "pA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -4175,7 +4175,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -4201,7 +4201,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -4210,7 +4210,7 @@
 /area/maintenance/expoutpost/outerportmaint)
 "qf" = (
 /obj/item/frame/apc,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -4246,7 +4246,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/structure/table/sifwoodentable,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled,
@@ -4310,7 +4310,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/nukestorage)
 "qw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4373,7 +4373,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarone)
 "qG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4530,7 +4530,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "ro" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4615,7 +4615,7 @@
 /area/expoutpost/hangarfour)
 "rE" = (
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4663,7 +4663,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4672,7 +4672,7 @@
 /area/maintenance/expoutpost/outerstarboardmaint)
 "rQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4783,7 +4783,7 @@
 "si" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4809,7 +4809,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4827,7 +4827,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerportmaint)
 "st" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4853,7 +4853,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -4895,7 +4895,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/echidna)
 "sz" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4957,7 +4957,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4971,7 +4971,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/hangaroneprep)
 "sJ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -5028,7 +5028,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangerhall)
 "sX" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5045,7 +5045,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hallwayaftport)
 "sY" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5082,7 +5082,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "tg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5141,7 +5141,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5159,7 +5159,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarfive)
 "tu" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -5246,7 +5246,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5257,7 +5257,7 @@
 /area/expoutpost/prep)
 "tR" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -5288,7 +5288,7 @@
 "tX" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5305,7 +5305,7 @@
 /area/expoutpost/hangaroneprep)
 "tY" = (
 /obj/machinery/light/small,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -5427,7 +5427,7 @@
 "us" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5449,7 +5449,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarsix)
 "uv" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5469,7 +5469,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/atmospherics)
 "uz" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5495,7 +5495,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "uC" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -5555,7 +5555,7 @@
 /obj/effect/floor_decal/corner/pink/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -5612,7 +5612,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5746,7 +5746,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5787,7 +5787,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/prep/recovery)
 "vG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5816,7 +5816,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5878,7 +5878,7 @@
 /area/expoutpost/hangaroneprep)
 "vZ" = (
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5986,7 +5986,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/echidna)
 "wH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6042,12 +6042,12 @@
 	pixel_x = 11;
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -6088,7 +6088,7 @@
 /turf/simulated/wall,
 /area/expoutpost/hallwayaftport)
 "wT" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6142,7 +6142,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -6170,7 +6170,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/innerstarboardmaint)
 "xi" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6202,7 +6202,7 @@
 "xm" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6246,7 +6246,7 @@
 /area/shuttle/shuttlebackup/start)
 "xw" = (
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6337,7 +6337,7 @@
 	name = "Gateway"
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6388,7 +6388,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarfour)
 "ya" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6400,7 +6400,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "yc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6447,7 +6447,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -6520,7 +6520,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/shuttle)
 "yE" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6559,7 +6559,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/gateway)
 "yN" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6600,7 +6600,7 @@
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/baby_mammoth)
 "yX" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -6620,7 +6620,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/aftdock)
 "zb" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6705,7 +6705,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -6748,7 +6748,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6773,7 +6773,7 @@
 "zM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6875,7 +6875,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/baby_mammoth)
 "Ag" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6948,7 +6948,7 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/hangarthree)
 "Av" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6996,7 +6996,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarsix)
 "AM" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7019,12 +7019,12 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarfour)
 "AR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -7130,7 +7130,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/innerportmaint)
 "Br" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7161,7 +7161,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "Bu" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7183,7 +7183,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/echidna)
 "Bw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7196,7 +7196,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "Bx" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7283,7 +7283,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttlebackup/start)
 "BI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7364,7 +7364,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7473,7 +7473,7 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/baby_mammoth)
 "Cw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7769,7 +7769,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/atmospherics)
 "DI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7794,7 +7794,7 @@
 "DN" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7876,12 +7876,12 @@
 /turf/space,
 /area/space)
 "Ec" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -7991,7 +7991,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/stargazer)
 "EA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8034,7 +8034,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarfive)
 "EH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8090,7 +8090,7 @@
 "EV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8106,7 +8106,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "EY" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8134,7 +8134,7 @@
 	input_level = 150000;
 	output_level = 100000
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -8188,7 +8188,7 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/baby_mammoth)
 "Fi" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8232,7 +8232,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
 "Fy" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8284,7 +8284,7 @@
 /area/expoutpost/displayroom)
 "FH" = (
 /obj/machinery/light/small,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -8310,7 +8310,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttlebackup/start)
 "FO" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8344,12 +8344,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8458,7 +8458,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8469,7 +8469,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "Gq" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -8636,7 +8636,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -8723,7 +8723,7 @@
 /area/solar/expstarboardsolar)
 "Hd" = (
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8750,7 +8750,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8832,7 +8832,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -9030,12 +9030,12 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarone)
 "Iv" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -9100,7 +9100,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/prep/recovery)
 "IG" = (
@@ -9289,7 +9289,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/hangaroneprep)
 "Jp" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9440,7 +9440,7 @@
 	pixel_y = 32;
 	req_one_access = list(43,67)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9530,7 +9530,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerstarboardmaint)
 "KB" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9588,12 +9588,12 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -9750,7 +9750,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
 "LA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -9853,7 +9853,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9882,7 +9882,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -9915,7 +9915,7 @@
 	pixel_y = -24;
 	req_access = list(19)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9994,7 +9994,7 @@
 /turf/simulated/shuttle/wall,
 /area/wreck/supplyshuttle)
 "Mp" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10140,7 +10140,7 @@
 /area/shuttle/shuttlebackup/start)
 "MT" = (
 /obj/structure/bed/chair/office/dark,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -10323,17 +10323,17 @@
 /turf/simulated/floor/airless,
 /area/solar/expportsolar)
 "NC" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -10441,7 +10441,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerstarboardmaint)
 "Oh" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -10476,7 +10476,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/aftdock)
 "Ol" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -10489,7 +10489,7 @@
 /area/expoutpost/hangerhall)
 "On" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -10530,7 +10530,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10642,7 +10642,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -10669,7 +10669,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -10768,7 +10768,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
 "Pn" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -10910,12 +10910,12 @@
 /turf/simulated/wall/r_wall,
 /area/wreck/ufoship)
 "Qb" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -10937,12 +10937,12 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/wreck/ufoship)
 "Qf" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -10966,7 +10966,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarone)
 "Qk" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11093,7 +11093,7 @@
 	req_access = list();
 	req_one_access = list(11,24)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11117,7 +11117,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/aftdock)
 "QI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11145,7 +11145,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/shuttlebackup/start)
 "QP" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11257,7 +11257,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangaroneprep)
 "Rg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11283,7 +11283,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11316,7 +11316,7 @@
 /turf/simulated/floor/airless,
 /area/wreck/ufoship)
 "Rv" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11373,7 +11373,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "RI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11442,7 +11442,7 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/shuttle/stargazer)
 "RR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11533,12 +11533,12 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/baby_mammoth)
 "Sl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -11666,7 +11666,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11729,7 +11729,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -11943,7 +11943,7 @@
 /obj/item/stack/cable_coil/yellow,
 /obj/item/stack/cable_coil/yellow,
 /obj/item/stack/cable_coil/yellow,
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /obj/machinery/camera/network/carrier{
 	c_tag = "CAR - Starboard Solars";
 	dir = 1
@@ -11970,7 +11970,7 @@
 /area/shuttle/stargazer)
 "TC" = (
 /obj/structure/catwalk,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12038,15 +12038,10 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/hangarone)
 "TQ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12078,7 +12073,7 @@
 	operating = 0;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -12094,7 +12089,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/expoutpost/innerstarboardmaint)
 "Uh" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -12116,7 +12111,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/innerportmaint)
 "Uk" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12229,7 +12224,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "UE" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12240,7 +12235,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/teleporter)
 "UF" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12249,7 +12244,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -12378,7 +12373,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12444,14 +12439,14 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/hangaroneprep)
 "Vk" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -12552,12 +12547,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "VK" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -12631,12 +12626,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
 "VW" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -12650,7 +12645,7 @@
 /area/expoutpost/prep)
 "Wb" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -12728,7 +12723,7 @@
 /turf/space,
 /area/space)
 "Wt" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12769,7 +12764,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12777,7 +12772,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/innerportmaint)
 "WC" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12798,12 +12793,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/gateway)
 "WG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -12929,7 +12924,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/gateway)
 "Xr" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13045,12 +13040,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -13129,7 +13124,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/expoutpost/hangarsix)
 "Ya" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13240,7 +13235,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -13274,7 +13269,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "YI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13290,7 +13285,7 @@
 	name = "Recovery";
 	req_one_access = list(5,43)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -13345,7 +13340,7 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/shuttle/echidna)
 "YW" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -13424,17 +13419,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -13484,7 +13479,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13526,7 +13521,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/expoutpost/hangarthree)
 "ZA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"

--- a/maps/relic_base/relicbase-12.dmm
+++ b/maps/relic_base/relicbase-12.dmm
@@ -1832,6 +1832,12 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/button/ext_button,
+/obj/machinery/access_button{
+	dir = 8;
+	name = "exterior access button";
+	pixel_x = -9;
+	pixel_y = -24
+	},
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/shuttle/ninja)
 "aZo" = (
@@ -7745,21 +7751,6 @@
 /obj/mecha/working/ripley/mining,
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/merchant)
-"iaB" = (
-/obj/machinery/access_button{
-	dir = 8;
-	name = "exterior access button";
-	pixel_x = 25;
-	pixel_y = 6
-	},
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/Dooruranium.dmi'
-	},
-/turf/unsimulated/floor{
-	icon_state = "plating";
-	name = "plating"
-	},
-/area/ninja_dojo/dojo)
 "iaK" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/belt/security/tactical/bandolier,
@@ -27385,7 +27376,7 @@ jUW
 nXc
 nXc
 lxX
-iaB
+lxX
 nXc
 jUW
 jUW

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -1764,8 +1764,8 @@
 "biC" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1780,6 +1780,11 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -27;
 	pixel_y = -12
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/tactical{
@@ -1802,11 +1807,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/tactical{
@@ -1841,11 +1841,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "bnq" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/reinforced,
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -1859,13 +1854,22 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/plating,
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -1875,24 +1879,6 @@
 	},
 /obj/structure/railing{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 8
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/tactical{
@@ -1920,11 +1906,6 @@
 "brs" = (
 /obj/machinery/light/no_nightshift{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/tactical{
@@ -2186,7 +2167,7 @@
 	dir = 8;
 	pixel_x = -21
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/plating,
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -4282,14 +4263,6 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"dNB" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/mixing{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
 "dPr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = null
@@ -4409,18 +4382,11 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dUh" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport{
+/turf/simulated/floor/tiled/white,
+/area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dUp" = (
@@ -4681,7 +4647,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -4735,9 +4701,13 @@
 "edz" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport{
@@ -48709,7 +48679,7 @@ rlb
 dKV
 ewC
 dKV
-dUh
+xNp
 edz
 dKV
 rlb
@@ -70350,7 +70320,7 @@ toy
 toy
 uAz
 vmf
-dNB
+dUh
 wxn
 dUN
 xpk

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -392,10 +392,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aoT" = (
@@ -977,6 +973,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
 "aDu" = (
@@ -1013,15 +1020,6 @@
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"aGq" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "aGJ" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -1289,21 +1287,22 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aRN" = (
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 1
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/cable,
-/obj/structure/lattice,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "aRS" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
@@ -1676,6 +1675,17 @@
 "bdZ" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -2372,6 +2382,11 @@
 "bVi" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "bVS" = (
@@ -2970,15 +2985,6 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"cCQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "cCT" = (
 /obj/structure/handrail{
 	dir = 4
@@ -3053,7 +3059,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3319,11 +3325,6 @@
 /obj/machinery/light/floortube{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "cXq" = (
@@ -3401,11 +3402,6 @@
 	dir = 1
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "dbj" = (
@@ -3413,11 +3409,6 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "dbm" = (
@@ -3658,6 +3649,15 @@
 	name = "Engineering Lockdown";
 	opacity = 0
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engineering/storage)
 "dos" = (
@@ -3841,11 +3841,6 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dsB" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
@@ -4003,8 +3998,15 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
@@ -4186,6 +4188,11 @@
 /obj/machinery/atmospherics/valve/shutoff{
 	name = "Atmospherics to Distro automatic shutoff valve"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "dKC" = (
@@ -4231,6 +4238,9 @@
 "dMN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -4449,14 +4459,12 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dVC" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -4676,10 +4684,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -4753,18 +4761,6 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"egv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "egA" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/rust,
@@ -5861,8 +5857,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -6130,11 +6126,6 @@
 	})
 "fuC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
@@ -6423,14 +6414,6 @@
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"fMJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "fNq" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -6653,20 +6636,6 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"gac" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "gae" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -7275,10 +7244,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "gDx" = (
@@ -8818,6 +8783,11 @@
 /obj/machinery/light/floortube{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "hZf" = (
@@ -8969,12 +8939,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ikR" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Atmos Substation Bypass"
 	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ilw" = (
@@ -9061,11 +9028,6 @@
 	})
 "iog" = (
 /obj/structure/closet/emcloset,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ioj" = (
@@ -9112,11 +9074,6 @@
 /area/surface/underground/in_da_walls)
 "iqe" = (
 /obj/machinery/suit_storage_unit/engineering,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "iqB" = (
@@ -9815,6 +9772,17 @@
 	})
 "iTS" = (
 /obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
 "iUc" = (
@@ -9978,14 +9946,11 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jgK" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
@@ -10070,11 +10035,11 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jkU" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -10296,12 +10261,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jrH" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jsA" = (
@@ -10342,17 +10304,16 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jun" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Atmospherics";
+	charge = 2e+006;
+	input_attempt = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/structure/cable{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/structure/catwalk,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jwx" = (
@@ -10513,11 +10474,6 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "ENG - Atmos North"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jIm" = (
@@ -10590,20 +10546,27 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jNJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jPq" = (
@@ -10960,11 +10923,6 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "kjv" = (
@@ -11130,17 +11088,24 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kxM" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
 	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kyJ" = (
 /obj/random/junk,
 /obj/random/trash,
@@ -11217,15 +11182,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
 "kFw" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -11823,14 +11788,22 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lMK" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "lNq" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 9
@@ -12037,11 +12010,6 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "mjG" = (
@@ -12610,17 +12578,22 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mOP" = (
-/obj/structure/cable/yellow{
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "mOU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -12932,11 +12905,6 @@
 "nkF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "nlx" = (
@@ -13241,12 +13209,18 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nGN" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -13302,11 +13276,6 @@
 "nKu" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -13375,11 +13344,6 @@
 	})
 "nPZ" = (
 /obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -13415,27 +13379,16 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nQX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "nSQ" = (
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "nSV" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "nTU" = (
@@ -13585,11 +13538,6 @@
 	})
 "odS" = (
 /obj/structure/stairs/spawner/south,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -13656,11 +13604,6 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "oif" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/rust,
 /obj/effect/landmark{
 	name = "maint_pred"
@@ -14427,6 +14370,11 @@
 	id = "dloop_atm_meter"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "peQ" = (
@@ -14624,11 +14572,6 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "prS" = (
@@ -14838,22 +14781,25 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "pAN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "pBk" = (
 /obj/structure/bed/chair/bay/shuttle,
 /obj/effect/decal/cleanable/dirt,
@@ -15359,11 +15305,7 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qgr" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/pipedispenser/disposal,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "qgE" = (
@@ -15569,11 +15511,8 @@
 /turf/unsimulated/wall/planetary/normal/thor,
 /area/surface/outpost/wall)
 "qsK" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -16005,20 +15944,26 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qWK" = (
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/white{
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
 	icon_state = "16-0"
 	},
+/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/storage)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "qWX" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
@@ -17559,11 +17504,16 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sTQ" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -17595,6 +17545,13 @@
 	name = "Air to Supply";
 	target_pressure = 301.325
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "sVk" = (
@@ -17614,16 +17571,6 @@
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"sWc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "sWi" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white,
@@ -17695,12 +17642,23 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -18119,11 +18077,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/light/floortube{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 4;
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -18506,11 +18465,6 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "tYi" = (
@@ -18570,11 +18524,6 @@
 	dir = 5
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ude" = (
@@ -18957,11 +18906,6 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uDQ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 8
@@ -19066,15 +19010,6 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"uJh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "uJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -19107,11 +19042,6 @@
 	})
 "uKE" = (
 /obj/machinery/suit_cycler/engineering,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "uLP" = (
@@ -19228,11 +19158,6 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "uVm" = (
@@ -19250,11 +19175,6 @@
 /area/hydroponics)
 "uVv" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "uWA" = (
@@ -19515,11 +19435,6 @@
 "vlX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "vmf" = (
@@ -19651,16 +19566,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vrt" = (
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -21806,11 +21724,6 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "xCr" = (
@@ -21851,19 +21764,11 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xEe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -22031,6 +21936,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "xNp" = (
@@ -22187,17 +22097,8 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xTH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -22591,20 +22492,20 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "yhF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "yhL" = (
 /turf/simulated/wall/thull,
 /area/maintenance/firstdeck/aftport{
@@ -29189,21 +29090,21 @@ rlb
 rlb
 nEe
 uDQ
-cCQ
-cCQ
-cCQ
-cCQ
-egv
-cCQ
-cCQ
-cCQ
-cCQ
-egv
-cCQ
-cCQ
-cCQ
-cCQ
-mOP
+iQE
+iQE
+iQE
+iQE
+uDQ
+iQE
+iQE
+iQE
+iQE
+uDQ
+iQE
+iQE
+iQE
+iQE
+uDQ
 nEe
 rlb
 rlb
@@ -29445,11 +29346,6 @@ rlb
 rlb
 rlb
 nEe
-aGq
-qXV
-qXV
-qXV
-qXV
 iQE
 qXV
 qXV
@@ -29460,7 +29356,12 @@ qXV
 qXV
 qXV
 qXV
-aGq
+iQE
+qXV
+qXV
+qXV
+qXV
+iQE
 nEe
 rlb
 rlb
@@ -29702,7 +29603,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 poa
 etG
@@ -29717,7 +29618,7 @@ qXV
 rjX
 cuB
 qXV
-aGq
+iQE
 nEe
 rlb
 rlb
@@ -29959,7 +29860,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 xeX
 xeX
@@ -29974,7 +29875,7 @@ qXV
 rJE
 rJE
 qXV
-aGq
+iQE
 nEe
 rlb
 rlb
@@ -30216,7 +30117,7 @@ nEe
 nEe
 nEe
 nEe
-aGq
+iQE
 qXV
 kka
 uQO
@@ -30231,7 +30132,7 @@ qXV
 ttq
 wOc
 qXV
-aGq
+iQE
 nEe
 rlb
 rlb
@@ -30470,14 +30371,9 @@ rlb
 rlb
 rlb
 nEe
-jrH
-egv
-cCQ
-uJh
-qXV
-hwn
-pKK
-qXV
+iQE
+uDQ
+iQE
 iQE
 qXV
 hwn
@@ -30488,7 +30384,12 @@ qXV
 hwn
 pKK
 qXV
-aGq
+iQE
+qXV
+hwn
+pKK
+qXV
+iQE
 nEe
 rlb
 rlb
@@ -30727,7 +30628,7 @@ nEe
 nEe
 nEe
 nEe
-aGq
+iQE
 iQE
 iQE
 iQE
@@ -30735,17 +30636,17 @@ iQE
 prv
 dbh
 ucx
-lMK
-lMK
-xEe
+iQE
+iQE
+prv
 dbh
 ucx
-lMK
-lMK
-xEe
+iQE
+iQE
+prv
 dbh
 ucx
-gac
+iQE
 nEe
 tWC
 tWC
@@ -30980,12 +30881,12 @@ rlb
 rlb
 nEe
 dsB
-cCQ
-cCQ
-cCQ
-cCQ
-jun
-qsK
+iQE
+iQE
+iQE
+iQE
+iQE
+iQE
 lbj
 hHT
 prn
@@ -31002,7 +30903,7 @@ hHT
 aou
 gKK
 fHs
-pAN
+oRf
 nEe
 rlb
 rlb
@@ -31236,7 +31137,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
@@ -31493,7 +31394,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 gVQ
 omh
@@ -31750,13 +31651,13 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 vQj
 omh
 jdk
 gkG
-yhF
+hYz
 nxC
 nrn
 qtg
@@ -32007,13 +31908,13 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
 qXV
 qXV
-jkU
+iQE
 hEa
 oRf
 nEE
@@ -32264,13 +32165,13 @@ rlb
 rlb
 rlb
 nEe
-dVC
+dsB
 iQE
 iQE
 iQE
 iQE
 iQE
-jkU
+iQE
 fHm
 vVd
 nEE
@@ -32521,7 +32422,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
@@ -32778,7 +32679,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 jzu
 qMh
@@ -32798,7 +32699,7 @@ biE
 vhz
 nft
 vVd
-vVd
+qsK
 fhZ
 oWa
 nEe
@@ -33035,13 +32936,13 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 aca
 qMh
 kUX
 gkG
-sWc
+hYz
 eac
 qtg
 gNQ
@@ -33055,7 +32956,7 @@ lYv
 hKD
 nft
 vVd
-vVd
+xTH
 tAy
 akD
 nEe
@@ -33292,7 +33193,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
@@ -33312,8 +33213,8 @@ ekv
 xQu
 lHA
 vVd
-vVd
-svc
+qsK
+jrH
 nEe
 nEe
 rlb
@@ -33549,7 +33450,7 @@ rlb
 rlb
 rlb
 nEe
-dVC
+dsB
 iQE
 iQE
 iQE
@@ -33569,8 +33470,8 @@ aEq
 tqs
 aSb
 vVd
-vVd
-svc
+nQX
+jkU
 nEe
 nEe
 rlb
@@ -33806,13 +33707,13 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
 qXV
 qXV
-sTQ
+iQE
 iHi
 vVd
 oMP
@@ -34063,7 +33964,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 wwy
 iTr
@@ -34320,7 +34221,7 @@ dCM
 dCM
 rlb
 nEe
-aGq
+iQE
 qXV
 xsZ
 iTr
@@ -34577,7 +34478,7 @@ dCM
 dCM
 dCM
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
@@ -34840,7 +34741,7 @@ hYz
 hYz
 hYz
 hYz
-xTH
+hYz
 fzW
 vhz
 vhz
@@ -35091,7 +34992,7 @@ rlb
 dCM
 dCM
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
@@ -35112,7 +35013,7 @@ oMP
 lHA
 vVd
 vVd
-svc
+vrt
 nEe
 nEe
 rlb
@@ -35348,7 +35249,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 hxn
 nSQ
@@ -35369,7 +35270,7 @@ oMP
 etF
 vVd
 vVd
-svc
+sTQ
 nEe
 nEe
 rlb
@@ -35605,7 +35506,7 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 dHN
 nSQ
@@ -35626,7 +35527,7 @@ oMP
 lHA
 vVd
 vVd
-svc
+sTQ
 nEe
 nEe
 rlb
@@ -35862,13 +35763,13 @@ rlb
 rlb
 rlb
 nEe
-aGq
+iQE
 qXV
 qXV
 qXV
 qXV
 qXV
-jkU
+iQE
 vVd
 vVd
 vVd
@@ -35883,7 +35784,7 @@ oMP
 lHA
 vVd
 vVd
-svc
+sTQ
 nEe
 nEe
 rlb
@@ -36119,23 +36020,23 @@ rlb
 rlb
 rlb
 nEe
-kxM
-cCQ
-cCQ
-cCQ
-cCQ
-cCQ
-vrt
-qgr
-qgr
+dsB
+iQE
+iQE
+iQE
+iQE
+iQE
+iQE
+vVd
+vVd
 cWG
+vVd
+vVd
 qgr
 qgr
-qgr
-qgr
-qgr
+vVd
 cWG
-fMJ
+vVd
 oMP
 lHA
 vVd
@@ -36398,7 +36299,7 @@ lHA
 vVd
 vVd
 xNi
-hHT
+dVC
 hHT
 hHT
 hHT
@@ -36655,7 +36556,7 @@ cLs
 vhz
 vhz
 vhz
-vhz
+xEe
 oUk
 pwQ
 xUe
@@ -37170,11 +37071,11 @@ iqe
 iqe
 uKE
 ecU
-ikR
+jun
 ikR
 kFw
 jNJ
-aRN
+oeN
 oeN
 rlb
 rlb
@@ -40520,10 +40421,10 @@ lJk
 lJk
 lJk
 lll
-lll
-qHZ
+aRN
+kxM
 nGN
-nQX
+mss
 oif
 was
 lJk
@@ -40777,10 +40678,10 @@ lll
 lll
 lll
 lll
-lll
+lMK
 yjd
 tdi
-lll
+qWK
 gqL
 gqL
 lJk
@@ -41030,14 +40931,14 @@ lJk
 rlb
 lJk
 lll
-lll
-lll
-lll
-lll
-lll
-yjd
+aRN
+yhF
+yhF
+yhF
+mOP
 yjd
 qHZ
+yjd
 was
 lJk
 lJk
@@ -41544,7 +41445,7 @@ lll
 lll
 lll
 lll
-lll
+pAN
 don
 aDi
 kFn
@@ -41804,7 +41705,7 @@ rlb
 rlb
 wOE
 iTS
-qWK
+kYw
 wOE
 lJk
 glQ

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -4282,6 +4282,14 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"dNB" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "dPr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = null
@@ -18719,7 +18727,7 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/firecloset/full,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -18776,7 +18784,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -18887,6 +18895,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/railing,
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -19183,6 +19192,9 @@
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna/cryosauna)
@@ -19484,6 +19496,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -19500,13 +19515,14 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/cable{
+/obj/structure/cable/green,
+/obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -19521,6 +19537,9 @@
 "vnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -70331,7 +70350,7 @@ toy
 toy
 uAz
 vmf
-sPj
+dNB
 wxn
 dUN
 xpk

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -2103,7 +2103,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -2419,7 +2420,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "bZd" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -3078,10 +3081,6 @@
 	dir = 1
 	},
 /obj/effect/zone_divider,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
 /obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
@@ -4381,14 +4380,6 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"dUh" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/mixing{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
 "dUp" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/recharger/wallcharger{
@@ -4813,6 +4804,11 @@
 	},
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/gun/energy/locked/phasegun/rifle/unlocked,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -4977,7 +4973,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "err" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -5304,7 +5302,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "eEV" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
@@ -5981,7 +5981,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fpc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/railing,
@@ -6330,7 +6332,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fJA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/stairs/dark_stairs{
@@ -6349,7 +6353,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fKk" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass{
@@ -6364,7 +6370,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "fKB" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -6398,7 +6406,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fLm" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -6801,41 +6811,30 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ggc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/fore{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
-"ggv" = (
 /obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"ggv" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "giW" = (
 /obj/structure/stairs/spawner/east,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -6905,7 +6904,8 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -6952,7 +6952,7 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gpr" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -7126,23 +7126,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gyJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/structure/cable/green,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/fore{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
-"gyM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -7163,11 +7153,6 @@
 	light_color = "#AF2A2A"
 	},
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -7198,7 +7183,8 @@
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7206,13 +7192,17 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gCg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7220,7 +7210,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gCu" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -12053,8 +12045,8 @@
 	},
 /obj/item/weapon/cell/device/weapon,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport{
@@ -15081,7 +15073,9 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos)
 "pRn" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/civilian{
@@ -16717,17 +16711,6 @@
 "rSE" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
-"rSP" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "rSX" = (
@@ -18433,11 +18416,17 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "tWI" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/mineral/cave,
-/area/surface/underground/in_da_walls)
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -23993,7 +23982,7 @@ rlb
 rlb
 rlb
 rlb
-tWI
+rlb
 rlb
 rlb
 rlb
@@ -45939,7 +45928,7 @@ rlb
 rlb
 lJk
 mnJ
-rSP
+mHt
 jjc
 lJk
 rlb
@@ -46196,7 +46185,7 @@ lJk
 lJk
 lJk
 eii
-eig
+tWI
 eig
 lJk
 rlb
@@ -59994,8 +59983,8 @@ rlb
 rlb
 rlb
 fNq
-ggv
-gyM
+fLb
+kdV
 gtt
 hjj
 fQk
@@ -70320,7 +70309,7 @@ toy
 toy
 uAz
 vmf
-dUh
+ggv
 wxn
 dUN
 xpk

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -1020,6 +1020,20 @@
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"aGq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "aGJ" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -1284,23 +1298,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
-"aRN" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aRS" = (
@@ -2249,7 +2246,8 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -2387,6 +2385,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "bVS" = (
@@ -2845,17 +2844,7 @@
 "ctT" = (
 /obj/structure/stairs/spawner/east,
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/zone_divider,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -2985,6 +2974,23 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"cCQ" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "cCT" = (
 /obj/structure/handrail{
 	dir = 4
@@ -3090,12 +3096,24 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/zone_divider,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -4193,6 +4211,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "dKC" = (
@@ -4459,15 +4480,16 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dVC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralstarboard{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "dVE" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/landmark{
@@ -4689,6 +4711,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "edi" = (
@@ -4761,6 +4784,12 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"egv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "egA" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/rust,
@@ -5151,11 +5180,6 @@
 	pixel_y = 32
 	},
 /obj/effect/zone_divider,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -6636,6 +6660,23 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"gac" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "gae" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -6748,7 +6789,14 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/open,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -6825,7 +6873,9 @@
 /area/surface/outpost/civilian/sauna/cryosauna)
 "gjO" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -8939,9 +8989,16 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ikR" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Atmos Substation Bypass"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Atmospherics";
+	charge = 2e+006;
+	input_attempt = 1
 	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "ilw" = (
@@ -10034,15 +10091,6 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"jkU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "jlg" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -10260,12 +10308,6 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"jrH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
 "jsA" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/outdoors/rocks/caves{
@@ -10304,16 +10346,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jun" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Atmospherics";
-	charge = 2e+006;
-	input_attempt = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "jwx" = (
@@ -11088,24 +11127,22 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kxM" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access = null
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "kyJ" = (
 /obj/random/junk,
 /obj/random/trash,
@@ -11125,7 +11162,9 @@
 	},
 /obj/structure/barricade,
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -11192,6 +11231,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "kFQ" = (
@@ -11238,11 +11280,14 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
@@ -11255,14 +11300,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "kKr" = (
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -11272,6 +11309,16 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/rust,
+/obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -11491,6 +11538,11 @@
 "lea" = (
 /obj/effect/floor_decal/rust,
 /obj/random/cigarettes,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -11788,22 +11840,11 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lMK" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "lNq" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 9
@@ -12402,6 +12443,11 @@
 	pixel_x = 5;
 	pixel_y = 21
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -12423,9 +12469,9 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
@@ -12578,22 +12624,14 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mOP" = (
-/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "mOU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -12699,34 +12737,20 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mVQ" = (
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "mYQ" = (
 /obj/structure/railing{
 	dir = 8
-	},
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/light/small/readylight{
 	dir = 4;
 	light_color = "#AF2A2A"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/open,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -12943,11 +12967,6 @@
 	})
 "npz" = (
 /obj/structure/stairs/spawner/south,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -12956,16 +12975,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/landmark{
-	name = "maint_pred"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/open,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -13379,8 +13389,8 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nQX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Atmos Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
@@ -14375,6 +14385,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "peQ" = (
@@ -14568,10 +14581,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "prv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "prS" = (
@@ -14784,22 +14799,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "pAN" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/engineering/atmos)
 "pBk" = (
 /obj/structure/bed/chair/bay/shuttle,
 /obj/effect/decal/cleanable/dirt,
@@ -15511,11 +15515,20 @@
 /turf/unsimulated/wall/planetary/normal/thor,
 /area/surface/outpost/wall)
 "qsK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "qtg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -15791,14 +15804,10 @@
 	})
 "qLU" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
@@ -15946,19 +15955,15 @@
 "qWK" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
@@ -17499,24 +17504,36 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aft{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
-"sTQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"sTQ" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "sTS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -17552,6 +17569,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "sVk" = (
@@ -17569,6 +17589,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"sWc" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sWi" = (
@@ -18315,6 +18346,17 @@
 "tTv" = (
 /turf/unsimulated/mineral,
 /area/surface/outpost/wall)
+"tUB" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "tVu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -19010,6 +19052,18 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"uJh" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/landmark{
+	name = "maint_pred"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "uJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -19125,7 +19179,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 21
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
@@ -19190,7 +19244,9 @@
 	})
 "uWC" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -19566,22 +19622,24 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "vrt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vrI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -20730,6 +20788,11 @@
 "wFy" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -21764,12 +21827,10 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xEe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "xEN" = (
@@ -22097,11 +22158,21 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xTH" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
+/obj/effect/floor_decal/rust,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "xUe" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -22194,14 +22265,14 @@
 	light_color = "#AF2A2A"
 	},
 /obj/effect/zone_divider,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
@@ -22494,14 +22565,16 @@
 "yhF" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -30633,17 +30706,17 @@ iQE
 iQE
 iQE
 iQE
-prv
+xEe
 dbh
 ucx
 iQE
 iQE
-prv
+xEe
 dbh
 ucx
 iQE
 iQE
-prv
+xEe
 dbh
 ucx
 iQE
@@ -32699,7 +32772,7 @@ biE
 vhz
 nft
 vVd
-qsK
+egv
 fhZ
 oWa
 nEe
@@ -32956,7 +33029,7 @@ lYv
 hKD
 nft
 vVd
-xTH
+pAN
 tAy
 akD
 nEe
@@ -33213,8 +33286,8 @@ ekv
 xQu
 lHA
 vVd
-qsK
-jrH
+egv
+lMK
 nEe
 nEe
 rlb
@@ -33470,8 +33543,8 @@ aEq
 tqs
 aSb
 vVd
-nQX
-jkU
+mVQ
+prv
 nEe
 nEe
 rlb
@@ -35013,7 +35086,7 @@ oMP
 lHA
 vVd
 vVd
-vrt
+kxM
 nEe
 nEe
 rlb
@@ -35270,7 +35343,7 @@ oMP
 etF
 vVd
 vVd
-sTQ
+aGq
 nEe
 nEe
 rlb
@@ -35527,7 +35600,7 @@ oMP
 lHA
 vVd
 vVd
-sTQ
+aGq
 nEe
 nEe
 rlb
@@ -35784,7 +35857,7 @@ oMP
 lHA
 vVd
 vVd
-sTQ
+aGq
 nEe
 nEe
 rlb
@@ -36299,7 +36372,7 @@ lHA
 vVd
 vVd
 xNi
-dVC
+jun
 hHT
 hHT
 hHT
@@ -36556,7 +36629,7 @@ cLs
 vhz
 vhz
 vhz
-xEe
+mOP
 oUk
 pwQ
 xUe
@@ -37071,8 +37144,8 @@ iqe
 iqe
 uKE
 ecU
-jun
 ikR
+nQX
 kFw
 jNJ
 oeN
@@ -40421,8 +40494,8 @@ lJk
 lJk
 lJk
 lll
-aRN
-kxM
+qWK
+vrt
 nGN
 mss
 oif
@@ -40678,10 +40751,10 @@ lll
 lll
 lll
 lll
-lMK
+yhF
 yjd
 tdi
-qWK
+sTQ
 gqL
 gqL
 lJk
@@ -40931,11 +41004,11 @@ lJk
 rlb
 lJk
 lll
-aRN
-yhF
-yhF
-yhF
-mOP
+qWK
+qsK
+qsK
+qsK
+cCQ
 yjd
 qHZ
 yjd
@@ -41445,7 +41518,7 @@ lll
 lll
 lll
 lll
-pAN
+gac
 don
 aDi
 kFn
@@ -50700,9 +50773,9 @@ lJk
 pyL
 kZR
 uWQ
-luF
+xTH
 gfD
-gfD
+uJh
 uWQ
 ycA
 ycA
@@ -50958,7 +51031,7 @@ ycA
 lUp
 uWQ
 mEJ
-mVQ
+gRe
 npz
 uWQ
 tuI
@@ -63091,8 +63164,8 @@ vnu
 olx
 vnu
 wFy
-vnu
-vnu
+tUB
+qLU
 vnu
 fXt
 was
@@ -63348,7 +63421,7 @@ rlb
 lJk
 was
 xVY
-qLU
+vnu
 sSP
 iVw
 hyL
@@ -70998,7 +71071,7 @@ bot
 dzk
 kDI
 kKr
-wgL
+sWc
 luE
 kxy
 rlb
@@ -71255,7 +71328,7 @@ rlb
 dzk
 kxy
 kKM
-wgL
+dVC
 luU
 kxy
 rlb

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -4380,6 +4380,14 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"dUh" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/mixing{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "dUp" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/recharger/wallcharger{
@@ -6825,14 +6833,6 @@
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"ggv" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/mixing{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
 "giW" = (
 /obj/structure/stairs/spawner/east,
 /turf/simulated/floor/plating,
@@ -7187,7 +7187,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/steel_dirty,
+/turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/dockhallway{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
@@ -70309,7 +70309,7 @@ toy
 toy
 uAz
 vmf
-ggv
+dUh
 wxn
 dUN
 xpk

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -668,6 +668,7 @@
 	})
 "axd" = (
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -1004,6 +1005,8 @@
 /area/engineering/atmos)
 "aFL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1196,6 +1199,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1682,6 +1687,8 @@
 	req_one_access = list(3)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -1749,6 +1756,8 @@
 	})
 "biC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1783,9 +1792,13 @@
 /area/engineering/atmos)
 "blr" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced,
@@ -1822,6 +1835,8 @@
 /area/engineering/atmos)
 "bnq" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/reinforced,
@@ -1869,6 +1884,7 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced,
@@ -1899,6 +1915,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/reinforced,
@@ -2813,10 +2831,14 @@
 /obj/structure/stairs/spawner/east,
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -4350,6 +4372,7 @@
 "dUh" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
@@ -4621,7 +4644,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/rust,
@@ -4673,6 +4696,8 @@
 "edz" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -5131,6 +5156,8 @@
 	},
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -6188,6 +6215,8 @@
 "fzv" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/zone_divider,
@@ -6808,6 +6837,8 @@
 "giW" = (
 /obj/structure/stairs/spawner/east,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -7099,6 +7130,8 @@
 	})
 "gyJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/rust,
@@ -7108,6 +7141,8 @@
 	})
 "gyM" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/rust,
@@ -7132,6 +7167,8 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -12029,6 +12066,7 @@
 	},
 /obj/item/weapon/cell/device/weapon,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -12117,9 +12155,8 @@
 	})
 "mwe" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	dir = 4;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille/rustic{
 	health = 25;
@@ -12274,9 +12311,8 @@
 	})
 "mCA" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	dir = 1;
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/grille/rustic{
 	health = 25;
@@ -12323,9 +12359,8 @@
 	})
 "mCG" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	dir = 1;
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -12350,9 +12385,8 @@
 	})
 "mDO" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	dir = 4;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/grille/rustic{
 	health = 25;
@@ -12698,6 +12732,7 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -12710,6 +12745,8 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/readylight{
@@ -12939,6 +12976,8 @@
 "npz" = (
 /obj/structure/stairs/spawner/south,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -12951,6 +12990,8 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark{
@@ -13012,16 +13053,14 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	dir = 1;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -13203,6 +13242,8 @@
 	})
 "nGN" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/rust,
@@ -13339,6 +13380,7 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -13374,6 +13416,8 @@
 	})
 "nQX" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
@@ -13542,6 +13586,8 @@
 "odS" = (
 /obj/structure/stairs/spawner/south,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -13611,6 +13657,8 @@
 	})
 "oif" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/rust,
@@ -13705,16 +13753,14 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	dir = 1;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -13935,16 +13981,14 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	dir = 1;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -14930,16 +14974,14 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	dir = 1;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -15816,6 +15858,7 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -16431,16 +16474,14 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	dir = 1;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -16649,6 +16690,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -16686,6 +16729,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -16698,6 +16743,7 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -16951,6 +16997,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -17288,6 +17336,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -17738,6 +17788,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -18154,6 +18206,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -18675,7 +18729,7 @@
 	},
 /obj/structure/closet/firecloset/full,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18686,9 +18740,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18728,7 +18786,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18737,6 +18795,8 @@
 	})
 "uuN" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18748,9 +18808,13 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18760,6 +18824,8 @@
 "uwL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18777,6 +18843,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18791,6 +18859,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18822,6 +18892,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -19084,6 +19156,8 @@
 /area/surface/outpost/civilian/sauna/cryosauna)
 "uPr" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -19289,6 +19363,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -19303,6 +19379,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -19334,6 +19412,8 @@
 	req_access = list(7)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -19348,6 +19428,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -19362,9 +19444,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -19767,6 +19853,8 @@
 /area/surface/outpost/civilian/sauna/cryosauna)
 "vGL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -19839,6 +19927,8 @@
 /area/engineering/atmos)
 "vLn" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -20097,6 +20187,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -20424,6 +20515,8 @@
 	})
 "wvR" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -20454,6 +20547,7 @@
 /area/engineering/atmos)
 "wwP" = (
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -20489,6 +20583,8 @@
 	req_access = list(8)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -20947,6 +21043,8 @@
 	})
 "wSA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -22196,6 +22294,7 @@
 	},
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -471,7 +471,7 @@
 	name = "Cargo Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -734,7 +734,7 @@
 "arq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -827,11 +827,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
@@ -1257,14 +1252,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -2232,12 +2222,12 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "bkw" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -2496,7 +2486,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -2731,11 +2721,6 @@
 	c_tag = "SUBS- Research";
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Research Substation Bypass"
 	},
@@ -2951,11 +2936,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
@@ -4319,7 +4299,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -5112,10 +5092,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -6542,25 +6519,10 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cRW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/mininglockerroom)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost{
+	outdoors = -1
+	})
 "cSp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6723,11 +6685,6 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_10)
 "cVO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
@@ -6875,7 +6832,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/armoury)
 "cXK" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8263,7 +8220,7 @@
 "dBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -8431,7 +8388,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/needle)
 "dDA" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8477,6 +8434,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost)
+"dEs" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "dEI" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -8987,11 +8960,6 @@
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/mininglockerroom)
 "dOw" = (
@@ -9155,7 +9123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10046,7 +10014,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10933,12 +10901,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -11263,7 +11227,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11565,11 +11529,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "eOU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_lockerroom)
 "ePs" = (
@@ -11916,7 +11875,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -12131,11 +12090,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "eYD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -12520,7 +12474,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
 "feS" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12647,7 +12601,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13999,15 +13953,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main)
@@ -14296,11 +14245,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -14858,7 +14802,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -15254,11 +15198,6 @@
 /obj/machinery/door/airlock/research{
 	name = "Research Locker Room";
 	req_access = list(47)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research_lockerroom)
@@ -15874,7 +15813,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/sc/hor)
 "gzN" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -16101,7 +16040,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -17193,7 +17132,7 @@
 	pixel_y = 24;
 	req_access = list(31)
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19496,7 +19435,7 @@
 "hUy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19526,6 +19465,15 @@
 "hVQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
+"hVR" = (
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "hWe" = (
 /obj/structure/railing{
@@ -19834,7 +19782,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "ibD" = (
-/obj/structure/cable,
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -20270,7 +20218,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -21084,11 +21032,6 @@
 /area/expoutpost/shuttle)
 "iCY" = (
 /obj/machinery/light,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "iDi" = (
@@ -21215,7 +21158,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
 "iEY" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -21228,6 +21171,11 @@
 	},
 /obj/effect/floor_decal/corner/beige/bordercorner{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -21298,7 +21246,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "iGL" = (
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost{
 	outdoors = -1
 	})
@@ -21401,11 +21355,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/purcarpet,
@@ -21755,7 +21704,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "iQM" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -22181,12 +22130,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23462,7 +23411,7 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych)
 "jHe" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -23487,7 +23436,7 @@
 	layer = 3.1;
 	name = "Cargo Shutters"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -23754,12 +23703,17 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/white,
-/obj/structure/cable/white{
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
@@ -24353,7 +24307,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
 "jXO" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -25318,7 +25272,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25396,9 +25350,9 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -25818,10 +25772,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main)
@@ -25835,7 +25794,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26326,7 +26285,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "kSn" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -26877,7 +26836,7 @@
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/security/lobby)
 "leY" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -26886,7 +26845,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -27840,11 +27799,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/disposal/wall{
 	pixel_y = 33
 	},
@@ -27923,12 +27877,12 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "lzc" = (
@@ -28101,7 +28055,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -28590,7 +28546,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
 "lOz" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -28690,7 +28646,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -28901,12 +28857,11 @@
 	name = "Station Intercom (General)";
 	pixel_x = 21
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-10"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "lTP" = (
@@ -29019,7 +28974,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -29200,6 +29155,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
+"mcf" = (
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "mch" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -29713,7 +29678,7 @@
 /turf/simulated/floor/plating,
 /area/expoutpost/pathfinder)
 "moL" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -30434,7 +30399,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -30443,9 +30408,10 @@
 	name = "Powernet Sensor - Cargo Subgrid";
 	name_tag = "Cargo Subgrid"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/railing{
 	dir = 4
@@ -30453,11 +30419,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-5"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
@@ -30579,11 +30543,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -31028,7 +30987,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "mPa" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -32791,15 +32750,10 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
 "nBQ" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -33329,11 +33283,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medbay)
 "nOj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -21
@@ -33899,7 +33848,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -34209,12 +34158,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -34410,7 +34359,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "opF" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -35183,8 +35132,8 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35809,7 +35758,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
 "oXs" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -38531,7 +38480,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/debriefing)
 "pZJ" = (
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -38811,9 +38762,7 @@
 /area/medical/medbay)
 "qdP" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
+	icon_state = "1-8"
 	},
 /obj/structure/cable/heavyduty{
 	d1 = 1;
@@ -38825,11 +38774,6 @@
 /area/surface/outside/path/plains)
 "qea" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
@@ -39309,7 +39253,7 @@
 /area/surface/outpost/main/gym)
 "qlO" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -39330,23 +39274,13 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_lockerroom)
@@ -39598,7 +39532,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -39728,11 +39662,6 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "qwp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -40195,7 +40124,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -40537,11 +40466,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "qRH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/mininglockerroom)
 "qSr" = (
@@ -40793,6 +40717,19 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"qXn" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/thor/planetuse,
+/area/surface/outside/path/plains)
 "qXq" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -40883,11 +40820,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "qZZ" = (
@@ -41484,16 +41416,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -41951,7 +41873,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -43284,7 +43206,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -43613,7 +43535,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -43956,7 +43878,13 @@
 	c_tag = "EXT - Cargo East 3";
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
 /area/surface/outpost/mining_main)
 "soG" = (
 /obj/machinery/status_display{
@@ -44139,7 +44067,13 @@
 	c_tag = "EXT - Cargo East 2";
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
 /area/surface/outpost/mining_main)
 "srH" = (
 /obj/structure/bed/padded,
@@ -45768,7 +45702,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
 "sZk" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -46218,7 +46152,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -46730,7 +46664,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
 "tuz" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -46902,7 +46836,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -47253,14 +47187,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/fans/tiny,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/heavyduty{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/bmarble,
 /area/quartermaster/mininglockerroom)
 "tBo" = (
@@ -47834,7 +47760,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -47847,7 +47773,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/hallway)
 "tMB" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -48153,10 +48079,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main)
@@ -49972,7 +49898,7 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/lawoffice)
 "uGZ" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -50120,7 +50046,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -50429,6 +50355,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating/thor/planetuse,
 /area/surface/outside/path/plains)
 "uNN" = (
@@ -50669,9 +50600,6 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Cargo Substation Bypass"
 	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "uTj" = (
@@ -50765,7 +50693,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -51494,7 +51422,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -52028,24 +51956,20 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "vqz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/research)
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "vqI" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
@@ -52091,11 +52015,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -52805,7 +52724,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -52842,11 +52761,6 @@
 	},
 /area/surface/outside/path/plains)
 "vFc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/purcarpet,
 /area/rnd/research)
@@ -53719,7 +53633,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "vZF" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54513,11 +54427,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "wnE" = (
@@ -54915,7 +54824,7 @@
 "wvn" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -56299,7 +56208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -57164,7 +57073,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -58262,23 +58171,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "xGd" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "xGB" = (
 /obj/structure/railing/grey,
 /obj/structure/table/rack/shelf/steel,
@@ -58532,7 +58427,8 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -77460,7 +77356,7 @@ rLe
 uww
 rLe
 rLe
-rLe
+mCZ
 ybp
 ncJ
 ybp
@@ -77709,15 +77605,15 @@ sYa
 sYa
 sYa
 sYa
-kGW
-kGW
-kGW
-rLe
-rLe
-uww
-rLe
-rLe
-rLe
+cRW
+cRW
+cRW
+mCZ
+mCZ
+eUh
+mCZ
+mCZ
+mCZ
 ybp
 ncJ
 ybp
@@ -77967,14 +77863,14 @@ vtd
 sYa
 sYa
 tgb
-kGW
-kGW
-rLe
-rLe
-uww
-rLe
-rLe
-rLe
+cRW
+cRW
+mCZ
+mCZ
+eUh
+mCZ
+mCZ
+mCZ
 sPH
 ncJ
 ybp
@@ -78221,19 +78117,19 @@ hDM
 hDM
 ldg
 vtd
-sYa
-sYa
-kGW
+nbF
+uav
+iGL
 srG
 iGL
-rLe
-rLe
-uww
+hVR
+hVR
+mcf
 sop
-rLe
-rLe
-mCZ
-ncJ
+hVR
+hVR
+hVR
+qdP
 ybp
 ybp
 rLe
@@ -78478,7 +78374,7 @@ jjb
 fQG
 hbn
 vtd
-sYa
+ncJ
 sYa
 wDK
 wDK
@@ -78735,7 +78631,7 @@ jjy
 shy
 lvp
 vtd
-ybp
+ncJ
 ybp
 wDK
 wNP
@@ -78992,7 +78888,7 @@ aLc
 xwn
 cOK
 vtd
-sYa
+ncJ
 sYa
 wDK
 wNP
@@ -79249,7 +79145,7 @@ wru
 kxf
 tiw
 vtd
-ybp
+ncJ
 ybp
 wDK
 wNP
@@ -79261,7 +79157,7 @@ eAE
 wNP
 wDK
 lRF
-qdP
+qAI
 ybp
 rLe
 rLe
@@ -79506,7 +79402,7 @@ loH
 sSH
 lgK
 vtd
-ybp
+ncJ
 ybp
 wDK
 wNP
@@ -79518,7 +79414,7 @@ wtQ
 wNP
 wDK
 mCZ
-ncJ
+xGd
 ybp
 xZf
 xZf
@@ -79763,7 +79659,7 @@ yaG
 xvp
 jND
 vtd
-ybp
+ncJ
 ybp
 wDK
 wNP
@@ -79775,7 +79671,7 @@ wNP
 wNP
 wDK
 mCZ
-ncJ
+xGd
 ybp
 xZf
 xZf
@@ -80020,7 +79916,7 @@ syG
 iAN
 hxJ
 vtd
-ybp
+ncJ
 ybp
 wDK
 wDK
@@ -80032,7 +79928,7 @@ wDK
 wDK
 wDK
 ttz
-ncJ
+xGd
 ybp
 uPu
 xZf
@@ -80277,7 +80173,7 @@ pdz
 pdz
 pdz
 pdz
-ybp
+ncJ
 ybp
 wDK
 ulV
@@ -80534,7 +80430,7 @@ mzc
 kti
 xLV
 xLV
-ybp
+ncJ
 vaH
 wDK
 rbj
@@ -80791,7 +80687,7 @@ qrO
 iQR
 xLV
 xLV
-ybp
+ncJ
 ybp
 wDK
 jAv
@@ -81048,7 +80944,7 @@ gKi
 iEk
 xLV
 xLV
-ybp
+ncJ
 ybp
 wDK
 tGI
@@ -81060,7 +80956,7 @@ lWU
 ksN
 gaF
 uVp
-cRW
+uVp
 vgP
 ibD
 tUO
@@ -81305,7 +81201,7 @@ ujO
 eXm
 iBe
 xLV
-ybp
+ncJ
 ybp
 wDK
 jDI
@@ -81562,7 +81458,7 @@ bNK
 gAV
 qxA
 xLV
-ybp
+ncJ
 ybp
 xOd
 wbj
@@ -81819,7 +81715,7 @@ own
 oDF
 xLV
 xLV
-ybp
+ncJ
 ybp
 xOd
 jDI
@@ -82076,7 +81972,7 @@ ndP
 pNC
 egl
 eFA
-ybp
+ncJ
 ybp
 xOd
 mMt
@@ -82333,7 +82229,7 @@ vlV
 tQI
 tQI
 fbb
-ybp
+ncJ
 ybp
 wDK
 rqX
@@ -82590,7 +82486,7 @@ atm
 kbZ
 pdW
 eFA
-ybp
+ncJ
 qmq
 wDK
 eLF
@@ -82847,7 +82743,7 @@ gFn
 eFA
 eFA
 eFA
-ybp
+ncJ
 ybp
 wDK
 oFv
@@ -83104,7 +83000,7 @@ kft
 uNN
 mCZ
 mCZ
-ybp
+ncJ
 ybp
 rOX
 kQU
@@ -83361,7 +83257,7 @@ vvD
 uNN
 mCZ
 mCZ
-ybp
+ncJ
 ybp
 rOX
 eWY
@@ -83618,7 +83514,7 @@ vpq
 uNN
 mCZ
 mCZ
-ybp
+ncJ
 ybp
 rOX
 nsY
@@ -83875,7 +83771,7 @@ qRG
 hIw
 hIw
 hIw
-ybp
+ncJ
 ybp
 rOX
 aCB
@@ -84132,7 +84028,7 @@ owk
 atU
 lXU
 uNN
-ybp
+ncJ
 sYa
 rOX
 mfn
@@ -84389,7 +84285,7 @@ acT
 mqD
 nOI
 uNN
-ybp
+ncJ
 nWk
 rOX
 gxA
@@ -84646,7 +84542,7 @@ sfn
 uYZ
 paN
 uNN
-sQm
+fWA
 fnT
 rOX
 xkU
@@ -84903,7 +84799,7 @@ hIw
 hIw
 hIw
 hIw
-ybp
+ncJ
 sYa
 rOX
 rOX
@@ -85160,7 +85056,7 @@ jSi
 hIw
 mNh
 ybp
-yeV
+ydT
 yeV
 vco
 qHA
@@ -85417,7 +85313,7 @@ rpB
 wrT
 mNG
 yeV
-yeV
+ydT
 yeV
 vco
 vco
@@ -85674,7 +85570,7 @@ rpB
 wrT
 mNG
 yeV
-yeV
+ydT
 yeV
 vco
 qHA
@@ -85931,7 +85827,7 @@ rpB
 wrT
 mNG
 ygB
-yeV
+ydT
 yeV
 vco
 vco
@@ -86188,7 +86084,7 @@ ckG
 hIw
 sog
 yeV
-yeV
+ydT
 yeV
 vco
 qgl
@@ -86445,7 +86341,7 @@ hIw
 hIw
 eBE
 yeV
-yeV
+ydT
 sPH
 vco
 vco
@@ -86702,7 +86598,7 @@ kcv
 qEf
 yeV
 yeV
-yeV
+ydT
 yeV
 ybp
 ybp
@@ -86959,7 +86855,7 @@ yeV
 yeV
 yeV
 yeV
-yeV
+ydT
 yeV
 yeV
 yeV
@@ -87216,7 +87112,7 @@ yeV
 yeV
 ygB
 yeV
-yeV
+ydT
 yeV
 yeV
 yeV
@@ -87473,7 +87369,7 @@ vSO
 vSO
 vSO
 vSO
-vSO
+vqz
 vSO
 vSO
 vSO
@@ -87730,7 +87626,7 @@ hvF
 hvF
 rxJ
 scm
-scm
+dEs
 scm
 scm
 ssM
@@ -90293,7 +90189,7 @@ uZH
 vRE
 wAt
 xqP
-xGd
+sNF
 sNF
 sNF
 hIF
@@ -90560,7 +90456,7 @@ tqv
 daA
 swv
 dFz
-qaW
+qXn
 yeV
 yeV
 jZn
@@ -103168,7 +103064,7 @@ qwp
 vFc
 qea
 cVO
-vqz
+vaX
 rxg
 tYx
 raF

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -29,7 +29,9 @@
 /area/surface/outpost/wall/checkpoint)
 "aaD" = (
 /obj/structure/cable/yellow{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
 	dir = 4
@@ -102,9 +104,13 @@
 /area/surface/outpost/wall/checkpoint)
 "abI" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -319,6 +325,8 @@
 /area/surface/outside/path/plains)
 "aio" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -335,6 +343,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating{
@@ -363,7 +373,8 @@
 /area/surface/outpost/mining_main/refinery)
 "aiJ" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
@@ -460,6 +471,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -541,7 +554,9 @@
 /area/lawoffice)
 "ang" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -583,6 +598,8 @@
 	id = "housetint4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -716,6 +733,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -724,7 +743,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -759,7 +780,9 @@
 /area/surface/outside/plains/outpost)
 "arW" = (
 /obj/structure/cable/green{
-	icon_state = "4-10"
+	icon_state = "4-10";
+	d1 = 4;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -804,6 +827,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -843,6 +868,8 @@
 	})
 "auf" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/zone_divider,
@@ -864,6 +891,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -930,9 +959,13 @@
 "axm" = (
 /obj/structure/railing/grey,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -974,7 +1007,9 @@
 /area/surface/outpost/main/dorms/dorm_7)
 "aAg" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -1012,6 +1047,8 @@
 	id = "housetint6"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1075,9 +1112,8 @@
 	})
 "aCZ" = (
 /obj/structure/cable/green{
-	d2 = 4;
-	dir = 8;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -1126,6 +1162,8 @@
 /area/expoutpost)
 "aFg" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -1177,6 +1215,8 @@
 /obj/item/weapon/rig/ch/pursuit,
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/gun/energy/x01,
@@ -1198,18 +1238,26 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -1232,7 +1280,9 @@
 /area/surface/outside/plains/outpost)
 "aGt" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -1257,6 +1307,8 @@
 /area/rnd/research)
 "aHy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/security{
@@ -1286,6 +1338,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
@@ -1417,6 +1470,7 @@
 	id = "hosoffice"
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -1496,6 +1550,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -1506,6 +1562,8 @@
 	name = "Head of Security"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/keycard_auth{
@@ -1523,6 +1581,8 @@
 /area/rnd/research)
 "aPP" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -1548,9 +1608,13 @@
 /area/surface/outpost/mining_main)
 "aQr" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -1564,9 +1628,13 @@
 /area/rnd/research_restroom_sc)
 "aQH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet,
@@ -1610,9 +1678,12 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -1724,7 +1795,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -1757,9 +1830,13 @@
 /area/security/security_hallway)
 "aXH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1813,6 +1890,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -1826,7 +1904,8 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -1844,6 +1923,8 @@
 "aYw" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -2008,6 +2089,8 @@
 /area/crew_quarters/heads/sc/hos)
 "beL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -2100,6 +2183,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -2115,6 +2199,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/wall/r_wall,
@@ -2139,9 +2225,13 @@
 /area/surface/outside/plains/outpost)
 "bkw" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2195,6 +2285,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
 	icon_state = "32-8"
 	},
 /turf/simulated/open,
@@ -2223,6 +2315,8 @@
 /area/rnd/lab)
 "bll" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
@@ -2299,6 +2393,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -2310,6 +2405,8 @@
 "bmL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -2321,7 +2418,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -2451,9 +2549,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2479,7 +2581,9 @@
 "bpw" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/wall/r_wall,
@@ -2552,6 +2656,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -2614,6 +2720,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/power/breakerbox/activated{
@@ -2704,6 +2812,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/gun/projectile/revolver/webley,
@@ -2729,6 +2839,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -2799,7 +2911,9 @@
 /area/quartermaster/hallway)
 "byB" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/camera/network/exterior{
@@ -2817,12 +2931,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -2886,6 +3006,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -2903,6 +3025,8 @@
 	pixel_y = 21
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2919,6 +3043,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -3107,6 +3233,8 @@
 /area/surface/outside/path/plains)
 "bGP" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -3160,6 +3288,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3279,17 +3409,20 @@
 "bJP" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d2 = 4;
-	dir = 8;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "hosoffice"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -3370,6 +3503,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3388,7 +3523,9 @@
 /area/expoutpost/debriefing)
 "bLS" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3427,6 +3564,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3506,6 +3645,8 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "bQE" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3518,6 +3659,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3610,6 +3753,8 @@
 	id = "housetint3"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3681,6 +3826,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/stairs/wood_stairs{
@@ -3751,6 +3898,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -3851,6 +3999,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular{
@@ -3936,6 +4086,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -3948,6 +4099,8 @@
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
@@ -3961,6 +4114,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom/department/security{
@@ -4033,6 +4188,8 @@
 /area/security/warden)
 "cdW" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/power/sensor{
@@ -4043,7 +4200,13 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/substation/engineering)
@@ -4066,6 +4229,8 @@
 "ceN" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -4117,12 +4282,15 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "cgO" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4140,7 +4308,8 @@
 	name = "Botanist"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/hydro,
@@ -4150,6 +4319,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -4253,7 +4424,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4342,6 +4515,8 @@
 /area/surface/outpost/main/gym)
 "clg" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -4378,6 +4553,8 @@
 /area/security/security_hallway)
 "clu" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/orange{
@@ -4447,6 +4624,8 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -4459,6 +4638,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4600,9 +4781,12 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4618,6 +4802,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4636,6 +4822,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4648,6 +4836,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4660,9 +4850,13 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -4711,6 +4905,8 @@
 /area/crew_quarters/bar)
 "cpZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -4855,6 +5051,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -4909,6 +5107,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
@@ -4939,7 +5138,9 @@
 	name = "Wilderness Containment"
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outpost/wall/checkpoint)
@@ -4995,6 +5196,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/table/steel_reinforced,
@@ -5100,6 +5302,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -5129,9 +5333,13 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet,
@@ -5174,6 +5382,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -5187,6 +5397,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -5216,6 +5428,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -5240,6 +5454,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -5256,6 +5472,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5268,6 +5486,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5294,9 +5514,13 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/alarm{
@@ -5337,6 +5561,8 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5392,6 +5618,8 @@
 	req_access = list(3)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/no_nightshift{
@@ -5490,7 +5718,9 @@
 /area/security/armoury)
 "cDX" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5502,6 +5732,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -5587,6 +5819,8 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/mob_spawner/mouse_nest,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/milspec,
@@ -5600,6 +5834,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5836,8 +6072,7 @@
 /area/surface/outpost/main/landing/two)
 "cIR" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
-	dir = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/blue,
@@ -5884,6 +6119,8 @@
 /area/rnd/research_restroom_sc)
 "cJJ" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6006,6 +6243,7 @@
 /area/security/security_processing)
 "cMg" = (
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -6018,6 +6256,8 @@
 "cMp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -6026,6 +6266,8 @@
 /area/surface/outside/path/plains)
 "cMs" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6041,6 +6283,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6057,6 +6301,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -6077,6 +6323,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6110,6 +6358,8 @@
 	req_access = null
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -6152,6 +6402,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
@@ -6171,9 +6423,13 @@
 /area/surface/outpost/civilian/emergency_storage)
 "cQA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6192,6 +6448,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6201,6 +6459,8 @@
 /area/chapel/main)
 "cRe" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6225,6 +6485,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -6271,12 +6533,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -6286,6 +6552,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6311,6 +6579,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -6368,12 +6638,18 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6386,6 +6662,8 @@
 	dir = 9
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -6432,6 +6710,8 @@
 /area/surface/outpost/main/dorms/dorm_10)
 "cVO" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -6447,6 +6727,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6547,6 +6829,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -6556,6 +6840,8 @@
 /area/rnd/research)
 "cXj" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -6576,6 +6862,8 @@
 /area/security/armoury)
 "cXK" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6591,6 +6879,8 @@
 /area/quartermaster/hallway)
 "cYo" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance/common{
@@ -6653,7 +6943,9 @@
 /area/ai_monitored/storage/eva)
 "dag" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6997,6 +7289,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -7119,6 +7413,8 @@
 "dkT" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7171,7 +7467,8 @@
 	dir = 5
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7266,7 +7563,9 @@
 "dox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -7531,6 +7830,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
@@ -7600,12 +7901,16 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -7668,6 +7973,8 @@
 /area/security/security_hallway)
 "dwx" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -7706,6 +8013,8 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/hand_labeler,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -7727,6 +8036,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7734,6 +8045,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet,
@@ -7836,6 +8149,8 @@
 /area/surface/outside/path/plains)
 "dAc" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -7933,6 +8248,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -7995,7 +8312,9 @@
 /area/security/armoury)
 "dCg" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8097,6 +8416,8 @@
 /area/shuttle/needle)
 "dDA" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -8153,6 +8474,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -8200,7 +8523,9 @@
 /area/crew_quarters/bar)
 "dFF" = (
 /obj/structure/cable/green{
-	icon_state = "6-8"
+	icon_state = "6-8";
+	d1 = 6;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -8265,6 +8590,8 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating{
@@ -8286,6 +8613,7 @@
 /area/library)
 "dGT" = (
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -8345,10 +8673,13 @@
 "dIU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
-	dir = 8
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -8396,6 +8727,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -8447,6 +8780,8 @@
 "dKL" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -8477,11 +8812,12 @@
 	name = "Holodeck Control"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/fans/tiny,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -8489,6 +8825,8 @@
 "dLr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8530,6 +8868,8 @@
 /area/medical/sleeper)
 "dMR" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
@@ -8625,6 +8965,8 @@
 	name = "Shaft Miner"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -8745,9 +9087,13 @@
 /area/expoutpost)
 "dQu" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -8760,6 +9106,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -8785,6 +9133,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -8818,6 +9168,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -8853,6 +9205,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -8888,6 +9242,8 @@
 	id = "housetint5"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8953,7 +9309,9 @@
 /area/surface/outpost/civilian/fishing)
 "dUs" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating{
@@ -9188,12 +9546,16 @@
 /area/shuttle/needle)
 "dXT" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -9270,6 +9632,8 @@
 /area/surface/outside/plains/outpost)
 "eaU" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -9416,6 +9780,8 @@
 /area/ai_monitored/storage/eva)
 "efm" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -9475,6 +9841,8 @@
 /area/ai_monitored/storage/eva)
 "egY" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -9489,6 +9857,8 @@
 /area/surface/outpost/main/dorms/dorm_4)
 "eie" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal/wall{
@@ -9507,7 +9877,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9667,6 +10038,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -9695,6 +10067,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -9718,6 +10091,8 @@
 /area/security/security_hallway)
 "emP" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -9728,6 +10103,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -9770,7 +10147,8 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -9793,9 +10171,13 @@
 /area/chapel/main)
 "enV" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/alarm{
@@ -9824,6 +10206,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9860,15 +10244,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "eoX" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -9909,6 +10299,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -9919,6 +10311,8 @@
 "epY" = (
 /obj/machinery/vending/security,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9944,7 +10338,9 @@
 /area/engineering/external_lights)
 "eqz" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9987,6 +10383,8 @@
 /area/engineering/external_lights)
 "eqL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -10213,7 +10611,9 @@
 /area/maintenance/substation/civilian)
 "eta" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10267,9 +10667,13 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10304,6 +10708,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/railing/grey{
@@ -10391,6 +10797,8 @@
 /area/surface/outpost/wall/checkpoint)
 "ewO" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10416,6 +10824,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -10490,15 +10900,21 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -10521,6 +10937,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -10546,6 +10964,8 @@
 "eAI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -10630,6 +11050,8 @@
 /area/library)
 "eDw" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10653,7 +11075,8 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -10708,6 +11131,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/stack/material/phoron{
@@ -10719,7 +11143,8 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/bed/chair/sofa/left/orange,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -10806,7 +11231,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -10848,9 +11274,13 @@
 /area/ai_monitored/storage/eva)
 "eIv" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10930,6 +11360,8 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/suit_cycler/medical,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -10989,6 +11421,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -11053,6 +11486,8 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11085,6 +11520,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -11096,6 +11533,8 @@
 /area/rnd/research)
 "eOU" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -11132,6 +11571,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -11156,7 +11596,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
@@ -11245,6 +11685,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11301,6 +11743,8 @@
 /area/surface/outside/path/plains)
 "eSV" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11317,6 +11761,8 @@
 /area/security/security_hallway)
 "eSW" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11404,6 +11850,8 @@
 /area/security/security_hallway)
 "eTK" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11434,6 +11882,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -11485,6 +11934,8 @@
 "eVi" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -11519,6 +11970,8 @@
 /area/storage/primary)
 "eVE" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11536,6 +11989,8 @@
 /area/security/aid_station)
 "eVT" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11554,6 +12009,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11584,6 +12041,8 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -11638,12 +12097,16 @@
 /area/engineering/hallway/engineer_hallway)
 "eYD" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11891,6 +12354,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -11973,6 +12438,8 @@
 /area/ai_monitored/storage/eva)
 "fes" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -12017,6 +12484,8 @@
 /area/expoutpost/prep)
 "feS" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -12040,7 +12509,8 @@
 	req_access = list(1)
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -12056,6 +12526,8 @@
 /area/security/lobby)
 "ffw" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -12065,9 +12537,13 @@
 /area/ai_monitored/storage/eva)
 "ffz" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12135,6 +12611,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -12256,6 +12734,8 @@
 /area/expoutpost/prep)
 "fiR" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -12268,7 +12748,8 @@
 /area/security/security_hallway)
 "fjl" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -12284,6 +12765,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12327,9 +12810,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12363,6 +12850,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12384,6 +12873,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -12394,6 +12885,8 @@
 /area/security/security_hallway)
 "fnf" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -12406,6 +12899,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -12452,18 +12947,26 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fnz" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -12487,6 +12990,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -12519,7 +13024,9 @@
 "fpc" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12533,6 +13040,8 @@
 /area/surface/outside/path/plains)
 "fpu" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12604,12 +13113,16 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fsR" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/panel,
@@ -12622,9 +13135,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12642,6 +13159,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12671,12 +13190,18 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12723,7 +13248,8 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction{
@@ -12866,6 +13392,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -12965,6 +13493,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13021,6 +13551,8 @@
 "fAc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
@@ -13080,6 +13612,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -13135,6 +13669,8 @@
 /area/ai_monitored/storage/eva)
 "fEq" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13235,7 +13771,9 @@
 /area/rnd/research_lockerroom)
 "fFX" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13260,9 +13798,12 @@
 	id = "detoffice"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -13276,7 +13817,9 @@
 /area/security/detectives_office)
 "fGY" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13389,6 +13932,7 @@
 	pixel_x = -36
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/alt/panel,
@@ -13417,9 +13961,13 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -13491,6 +14039,8 @@
 /area/library)
 "fNp" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13561,6 +14111,8 @@
 /obj/item/weapon/pen/multi,
 /obj/item/weapon/stamp/ce,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -13623,19 +14175,25 @@
 /area/engineering/workshop)
 "fQV" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "fRk" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fRm" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13695,6 +14253,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/firealarm{
@@ -13751,9 +14311,13 @@
 /area/security/security_hallway)
 "fTz" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -13788,6 +14352,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -13801,6 +14367,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/department/security{
@@ -13816,6 +14384,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13828,6 +14398,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -13871,7 +14443,9 @@
 /area/rnd/research_lockerroom)
 "fWl" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/exterior{
@@ -13879,7 +14453,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "6-8"
+	icon_state = "6-8";
+	d1 = 6;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -13892,7 +14468,9 @@
 /area/surface/outside/path/plains)
 "fWA" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/effect/zone_divider,
@@ -13906,6 +14484,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
@@ -13927,19 +14507,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/bathroom)
 "fWW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
 /obj/structure/cable/cyan{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "fXg" = (
 /obj/machinery/newscaster{
@@ -13949,6 +14522,8 @@
 /area/surface/outpost/main/dorms/dorm_5)
 "fXP" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
@@ -13974,6 +14549,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -13996,6 +14573,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -14023,13 +14602,17 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fYB" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -14053,6 +14636,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -14084,6 +14669,7 @@
 	name_tag = "Civilian Subgrid"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -14096,6 +14682,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -14137,6 +14725,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14191,6 +14781,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14224,6 +14816,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -14405,6 +14999,8 @@
 "gfK" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -14551,13 +15147,16 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
 /area/security/lobby)
 "giY" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14619,6 +15218,8 @@
 	req_access = list(47)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -14718,6 +15319,8 @@
 /area/expoutpost/debriefing)
 "gmB" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14738,6 +15341,8 @@
 /area/engineering/hallway/atmos_hallway)
 "gmJ" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14750,6 +15355,8 @@
 /area/security/evidence_storage)
 "gmW" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -14768,7 +15375,9 @@
 "gnb" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/cable/green{
-	icon_state = "6-8"
+	icon_state = "6-8";
+	d1 = 6;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
@@ -15034,7 +15643,8 @@
 	req_one_access = list(11,24)
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -15059,6 +15669,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15072,12 +15684,18 @@
 /area/surface/outside/plains/outpost)
 "gvV" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15089,12 +15707,16 @@
 /area/ai_monitored/storage/eva)
 "gvZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -15111,6 +15733,8 @@
 "gwl" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -15178,10 +15802,13 @@
 "gxN" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
-	dir = 4
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -15211,6 +15838,8 @@
 /area/crew_quarters/heads/sc/hor)
 "gzN" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
@@ -15310,6 +15939,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15339,7 +15970,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -15372,6 +16005,7 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -15382,6 +16016,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15429,6 +16065,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -15596,6 +16234,8 @@
 	RCon_tag = "Dorms Substation Bypass"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -15639,7 +16279,9 @@
 /area/security/detectives_office)
 "gJp" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -15693,6 +16335,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -15737,6 +16380,8 @@
 "gKP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/lino,
@@ -15830,6 +16475,8 @@
 /area/surface/outpost/main/dorms/dorm_10)
 "gMA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15840,6 +16487,8 @@
 /area/surface/outpost/main/exploration)
 "gMH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16088,6 +16737,8 @@
 /area/surface/outpost/civilian/emergency_storage)
 "gTj" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16202,6 +16853,8 @@
 /area/security/security_hallway)
 "gVI" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal/wall{
@@ -16432,6 +17085,8 @@
 /area/security/aid_station)
 "gYQ" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -16465,6 +17120,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16505,6 +17162,8 @@
 	req_access = list(31)
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -16658,7 +17317,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16780,6 +17441,8 @@
 /area/assembly/chargebay)
 "hfb" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -16803,6 +17466,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
@@ -16820,6 +17484,8 @@
 /obj/structure/cable,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -16918,9 +17584,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -16945,6 +17615,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -16989,9 +17661,13 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
@@ -17004,6 +17680,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -17016,6 +17694,7 @@
 	pixel_x = 32
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
@@ -17044,15 +17723,21 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "hnL" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -17131,6 +17816,8 @@
 /area/surface/outside/plains/outpost)
 "hoY" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/pink{
@@ -17156,6 +17843,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17188,6 +17877,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17203,6 +17894,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17286,10 +17979,14 @@
 "hrg" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -17319,6 +18016,8 @@
 /area/surface/outside/plains/outpost)
 "hrE" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -17336,10 +18035,14 @@
 /area/security/lobby)
 "hrI" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "6-9"
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17357,7 +18060,9 @@
 /area/surface/outside/plains/outpost)
 "hrK" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/effect/zone_divider,
@@ -17453,6 +18158,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/lino,
@@ -17507,7 +18214,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -17546,6 +18255,8 @@
 /area/security/evidence_storage)
 "hwi" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/firealarm{
@@ -17565,15 +18276,14 @@
 	},
 /obj/effect/landmark/vines,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
@@ -17607,6 +18317,8 @@
 /area/medical/reception)
 "hxl" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -17687,6 +18399,8 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/thor/planetuse,
@@ -17719,11 +18433,15 @@
 /area/security/security_hallway)
 "hyt" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -17779,7 +18497,8 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17902,6 +18621,8 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -18011,7 +18732,8 @@
 /area/quartermaster/mininglockerroom)
 "hEJ" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -18044,6 +18766,8 @@
 /area/crew_quarters/bar)
 "hFT" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -18201,6 +18925,7 @@
 /obj/fiftyspawner/steel,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/shuttle/floor/yellow,
@@ -18257,6 +18982,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -18315,6 +19042,8 @@
 "hKO" = (
 /obj/machinery/photocopier,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -18322,6 +19051,8 @@
 "hKV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -18332,6 +19063,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -18365,6 +19098,8 @@
 	},
 /obj/structure/table/rack,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -18413,11 +19148,14 @@
 /area/hallway/primary/thirddeck/stationgateway)
 "hOG" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -18427,6 +19165,8 @@
 /obj/item/weapon/storage/briefcase/crimekit,
 /obj/item/weapon/storage/briefcase/crimekit,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
@@ -18561,7 +19301,9 @@
 /area/security/evidence_storage)
 "hQZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small,
@@ -18605,6 +19347,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18665,13 +19409,20 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "hTU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/structure/cable/cyan{
+	icon_state = "16-0";
+	d1 = 16;
+	d2 = 0
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/hallway/engineer_hallway)
 "hUa" = (
 /obj/item/weapon/flag,
@@ -18702,13 +19453,19 @@
 /area/medical/medbay)
 "hUm" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -18952,7 +19709,8 @@
 	name = "Medical Hardsuits"
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -18981,6 +19739,8 @@
 /area/surface/outpost/main/dorms/dorm_8)
 "iaD" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -19203,6 +19963,8 @@
 "idy" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating{
@@ -19374,6 +20136,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19493,6 +20256,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19518,6 +20283,8 @@
 /area/surface/outside/plains/outpost)
 "imZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19547,9 +20314,13 @@
 /area/medical/foyer)
 "inO" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -19651,6 +20422,8 @@
 /area/medical/sleeper)
 "ioS" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -19902,7 +20675,8 @@
 /area/quartermaster/foyer)
 "iuE" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -19936,7 +20710,9 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "1-5"
+	icon_state = "1-5";
+	d1 = 1;
+	d2 = 5
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -19944,10 +20720,13 @@
 /area/engineering/foyer)
 "ivu" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19956,6 +20735,8 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -19965,6 +20746,8 @@
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -19982,6 +20765,8 @@
 /area/surface/outside/plains/outpost)
 "ivG" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/power/breakerbox/activated{
@@ -19998,7 +20783,9 @@
 /area/surface/outpost/main/gym)
 "iwY" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20010,6 +20797,8 @@
 /area/surface/outside/path/plains)
 "ixx" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -20023,7 +20812,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -20031,7 +20821,8 @@
 	req_one_access = list(12)
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bmarble,
@@ -20056,6 +20847,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -20076,6 +20869,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -20088,7 +20883,8 @@
 /area/library)
 "iyj" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -20150,7 +20946,9 @@
 /area/chapel/main)
 "izx" = (
 /obj/structure/cable/green{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -20182,7 +20980,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
@@ -20297,6 +21095,8 @@
 "iCY" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -20426,6 +21226,8 @@
 /area/medical/cryo/autoresleeve)
 "iEY" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20585,9 +21387,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -20697,6 +21503,8 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
@@ -20716,6 +21524,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -20735,6 +21545,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20805,7 +21617,9 @@
 /area/medical/sleeper)
 "iNh" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20831,6 +21645,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -20846,6 +21662,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -20886,6 +21704,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
@@ -20894,6 +21713,8 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -20909,6 +21730,8 @@
 /area/crew_quarters/heads/sc/hop/quarters)
 "iQu" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20958,12 +21781,16 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "iRJ" = (
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
 	icon_state = "32-8"
 	},
 /turf/simulated/open{
@@ -21001,6 +21828,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -21055,6 +21883,8 @@
 /area/hallway/primary/seconddeck/dockhallway)
 "iTr" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/closet/firecloset,
@@ -21280,9 +22110,13 @@
 /area/medical/sleeper)
 "iWV" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -21337,9 +22171,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -21393,6 +22231,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/fans/tiny,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -21441,7 +22281,9 @@
 /area/medical/sleeper)
 "jbS" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating{
@@ -21467,7 +22309,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/fans/tiny,
@@ -21487,7 +22329,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
@@ -21591,6 +22434,8 @@
 	name = "pew"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -21620,6 +22465,8 @@
 /area/surface/outpost/wall/checkpoint)
 "jfN" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -21657,7 +22504,9 @@
 	id = "housetint2"
 	},
 /obj/structure/cable/green{
-	icon_state = "6-9"
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_3)
@@ -21684,6 +22533,8 @@
 /area/expoutpost/prep/recovery)
 "jho" = (
 /obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -21779,6 +22630,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -22057,6 +22910,8 @@
 	RCon_tag = "Command Substation Bypass"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -22069,6 +22924,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -22092,6 +22949,8 @@
 "juU" = (
 /obj/effect/landmark/vines,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -22106,6 +22965,7 @@
 	},
 /obj/machinery/power/terminal,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -22160,9 +23020,13 @@
 /area/surface/outpost/main/gym)
 "jxZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -22173,6 +23037,7 @@
 	name_tag = "Command Subgrid"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
@@ -22204,6 +23069,8 @@
 	req_access = list(57)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22232,6 +23099,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -22242,9 +23110,12 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -22313,6 +23184,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -22365,7 +23237,7 @@
 "jBT" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/blue{
@@ -22378,7 +23250,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22419,6 +23293,8 @@
 /area/hallway/primary/seconddeck/dockhallway)
 "jCX" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -22505,6 +23381,7 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -22562,6 +23439,8 @@
 	name = "Cargo Shutters"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22571,6 +23450,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -22583,7 +23464,9 @@
 /area/hallway/primary/thirddeck/stationgateway)
 "jIj" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating{
@@ -22635,6 +23518,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22701,6 +23586,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -22737,6 +23624,8 @@
 	name = "null"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -22784,9 +23673,13 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22933,6 +23826,8 @@
 /area/quartermaster/foyer)
 "jPu" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -22988,7 +23883,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23034,12 +23931,18 @@
 	req_access = list(1)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -23116,9 +24019,13 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -23143,6 +24050,8 @@
 /area/assembly/robotics)
 "jTP" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -23166,9 +24075,11 @@
 /area/ai_monitored/storage/eva)
 "jUg" = (
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
@@ -23178,9 +24089,13 @@
 /area/maintenance/substation/command)
 "jUh" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23205,6 +24120,8 @@
 	req_access = list(57)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -23244,9 +24161,13 @@
 /area/chapel/main)
 "jUW" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23263,7 +24184,9 @@
 /area/crew_quarters/heads/sc/hop)
 "jUY" = (
 /obj/structure/cable/green{
-	icon_state = "5-10"
+	icon_state = "5-10";
+	d1 = 5;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -23275,6 +24198,8 @@
 /area/surface/outside/path/plains)
 "jVj" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -23284,6 +24209,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -23319,6 +24246,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -23346,9 +24275,13 @@
 "jXI" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/command{
@@ -23359,15 +24292,21 @@
 "jXJ" = (
 /obj/machinery/account_database,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
 "jXO" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -23393,6 +24332,8 @@
 	pixel_x = 22
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -23518,7 +24459,9 @@
 /area/engineering/foyer)
 "kcy" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating{
@@ -23537,6 +24480,8 @@
 /area/rnd/workshop)
 "kcS" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -23601,10 +24546,11 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/fans/tiny,
@@ -23628,7 +24574,9 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "kfm" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/effect/floor_decal/spline/fancy,
@@ -23707,7 +24655,9 @@
 /area/medical/foyer)
 "kge" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/item/weapon/flag,
@@ -23724,6 +24674,8 @@
 /area/engineering/external_lights)
 "khi" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -23792,16 +24744,22 @@
 /area/surface/outpost/main/dorms/dorm_2)
 "kiP" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7)
 "kiR" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/structure/railing/grey,
@@ -23817,7 +24775,9 @@
 /area/surface/outside/plains/outpost)
 "kjI" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23849,6 +24809,7 @@
 	outputting = 1
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
@@ -23943,6 +24904,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -24066,7 +25029,8 @@
 /area/storage/primary)
 "kpm" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24148,6 +25112,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -24157,7 +25123,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -24185,8 +25153,7 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
-	dir = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24228,9 +25195,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -24239,6 +25210,8 @@
 /area/surface/outside/path/plains)
 "ksg" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -24249,6 +25222,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
@@ -24289,6 +25264,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -24337,7 +25314,8 @@
 /area/crew_quarters/heads/sc/chief)
 "ktZ" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -24440,6 +25418,8 @@
 /area/security/lobby)
 "kwI" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24488,6 +25468,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -24666,7 +25648,9 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
-	icon_state = "6-9"
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -24693,6 +25677,8 @@
 /area/medical/sleeper)
 "kBC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24741,6 +25727,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
@@ -24779,7 +25767,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -24795,6 +25784,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24892,6 +25883,8 @@
 /area/hallway/primary/thirddeck/stationgateway)
 "kFB" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -24954,7 +25947,7 @@
 	req_access = list(19)
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
@@ -24979,6 +25972,8 @@
 /area/maintenance/substation/civilian)
 "kIs" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -25056,9 +26051,13 @@
 /obj/item/weapon/packageWrap,
 /obj/item/weapon/hand_labeler,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -25069,6 +26068,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -25117,7 +26117,9 @@
 /area/surface/outpost/main/gym)
 "kNj" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25160,6 +26162,8 @@
 /area/surface/outpost/main/gym)
 "kPi" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -25168,7 +26172,8 @@
 /area/surface/outside/path/plains)
 "kPV" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -25200,6 +26205,8 @@
 /area/maintenance/substation/engineering)
 "kQH" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/cryopod{
@@ -25234,6 +26241,8 @@
 /area/surface/outpost/mining_main/refinery)
 "kRa" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -25251,6 +26260,8 @@
 "kRp" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -25270,6 +26281,8 @@
 /area/crew_quarters/bar)
 "kSn" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25397,6 +26410,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -25532,6 +26546,8 @@
 "kXH" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25574,6 +26590,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25600,7 +26618,9 @@
 /area/expoutpost/debriefing)
 "kZI" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25730,6 +26750,8 @@
 "ldx" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25776,6 +26798,8 @@
 /area/shuttle/needle)
 "lep" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -25817,6 +26841,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -25856,7 +26882,9 @@
 /area/surface/outside/path/plains)
 "lfX" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -25871,7 +26899,9 @@
 /area/surface/outside/path/plains)
 "lgh" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -25923,7 +26953,8 @@
 /area/engineering/workshop)
 "lgQ" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -25952,9 +26983,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
@@ -25981,7 +27016,9 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26012,7 +27049,9 @@
 /area/surface/outpost/main/landing/one)
 "lhZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26040,7 +27079,9 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26151,6 +27192,8 @@
 /area/surface/outside/plains/outpost)
 "llJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -26233,9 +27276,13 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/pen/multi,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -26270,7 +27317,8 @@
 /area/surface/outside/path/plains)
 "lnA" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26294,7 +27342,9 @@
 	pixel_z = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "6-9"
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -26310,7 +27360,8 @@
 /area/surface/outside/path/plains)
 "loH" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -26327,7 +27378,8 @@
 /area/engineering/engine_eva)
 "lpj" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26347,12 +27399,13 @@
 /area/surface/outside/plains/outpost)
 "lpm" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "lpx" = (
@@ -26468,6 +27521,8 @@
 "lrn" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -26490,6 +27545,8 @@
 /area/rnd/research)
 "lrN" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -26664,6 +27721,8 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -26687,6 +27746,8 @@
 /area/engineering/workshop)
 "lvr" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26734,6 +27795,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/wall{
@@ -26774,6 +27837,8 @@
 /area/engineering/external_lights)
 "lyw" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26871,10 +27936,14 @@
 /area/quartermaster/hallway)
 "lAd" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -26905,7 +27974,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26936,6 +28007,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26946,7 +28019,9 @@
 /area/chapel/main)
 "lBW" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -27051,7 +28126,8 @@
 /area/medical/medbay)
 "lDO" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -27118,6 +28194,8 @@
 /area/crew_quarters/bar)
 "lFF" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -27126,6 +28204,8 @@
 /area/surface/outside/path/plains)
 "lFI" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
@@ -27146,6 +28226,8 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
 	icon_state = "32-8"
 	},
 /turf/simulated/open{
@@ -27154,7 +28236,9 @@
 /area/maintenance/substation/research)
 "lGH" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -27184,6 +28268,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
@@ -27202,10 +28288,7 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
 "lHS" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Substation - Reactor"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "lHV" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -27304,6 +28387,8 @@
 /area/expoutpost)
 "lMf" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27332,6 +28417,8 @@
 /area/bridge)
 "lMK" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -27397,9 +28484,13 @@
 /area/engineering/workshop)
 "lNy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -27422,19 +28513,26 @@
 /area/crew_quarters/heads/sc/hop)
 "lNR" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
 "lOz" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -27466,12 +28564,18 @@
 /area/maintenance/substation/medical)
 "lOW" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -27509,6 +28613,8 @@
 	})
 "lPs" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -27525,13 +28631,16 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "lPE" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -27547,6 +28656,8 @@
 "lPT" = (
 /obj/structure/dogbed,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -27567,6 +28678,8 @@
 	})
 "lQq" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -27592,7 +28705,8 @@
 /area/surface/outside/plains/outpost)
 "lRo" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/no_nightshift,
@@ -27623,7 +28737,7 @@
 /area/expoutpost/pathfinder)
 "lRF" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
@@ -27637,6 +28751,8 @@
 "lRK" = (
 /obj/effect/floor_decal/plaque,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -27683,6 +28799,8 @@
 	id = "housetint1"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27785,6 +28903,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -27835,7 +28955,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -28005,6 +29126,8 @@
 /area/security/lobby)
 "mce" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -28020,6 +29143,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/disposal/wall{
@@ -28049,6 +29174,8 @@
 "mdJ" = (
 /obj/structure/bed/chair/office/dark,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start{
@@ -28097,7 +29224,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/exterior{
@@ -28123,6 +29252,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -28165,9 +29296,13 @@
 /area/surface/outside/plains/outpost)
 "mgN" = (
 /obj/structure/cable/green{
-	icon_state = "2-9"
+	icon_state = "2-9";
+	d1 = 2;
+	d2 = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -28182,6 +29317,8 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "mhW" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/keycard_auth{
@@ -28232,9 +29369,12 @@
 	pixel_x = 36
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -28437,6 +29577,8 @@
 /area/surface/outpost/main/garage)
 "mms" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -28519,6 +29661,7 @@
 /area/expoutpost/pathfinder)
 "moL" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -28600,7 +29743,8 @@
 	dir = 5
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28632,6 +29776,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -28723,6 +29869,8 @@
 /area/medical/cryo/autoresleeve)
 "msC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -28739,6 +29887,8 @@
 /area/expoutpost/shuttle)
 "msS" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/wall{
@@ -28791,6 +29941,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
@@ -28804,7 +29956,9 @@
 /area/surface/outside/path/plains)
 "muj" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -28844,7 +29998,8 @@
 /area/surface/outside/plains/outpost)
 "mvE" = (
 /obj/structure/cable/yellow{
-	icon_state = "32-1"
+	icon_state = "32-1";
+	d1 = 32
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -28967,6 +30122,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -29154,11 +30311,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/hallway/primary/seconddeck/dockhallway)
 "mDJ" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
+/obj/structure/cable/green,
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "hop_office"
 	},
@@ -29213,7 +30366,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/power/sensor{
@@ -29250,6 +30404,8 @@
 "mED" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -29319,6 +30475,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -29342,12 +30500,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -29390,6 +30554,8 @@
 	},
 /obj/item/tape/engineering,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -29446,12 +30612,18 @@
 /area/expoutpost)
 "mIB" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
@@ -29642,7 +30814,9 @@
 /area/medical/surgery_storage)
 "mMJ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -29685,6 +30859,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29782,6 +30958,8 @@
 /area/rnd/research)
 "mPa" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -29817,6 +30995,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -29845,6 +31024,8 @@
 /area/engineering/break_room)
 "mQJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -29863,9 +31044,13 @@
 /area/surface/outside/plains/outpost)
 "mQK" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -29933,7 +31118,9 @@
 /area/medical/psych)
 "mRG" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/camera/network/exterior{
@@ -30001,6 +31188,8 @@
 	req_one_access = list(11)
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -30279,6 +31468,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -30297,6 +31488,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -30388,6 +31581,8 @@
 "nbl" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -30420,7 +31615,9 @@
 /area/medical/sleeper)
 "ncJ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -30514,6 +31711,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30529,7 +31728,9 @@
 /area/rnd/research)
 "neZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -30570,7 +31771,9 @@
 /area/chapel/main)
 "nfu" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30591,6 +31794,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/alarm{
@@ -30642,11 +31847,13 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -30656,7 +31863,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/rust,
@@ -30673,6 +31881,8 @@
 /area/surface/outside/path/plains)
 "ngd" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -30685,7 +31895,9 @@
 /area/surface/outside/plains/outpost)
 "nho" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30700,13 +31912,17 @@
 /area/surface/outside/path/plains)
 "nhy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_1)
 "nhN" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30839,6 +32055,8 @@
 "nkU" = (
 /obj/structure/railing/grey,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -30869,7 +32087,9 @@
 /area/security/lobby)
 "nlN" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -30888,6 +32108,8 @@
 /obj/effect/floor_decal/rust,
 /obj/random/tech_supply,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/milspec,
@@ -31040,7 +32262,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -31174,6 +32397,8 @@
 "ntM" = (
 /obj/effect/floor_decal/milspec/box,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -31211,7 +32436,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31257,7 +32484,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31270,6 +32497,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -31282,6 +32510,8 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/blast/shutters{
@@ -31333,7 +32563,9 @@
 /area/surface/outpost/main/garage)
 "nxV" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -31342,6 +32574,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -31374,6 +32607,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -31387,7 +32622,9 @@
 /area/surface/outpost/main/dorms/dorm_8)
 "nzl" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -31397,6 +32634,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -31408,12 +32647,16 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "nzy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -31425,13 +32668,17 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "nzO" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -31456,6 +32703,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -31473,9 +32721,13 @@
 /area/surface/outside/path/plains)
 "nBQ" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
@@ -31495,7 +32747,9 @@
 /area/assembly/chargebay)
 "nCl" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31548,6 +32802,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -31693,7 +32949,8 @@
 /area/surface/outpost/civilian/emergency_storage)
 "nIm" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -31730,10 +32987,13 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -31777,6 +33037,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -31819,19 +33081,6 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/secondary/cryostorage_hallway)
-"nKV" = (
-/obj/structure/closet/walllocker_double/engineering/north{
-	starts_with = list(/obj/item/clothing/suit/radiation = 2, /obj/item/clothing/head/radiation = 2, /obj/item/device/geiger = 2)
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/hallway/engineer_hallway)
 "nLa" = (
 /obj/effect/floor_decal/emblem/nt2,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -31916,9 +33165,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green,
@@ -31935,6 +33188,8 @@
 /area/shuttle/needle)
 "nNH" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31996,6 +33251,8 @@
 /area/medical/medbay)
 "nOj" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
@@ -32032,9 +33289,13 @@
 /area/medical/biostorage)
 "nOH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -32143,12 +33404,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/cmo/quarters)
 "nPC" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -32195,7 +33450,9 @@
 /area/surface/outpost/main/garage)
 "nQK" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/camera/network/exterior{
@@ -32249,7 +33506,9 @@
 /area/surface/outpost/main/garage)
 "nSd" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/wall/checkpoint)
@@ -32261,6 +33520,8 @@
 "nSD" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32274,6 +33535,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating{
@@ -32288,7 +33551,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -32300,6 +33564,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -32316,6 +33582,8 @@
 	icon_state = "mfloor7"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -32332,6 +33600,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32372,7 +33642,9 @@
 /area/rnd/research)
 "nVH" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -32412,6 +33684,8 @@
 	starts_with = list(/obj/item/clothing/suit/radiation = 2, /obj/item/clothing/head/radiation = 2, /obj/item/device/geiger = 2)
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -32492,7 +33766,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -32502,6 +33778,7 @@
 "nYu" = (
 /obj/machinery/power/smes/batteryrack/mapped,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -32527,7 +33804,9 @@
 /area/rnd/research)
 "nYK" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32616,7 +33895,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -32775,7 +34056,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating{
@@ -32848,9 +34131,13 @@
 	dir = 10
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -32866,7 +34153,9 @@
 /area/quartermaster/hallway)
 "ojv" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -32925,6 +34214,8 @@
 /area/surface/outside/path/plains)
 "olJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -32951,7 +34242,9 @@
 /area/security/security_hallway)
 "onl" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33000,6 +34293,8 @@
 "onK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33012,9 +34307,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating{
@@ -33038,6 +34337,8 @@
 /area/medical/medbay_primary_storage)
 "opF" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -33086,6 +34387,8 @@
 	pixel_y = -21
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -33189,9 +34492,13 @@
 /area/medical/sleeper)
 "ovy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -33260,14 +34567,16 @@
 	name_tag = "Engineering Subgrid"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/structure/cable/heavyduty{
-	d2 = 0;
-	icon_state = "0-8"
 	},
 /obj/structure/cable/heavyduty,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "oxO" = (
@@ -33347,6 +34656,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -33392,6 +34703,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33416,6 +34729,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -33446,6 +34760,8 @@
 /area/surface/outside/plains/outpost)
 "oEn" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/autolathe,
@@ -33460,6 +34776,8 @@
 /area/assembly/robotics)
 "oEK" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -33560,6 +34878,8 @@
 	RCon_tag = "Medical Substation Bypass"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -33573,6 +34893,8 @@
 "oIk" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
 	icon_state = "32-4"
 	},
 /turf/simulated/open{
@@ -33620,15 +34942,21 @@
 "oIO" = (
 /obj/item/clothing/head/welding/demon,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "oJk" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
@@ -33775,9 +35103,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33963,13 +35295,17 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/janitor)
 "oPf" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating{
@@ -34065,6 +35401,8 @@
 /area/surface/outside/plains/outpost)
 "oQJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -34074,9 +35412,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
@@ -34093,6 +35435,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34156,6 +35500,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -34333,6 +35679,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -34384,6 +35731,8 @@
 /area/medical/medbay)
 "oWC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -34392,6 +35741,8 @@
 /area/rnd/research_foyer)
 "oXs" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/no_nightshift{
@@ -34422,7 +35773,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -34479,6 +35831,8 @@
 /area/medical/biostorage)
 "oZA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal/wall{
@@ -34554,6 +35908,8 @@
 /area/surface/outpost/main/garage)
 "pau" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -34837,6 +36193,8 @@
 	name = "blobstart"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -34907,7 +36265,8 @@
 	req_one_access = list(11,24)
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34939,7 +36298,9 @@
 /area/engineering/engine_eva)
 "plh" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35071,6 +36432,8 @@
 /area/rnd/research_restroom_sc)
 "pnG" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35122,6 +36485,8 @@
 "poj" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -35175,7 +36540,9 @@
 /area/surface/outpost/main/landing/two)
 "ppB" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -35307,7 +36674,9 @@
 /area/surface/outside/plains/outpost)
 "psQ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35360,7 +36729,9 @@
 /area/medical/foyer)
 "ptg" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35426,7 +36797,9 @@
 /area/shuttle/needle)
 "puM" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35447,7 +36820,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35652,6 +37027,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -35705,7 +37081,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35722,6 +37100,8 @@
 "pzq" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35781,6 +37161,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -35804,7 +37186,9 @@
 /area/crew_quarters/heads/sc/cmo/quarters)
 "pAm" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -35820,6 +37204,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced/polarized/full{
@@ -35857,6 +37243,8 @@
 /area/shuttle/needle)
 "pBn" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -35922,6 +37310,8 @@
 /area/engineering/external_lights)
 "pDx" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/power/breakerbox/activated{
@@ -35953,7 +37343,8 @@
 /area/surface/outpost/civilian/emergency_storage)
 "pEg" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -36029,7 +37420,9 @@
 /area/medical/psych)
 "pFP" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36050,6 +37443,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -36090,6 +37485,8 @@
 /obj/random/obstruction,
 /obj/item/ammo_magazine/m10mm/empty,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -36128,6 +37525,8 @@
 /area/surface/outpost/main/garage)
 "pIS" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -36170,6 +37569,7 @@
 	id = "detoffice"
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -36197,7 +37597,9 @@
 /area/rnd/misc_lab)
 "pKL" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36374,6 +37776,8 @@
 /area/rnd/research_restroom_sc)
 "pNP" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36409,6 +37813,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -36417,6 +37823,8 @@
 /area/surface/outside/path/plains)
 "pPb" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -36431,6 +37839,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -36479,14 +37888,17 @@
 /area/surface/outpost/civilian/emergency_storage)
 "pQm" = (
 /obj/machinery/power/grid_checker,
-/obj/structure/cable/heavyduty{
-	icon_state = "2-4"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "pQy" = (
 /obj/structure/cable/green{
-	icon_state = "4-9"
+	icon_state = "4-9";
+	d1 = 4;
+	d2 = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -36521,7 +37933,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/heavyduty{
@@ -36533,9 +37946,13 @@
 /area/surface/outside/path/plains)
 "pRx" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -36544,6 +37961,8 @@
 /area/surface/outside/path/plains)
 "pRH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -36557,7 +37976,9 @@
 /area/rnd/research_foyer)
 "pSe" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36654,6 +38075,8 @@
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood/alt/panel,
@@ -36699,7 +38122,8 @@
 /area/expoutpost/prep)
 "pUS" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -36722,7 +38146,8 @@
 /area/crew_quarters/kitchen)
 "pUV" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -36771,7 +38196,9 @@
 /area/engineering/external_lights)
 "pWj" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36789,12 +38216,18 @@
 /area/surface/outside/path/plains)
 "pWm" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -36826,6 +38259,8 @@
 /area/expoutpost/pathfinder)
 "pXp" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37063,6 +38498,8 @@
 "pZR" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -37159,9 +38596,13 @@
 /area/engineering/hallway/engineer_hallway)
 "qct" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -37314,7 +38755,9 @@
 /area/medical/medbay)
 "qdP" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/cable/heavyduty{
 	d1 = 1;
@@ -37327,6 +38770,8 @@
 "qea" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -37445,7 +38890,9 @@
 /area/medical/medbay)
 "qfn" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37457,6 +38904,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -37468,7 +38917,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/sign/directions/medical/resleeving{
@@ -37525,6 +38976,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
@@ -37612,6 +39064,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -37630,6 +39084,8 @@
 /area/medical/sleeper)
 "qio" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -37722,7 +39178,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/sink/kitchen{
@@ -37775,6 +39232,8 @@
 /area/hydroponics)
 "qkw" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37795,6 +39254,8 @@
 "qlO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -37812,15 +39273,23 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -38068,6 +39537,8 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -38166,9 +39637,13 @@
 /area/surface/outpost/main/dorms/dorm_8)
 "qvY" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -38194,6 +39669,8 @@
 /area/surface/outpost/main/garage)
 "qwp" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38334,7 +39811,9 @@
 /area/surface/outside/path/plains)
 "qAQ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/wall/r_wall,
@@ -38449,6 +39928,8 @@
 /area/medical/medbay)
 "qFo" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
@@ -38563,9 +40044,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38586,7 +40071,9 @@
 /area/surface/outpost/main/dorms/dorm_3)
 "qIv" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -38650,6 +40137,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -38671,9 +40160,13 @@
 /area/janitor)
 "qKD" = (
 /obj/structure/cable/green{
-	icon_state = "2-9"
+	icon_state = "2-9";
+	d1 = 2;
+	d2 = 9
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -38741,7 +40234,10 @@
 	input_level = 750000;
 	output_level = 750000
 	},
-/obj/structure/cable/heavyduty,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "qLK" = (
@@ -38769,6 +40265,8 @@
 /area/surface/outside/path/plains)
 "qMC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small,
@@ -38856,7 +40354,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38977,6 +40476,8 @@
 /area/engineering/foyer)
 "qRH" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -38984,6 +40485,8 @@
 "qSr" = (
 /obj/random/tech_supply,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -39229,6 +40732,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -39246,7 +40750,9 @@
 /area/library)
 "qYb" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39308,12 +40814,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -39383,6 +40887,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/sandstone{
@@ -39583,10 +41089,14 @@
 /area/shuttle/needle)
 "rfp" = (
 /obj/structure/cable/green{
-	icon_state = "4-5"
+	icon_state = "4-5";
+	d1 = 4;
+	d2 = 5
 	},
 /obj/structure/cable/green{
-	icon_state = "4-10"
+	icon_state = "4-10";
+	d1 = 4;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -39665,6 +41175,8 @@
 /area/expoutpost/debriefing)
 "rin" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -39894,18 +41406,28 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40108,13 +41630,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "16-0"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "rpT" = (
@@ -40146,9 +41661,12 @@
 /obj/machinery/power/terminal,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -40347,7 +41865,9 @@
 /area/surface/outpost/main/garage)
 "rtc" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -40361,6 +41881,8 @@
 /area/surface/outside/path/plains)
 "rtS" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -40409,6 +41931,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced/polarized/full{
@@ -40532,7 +42056,9 @@
 /area/library)
 "rwS" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40592,7 +42118,9 @@
 	dir = 8
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -40747,7 +42275,8 @@
 /area/assembly/robotics)
 "rBv" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -40898,6 +42427,8 @@
 	name = "pew"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -40912,12 +42443,11 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/engineer_hallway)
 "rGo" = (
@@ -40941,6 +42471,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -40964,6 +42495,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -41054,6 +42587,8 @@
 /area/crew_quarters/kitchen)
 "rJx" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41467,7 +43002,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Outpost Engine output";
+	RCon_tag = "Engine - Input";
 	charge = 2e+007;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -41478,9 +43013,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/engineer_hallway)
 "rST" = (
@@ -41489,7 +43021,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -41515,9 +43049,13 @@
 /area/medical/medbay_emt_bay)
 "rTd" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -41569,7 +43107,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -41798,7 +43338,9 @@
 /area/medical/medbay)
 "scm" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -42007,6 +43549,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -42061,6 +43605,8 @@
 	id = "housetint7"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -42071,6 +43617,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -42396,7 +43944,9 @@
 /area/surface/outpost/civilian/emergency_storage)
 "spS" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -42436,6 +43986,8 @@
 /area/crew_quarters/heads/sc/hor)
 "sqg" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -42538,6 +44090,8 @@
 /area/surface/outpost/main/landing/one)
 "ssv" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -42545,7 +44099,9 @@
 "ssM" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -42582,13 +44138,17 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/surface/outpost/civilian/fishing)
 "stn" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42659,7 +44219,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -42679,18 +44240,17 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/fishing)
 "suJ" = (
-/obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "suQ" = (
 /obj/machinery/door/firedoor/border_only,
@@ -42710,6 +44270,8 @@
 /area/medical/psych)
 "svJ" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -42717,7 +44279,8 @@
 "svK" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -42826,7 +44389,9 @@
 /area/engineering/locker_room)
 "sxN" = (
 /obj/structure/cable/green{
-	icon_state = "5-8"
+	icon_state = "5-8";
+	d1 = 5;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -42944,6 +44509,8 @@
 /area/maintenance/substation/firstdeck/cargo)
 "sAE" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -42960,6 +44527,8 @@
 /area/expoutpost/pathfinder)
 "sAS" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -42979,7 +44548,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -43240,7 +44811,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -43253,6 +44825,8 @@
 /area/crew_quarters/bar)
 "sGf" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -43413,12 +44987,18 @@
 "sMm" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -43479,7 +45059,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -43534,6 +45115,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -43546,7 +45129,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -43565,7 +45149,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -43576,7 +45161,8 @@
 /area/crew_quarters/bar)
 "sOg" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -43590,7 +45176,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -43712,7 +45299,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43738,6 +45327,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -43831,7 +45422,9 @@
 /area/crew_quarters/heads/sc/cmo)
 "sRF" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/computer/timeclock/premade/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -43847,7 +45440,8 @@
 /area/engineering/external_lights)
 "sSH" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -43865,6 +45459,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -43945,6 +45540,8 @@
 	sortType = "Apartment 7"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -43956,6 +45553,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -44003,6 +45602,8 @@
 /area/hallway/primary/thirddeck/stationgateway)
 "sWR" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -44067,7 +45668,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating{
@@ -44085,6 +45688,8 @@
 /area/surface/outside/plains/outpost)
 "sZk" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
@@ -44191,6 +45796,8 @@
 /area/engineering/engine_eva)
 "taC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal/wall{
@@ -44209,6 +45816,8 @@
 	id = "housetint8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -44217,9 +45826,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -44253,6 +45859,8 @@
 	name = "Station Engineer"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -44293,6 +45901,8 @@
 "tcU" = (
 /obj/machinery/camera/network/engine,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -44316,6 +45926,8 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -44349,13 +45961,18 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -44383,6 +46000,8 @@
 	name = "Station Engineer"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -44423,6 +46042,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -44433,7 +46054,9 @@
 "thn" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44522,6 +46145,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -44560,6 +46185,8 @@
 	name = "Station Engineer"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -44577,6 +46204,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -44617,6 +46246,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/old_tile/white,
@@ -44636,6 +46267,8 @@
 /area/medical/medbay)
 "tnl" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/old_tile/white,
@@ -44814,7 +46447,8 @@
 /area/surface/outpost/main/gym)
 "tpK" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44834,17 +46468,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "tqp" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44953,7 +46583,9 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/cable/green{
-	icon_state = "4-10"
+	icon_state = "4-10";
+	d1 = 4;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/kitchen)
@@ -44985,7 +46617,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -44997,13 +46630,16 @@
 /area/surface/outside/path/plains)
 "ttU" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "tum" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45021,6 +46657,8 @@
 /area/surface/outside/path/plains)
 "tuz" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -45078,13 +46716,16 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /mob/living/simple_mob/animal/goat{
 	name = "Pete"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -45127,7 +46768,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -45152,12 +46794,18 @@
 /area/rnd/research)
 "tvD" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -45186,7 +46834,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -45202,6 +46851,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45217,7 +46868,8 @@
 	dir = 9
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -45418,6 +47070,8 @@
 "tzr" = (
 /obj/machinery/light/no_nightshift,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/cryopod/gateway{
@@ -45447,7 +47101,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -45515,7 +47171,9 @@
 /area/surface/outpost/main/dorms/dorm_6)
 "tBc" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
@@ -45527,10 +47185,11 @@
 /obj/machinery/door/firedoor,
 /obj/structure/fans/tiny,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/bmarble,
@@ -45636,6 +47295,8 @@
 /area/medical/chemistry)
 "tEc" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45651,6 +47312,8 @@
 /area/library)
 "tEh" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/alt/panel,
@@ -45800,6 +47463,8 @@
 /obj/effect/floor_decal/techfloor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/lino,
@@ -45963,7 +47628,8 @@
 	dir = 8
 	},
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/heavyduty{
@@ -45983,7 +47649,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -46044,7 +47712,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46067,6 +47737,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46089,6 +47761,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -46101,6 +47774,8 @@
 /area/quartermaster/hallway)
 "tMB" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -46224,6 +47899,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46312,7 +47989,9 @@
 /area/surface/outpost/mining_main/refinery)
 "tQW" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46327,7 +48006,9 @@
 /area/surface/outside/plains/outpost)
 "tRf" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -46399,6 +48080,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -46517,6 +48200,8 @@
 /area/engineering/workshop)
 "tXv" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -46585,16 +48270,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/bmarble,
 /area/engineering/hallway/engineer_hallway)
 "tYq" = (
@@ -46648,6 +48323,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -46676,6 +48353,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -46700,7 +48379,9 @@
 "uav" = (
 /obj/structure/catwalk,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
@@ -46774,12 +48455,16 @@
 /area/engineering/engi_restroom)
 "udl" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/computer/timeclock/premade/east,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	icon_state = "5-10"
+	icon_state = "5-10";
+	d1 = 5;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -46796,6 +48481,8 @@
 /area/surface/outside/plains/outpost)
 "uei" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -46855,6 +48542,8 @@
 /obj/item/clothing/gloves/sterile/latex,
 /obj/item/clothing/gloves/sterile/latex,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -46911,6 +48600,8 @@
 	starts_with = list(/obj/item/clothing/suit/radiation = 2, /obj/item/clothing/head/radiation = 2, /obj/item/device/geiger = 2)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -47013,16 +48704,16 @@
 /area/surface/outpost/main/gym)
 "uiX" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_10)
 "ujc" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -47050,6 +48741,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -47083,7 +48776,8 @@
 /area/surface/outpost/wall/checkpoint)
 "ukA" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/no_nightshift,
@@ -47092,7 +48786,8 @@
 /area/crew_quarters/kitchen)
 "ukO" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -47103,7 +48798,8 @@
 /area/crew_quarters/kitchen)
 "ulx" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -47115,6 +48811,8 @@
 "ulD" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -47173,7 +48871,8 @@
 /area/surface/outside/path/plains)
 "uno" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -47213,7 +48912,8 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
@@ -47311,7 +49011,9 @@
 	dir = 1
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -47372,6 +49074,8 @@
 /area/surface/outside/path/plains)
 "usV" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -47400,6 +49104,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -47462,6 +49168,8 @@
 /area/surface/outpost/civilian/emergency_storage)
 "uvd" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -47496,6 +49204,8 @@
 /area/server)
 "uvR" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/standard,
@@ -47650,6 +49360,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -47886,6 +49598,8 @@
 /area/surface/outside/plains/outpost)
 "uCM" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -47977,7 +49691,9 @@
 /area/crew_quarters/bar)
 "uDP" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
@@ -48159,9 +49875,12 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -48188,6 +49907,8 @@
 /area/lawoffice)
 "uGZ" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -48277,6 +49998,8 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/suit_cycler/exploration,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -48332,6 +50055,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -48538,6 +50263,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow,
@@ -48586,6 +50312,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -48635,9 +50363,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uNI" = (
@@ -48647,6 +50372,8 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/thor/planetuse,
@@ -48676,9 +50403,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
@@ -48730,6 +50454,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -48986,6 +50712,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
@@ -48995,7 +50723,9 @@
 /area/quartermaster/mininglockerroom)
 "uVr" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/effect/zone_divider,
@@ -49052,6 +50782,8 @@
 "uWo" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -49061,6 +50793,8 @@
 "uWq" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -49092,6 +50826,8 @@
 /area/surface/outside/plains/outpost)
 "uWJ" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -49110,7 +50846,9 @@
 /area/expoutpost/prep)
 "uXj" = (
 /obj/structure/cable/green{
-	icon_state = "6-9"
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -49182,6 +50920,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -49220,7 +50960,9 @@
 /area/engineering/external_lights)
 "uYN" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49286,6 +51028,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49306,6 +51050,8 @@
 /area/library)
 "vay" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49339,6 +51085,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass_research,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -49352,6 +51100,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49369,6 +51119,8 @@
 /area/security/lobby)
 "vcc" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -49381,7 +51133,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49465,6 +51219,7 @@
 	},
 /obj/machinery/papershredder,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -49603,7 +51358,9 @@
 /area/medical/cryo)
 "vfM" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -49684,6 +51441,8 @@
 	dir = 5
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -49731,13 +51490,17 @@
 	},
 /obj/item/device/radio/beacon,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "viv" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -49789,7 +51552,9 @@
 /area/shuttle/research/station)
 "vju" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49905,7 +51670,9 @@
 "vlo" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50212,9 +51979,13 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -50261,12 +52032,18 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -50380,6 +52157,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -50401,6 +52179,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -50447,7 +52227,8 @@
 /area/surface/outside/path/plains)
 "vtR" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
@@ -50525,6 +52306,8 @@
 /area/surface/outpost/civilian/sauna)
 "vuP" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -50607,7 +52390,9 @@
 /area/engineering/atmos)
 "vwy" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50627,7 +52412,9 @@
 /area/surface/outpost/main/dorms/dorm_9)
 "vwI" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50698,6 +52485,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -50743,11 +52532,13 @@
 	dir = 6
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -50761,7 +52552,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/railing/grey{
@@ -50811,6 +52603,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -50824,6 +52618,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -50836,6 +52632,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -50861,6 +52659,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -50969,6 +52769,8 @@
 /area/quartermaster/hallway)
 "vDZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50980,6 +52782,8 @@
 /area/surface/outside/path/plains)
 "vEF" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50992,6 +52796,8 @@
 /area/surface/outside/path/plains)
 "vFc" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -51062,6 +52868,8 @@
 /area/engineering/foyer)
 "vGi" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -51229,6 +53037,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
@@ -51237,6 +53047,8 @@
 /area/surface/outside/plains/outpost)
 "vKF" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -51285,13 +53097,17 @@
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
 "vNa" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51391,9 +53207,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -51431,6 +53251,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/stool/baystool/padded,
@@ -51462,6 +53284,8 @@
 /area/crew_quarters/bar)
 "vSO" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -51474,7 +53298,9 @@
 /area/medical/surgery_storage)
 "vTe" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51503,14 +53329,16 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/railing/grey{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -51533,7 +53361,8 @@
 "vTx" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/no_nightshift{
@@ -51645,6 +53474,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/research{
@@ -51720,6 +53551,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -51845,6 +53678,8 @@
 /area/rnd/lab)
 "vZF" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -51998,6 +53833,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -52109,6 +53946,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -52207,6 +54045,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -52254,7 +54094,9 @@
 /area/medical/surgery)
 "wfc" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/effect/floor_decal/spline/fancy,
@@ -52306,13 +54148,20 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "wgU" = (
@@ -52502,7 +54351,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -52549,7 +54399,9 @@
 /area/surface/outside/plains/outpost)
 "wlX" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52575,6 +54427,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/suit_storage_unit/hazmat,
@@ -52594,7 +54448,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/engineering,
@@ -52615,12 +54470,18 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -52663,6 +54524,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
@@ -52811,7 +54674,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -52838,7 +54702,9 @@
 /area/medical/foyer)
 "wqX" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -52848,6 +54714,8 @@
 "wqY" = (
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -52901,6 +54769,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -52931,7 +54800,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -52947,7 +54818,9 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
 /obj/structure/cable/green{
-	icon_state = "5-10"
+	icon_state = "5-10";
+	d1 = 5;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -52974,7 +54847,9 @@
 /area/holodeck/alphadeck)
 "wuT" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52997,9 +54872,13 @@
 /area/surface/outside/plains/outpost)
 "wuY" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -53011,6 +54890,8 @@
 /obj/effect/floor_decal/industrial/loading,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -53071,7 +54952,8 @@
 /area/surface/outpost/mining_main)
 "wxh" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -53106,7 +54988,9 @@
 /area/surface/outpost/main/dorms/dorm_4)
 "wxZ" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -53243,6 +55127,8 @@
 "wAt" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -53258,6 +55144,8 @@
 /area/crew_quarters/bar)
 "wAF" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
@@ -53315,7 +55203,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -53364,7 +55253,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -53380,7 +55270,8 @@
 	name = "Botanist"
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -53422,7 +55313,9 @@
 /area/assembly/robotics)
 "wEw" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -53506,6 +55399,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -53571,6 +55465,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -53620,6 +55516,8 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "wJb" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -53628,7 +55526,8 @@
 	})
 "wJc" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -53693,6 +55592,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -53759,6 +55660,8 @@
 /area/surface/outpost/main/dorms/dorm_3)
 "wLF" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
@@ -53880,7 +55783,9 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -54020,6 +55925,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -54051,6 +55958,8 @@
 /obj/effect/floor_decal/stairs/dark_stairs,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -54072,6 +55981,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -54107,6 +56018,7 @@
 	req_one_access = list(11,24,50)
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/fans/tiny,
@@ -54117,7 +56029,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54256,7 +56170,9 @@
 /area/expoutpost/bathroom)
 "wZq" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54366,6 +56282,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -54391,6 +56309,8 @@
 /area/medical/medical_restroom)
 "xbB" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction{
@@ -54417,7 +56337,7 @@
 /area/crew_quarters/bar)
 "xcs" = (
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/super{
@@ -54464,9 +56384,13 @@
 /area/medical/medbay)
 "xcM" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -54519,6 +56443,8 @@
 /area/medical/cryo/autoresleeve)
 "xex" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/breakerbox/activated{
@@ -54534,6 +56460,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -54546,6 +56474,8 @@
 /area/surface/outside/plains/outpost)
 "xeM" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -54569,7 +56499,8 @@
 /area/quartermaster/foyer)
 "xfc" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -54623,11 +56554,13 @@
 "xfq" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -54667,6 +56600,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -54761,6 +56695,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -55216,6 +57152,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -55258,6 +57196,8 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark{
@@ -55284,7 +57224,8 @@
 "xrz" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -55335,7 +57276,9 @@
 /area/engineering/hallway/engineer_hallway)
 "xsw" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -55412,6 +57355,8 @@
 /area/medical/reception)
 "xtM" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -55836,6 +57781,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/zone_divider,
@@ -55926,7 +57873,8 @@
 /area/surface/outpost/main/dorms/dorm_8)
 "xAm" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -56005,6 +57953,8 @@
 /area/engineering/external_lights)
 "xBl" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -56018,6 +57968,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -56041,6 +57993,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -56166,6 +58119,8 @@
 /area/surface/outpost/main/dorms/dorm_10)
 "xEG" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -56183,6 +58138,8 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "xES" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -56208,6 +58165,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -56245,6 +58203,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -56301,6 +58261,8 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -56351,7 +58313,9 @@
 /area/surface/outpost/main/gym)
 "xHB" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -56446,6 +58410,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -56581,7 +58547,8 @@
 "xKK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -57171,7 +59138,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57190,7 +59159,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57223,6 +59193,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -57323,7 +59295,9 @@
 	dir = 4
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57405,6 +59379,8 @@
 	c_tag = "SUBS - Medical"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -57430,6 +59406,8 @@
 /area/quartermaster/delivery)
 "xZh" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -57446,6 +59424,8 @@
 "xZP" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57463,6 +59443,8 @@
 /area/engineering/workshop)
 "yas" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -57572,7 +59554,8 @@
 /area/engineering/engine_eva)
 "yck" = (
 /obj/structure/cable/heavyduty{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -57616,7 +59599,9 @@
 /area/medical/foyer)
 "ycL" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -57640,6 +59625,8 @@
 /area/rnd/research_foyer)
 "ydd" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -57667,7 +59654,9 @@
 	})
 "ydT" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -57722,6 +59711,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -57741,6 +59732,7 @@
 /area/surface/outside/path/plains)
 "yfy" = (
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -57773,7 +59765,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -57795,7 +59788,9 @@
 /area/hallway/primary/thirddeck/stationgateway)
 "yfU" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57836,7 +59831,9 @@
 /area/engineering/foyer)
 "yhm" = (
 /obj/structure/cable/green{
-	icon_state = "5-10"
+	icon_state = "5-10";
+	d1 = 5;
+	d2 = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -57986,6 +59983,8 @@
 "ykh" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58058,6 +60057,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
@@ -78245,7 +80246,7 @@ oOQ
 oOQ
 oOQ
 oOQ
-eFA
+hTU
 suJ
 fWW
 eFA
@@ -78502,7 +80503,7 @@ plM
 pMK
 qHo
 oOQ
-nKV
+pmU
 rqc
 rSv
 eFA
@@ -79275,7 +81276,7 @@ oTY
 oOQ
 ugF
 nPC
-hTU
+lHS
 eFA
 xFu
 yaQ

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -1127,6 +1127,11 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/hos)
 "aDe" = (
@@ -1215,11 +1220,6 @@
 /obj/item/device/holowarrant,
 /obj/item/weapon/rig/ch/pursuit,
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/weapon/gun/energy/x01,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/hos)
@@ -1755,6 +1755,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "aUM" = (
@@ -2190,18 +2195,18 @@
 /turf/simulated/wall/r_wall,
 /area/security/security_ses)
 "biT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
-/turf/simulated/wall/r_wall,
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/open,
 /area/security/armoury)
 "bjp" = (
 /obj/structure/disposalpipe/segment,
@@ -2278,19 +2283,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
 "bkB" = (
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 8
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 8
+/obj/structure/railing/grey{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 8;
-	icon_state = "32-8"
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
 	},
-/turf/simulated/open,
-/area/security/armoury)
+/area/surface/outside/path/plains)
 "bkH" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -3604,13 +3606,20 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "bQd" = (
-/obj/structure/cable/orange{
-	icon_state = "32-2"
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/open{
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/surface/outside/path/plains)
+/area/surface/outside/plains/outpost)
 "bQr" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/borderfloor/corner,
@@ -3652,6 +3661,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/security_port)
 "bQM" = (
@@ -4731,6 +4741,24 @@
 /obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
+"cnP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "cnU" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -5210,6 +5238,10 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "cwh" = (
@@ -5320,11 +5352,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "cxB" = (
@@ -5364,11 +5391,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/security/warden)
@@ -5378,11 +5400,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
@@ -5410,11 +5427,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/security{
 	name = "Warden's Office";
 	req_access = list(3)
@@ -5436,11 +5448,6 @@
 "cAA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner_oldtile/gray{
 	dir = 9
 	},
@@ -5453,11 +5460,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
@@ -5476,6 +5478,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/security_port)
@@ -5500,11 +5505,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -5786,7 +5786,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "cEC" = (
 /obj/structure/sign/directions/stairs_up,
@@ -6348,11 +6348,6 @@
 	pixel_x = -6;
 	req_access = null
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/security/aid_station)
 "cOK" = (
@@ -6460,6 +6455,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/security_port)
 "cRk" = (
@@ -6519,10 +6517,20 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cRW" = (
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost{
-	outdoors = -1
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/mininglockerroom)
 "cSp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6612,11 +6620,6 @@
 "cTJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8018,9 +8021,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
@@ -8044,6 +8052,11 @@
 	},
 /obj/item/device/radio/intercom/department/security{
 	pixel_y = -23
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/security/warden)
@@ -8434,22 +8447,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost)
-"dEs" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "dEI" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -9167,6 +9164,11 @@
 /obj/machinery/door/airlock/security{
 	name = "Warden's Office";
 	req_access = list(3)
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/bmarble,
 /area/security/warden)
@@ -10172,9 +10174,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -10200,11 +10202,6 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
@@ -10238,16 +10235,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
@@ -10306,11 +10293,6 @@
 /area/security/security_hallway)
 "epY" = (
 /obj/machinery/vending/security,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -10739,12 +10721,12 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -10752,7 +10734,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/security/security_ses)
 "evF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals3{
@@ -11734,11 +11716,6 @@
 	},
 /area/surface/outside/path/plains)
 "eSV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -11859,6 +11836,11 @@
 	req_access = newlist()
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/aid_station)
 "eTS" = (
@@ -11963,24 +11945,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "eVE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/aid_station)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost)
 "eVT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12947,11 +12916,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fnz" = (
@@ -13121,24 +13085,23 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/lawoffice)
 "fsU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_hallway)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "fsV" = (
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
@@ -13186,11 +13149,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -13686,6 +13644,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
+"fEI" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "fEJ" = (
 /obj/structure/flora/log2,
 /turf/simulated/floor/water/atoll,
@@ -13791,15 +13766,18 @@
 	id = "detoffice"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
 /area/security/detectives_office)
 "fGV" = (
 /obj/structure/table/wooden_reinforced,
@@ -13969,6 +13947,24 @@
 	special_temperature = null
 	},
 /area/surface/outside/plains/outpost)
+"fLJ" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "hosoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/hos)
 "fLT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -15370,10 +15366,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "gov" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/structure/cable/green,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
@@ -17101,6 +17094,17 @@
 /obj/effect/landmark/vines,
 /turf/simulated/floor/bmarble,
 /area/chapel/main)
+"haq" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "haH" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -17556,8 +17560,8 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
@@ -17631,11 +17635,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "hmU" = (
@@ -17692,11 +17691,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -18134,6 +18128,17 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"hug" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "hus" = (
 /turf/simulated/wall/r_wall{
 	cached_rad_resistance = 150
@@ -19011,11 +19016,6 @@
 /area/expoutpost/prep)
 "hKO" = (
 /obj/machinery/photocopier,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "hKV" = (
@@ -19031,11 +19031,6 @@
 /obj/machinery/papershredder,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -19129,11 +19124,6 @@
 /obj/structure/table/rack,
 /obj/item/weapon/storage/briefcase/crimekit,
 /obj/item/weapon/storage/briefcase/crimekit,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "hOU" = (
@@ -19465,15 +19455,6 @@
 "hVQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/plains/outpost)
-"hVR" = (
-/obj/structure/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
-	},
-/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "hWe" = (
 /obj/structure/railing{
@@ -19871,6 +19852,16 @@
 	id = "security_lockdown";
 	name = "Security Blast Door";
 	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
@@ -20662,6 +20653,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"ivp" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost)
 "ivq" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Engineering North 6";
@@ -20702,11 +20697,6 @@
 	},
 /area/surface/outside/plains/outpost)
 "ivG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Security Substation Bypass"
 	},
@@ -20734,7 +20724,7 @@
 	},
 /area/surface/outside/path/plains)
 "ixx" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20784,7 +20774,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -22697,6 +22687,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"jok" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
+"joo" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "jop" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -25113,6 +25114,14 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/assembly/robotics)
+"kqk" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet,
+/area/security/warden)
 "kqt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26692,6 +26701,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/expoutpost/pathfinder)
+"lba" = (
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "lbd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26994,8 +27013,8 @@
 	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -29155,16 +29174,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
-"mcf" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
-	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
 "mch" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -35201,6 +35210,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
+"oNi" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "oNp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -35356,10 +35376,7 @@
 "oPG" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/cable/green,
 /obj/machinery/door/blast/shutters{
 	id = "Warden_Shutters";
 	name = "Warden Shutters"
@@ -37076,6 +37093,19 @@
 "pyQ" = (
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
+"pyT" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "pyU" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -38762,16 +38792,15 @@
 /area/medical/medbay)
 "qdP" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
+/obj/structure/cable,
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "qea" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -39632,6 +39661,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_8)
+"qvU" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "qvY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -40717,19 +40758,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"qXn" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/thor/planetuse,
-/area/surface/outside/path/plains)
 "qXq" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -43996,6 +44024,11 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
@@ -47613,6 +47646,22 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/cryo)
+"tIA" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "tIK" = (
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
@@ -50078,6 +50127,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_restroom)
+"uIT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "uJg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -50689,20 +50758,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uVp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 2
 	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/mininglockerroom)
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "uVr" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8";
@@ -51956,20 +52019,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "vqz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost{
+	outdoors = -1
+	})
 "vqI" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
@@ -53021,6 +53074,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
+"vLv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
 /area/surface/outside/path/plains)
@@ -55371,6 +55439,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
+"wGt" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/sc/hos)
 "wGA" = (
 /obj/structure/boxingrope{
 	dir = 8
@@ -57811,6 +57887,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/thirddeck/stationgateway)
+"xAr" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "xAC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
@@ -58172,7 +58265,16 @@
 /area/crew_quarters/bar)
 "xGd" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/thor/planetuse,
 /area/surface/outside/path/plains)
 "xGB" = (
 /obj/structure/railing/grey,
@@ -77605,9 +77707,9 @@ sYa
 sYa
 sYa
 sYa
-cRW
-cRW
-cRW
+vqz
+vqz
+vqz
 mCZ
 mCZ
 eUh
@@ -77863,8 +77965,8 @@ vtd
 sYa
 sYa
 tgb
-cRW
-cRW
+vqz
+vqz
 mCZ
 mCZ
 eUh
@@ -78122,14 +78224,14 @@ uav
 iGL
 srG
 iGL
-hVR
-hVR
-mcf
+uVp
+uVp
+lba
 sop
-hVR
-hVR
-hVR
-qdP
+uVp
+uVp
+uVp
+qvU
 ybp
 ybp
 rLe
@@ -79414,7 +79516,7 @@ wtQ
 wNP
 wDK
 mCZ
-xGd
+joo
 ybp
 xZf
 xZf
@@ -79671,7 +79773,7 @@ wNP
 wNP
 wDK
 mCZ
-xGd
+joo
 ybp
 xZf
 xZf
@@ -79928,7 +80030,7 @@ wDK
 wDK
 wDK
 ttz
-xGd
+joo
 ybp
 uPu
 xZf
@@ -80955,8 +81057,8 @@ rGo
 lWU
 ksN
 gaF
-uVp
-uVp
+cRW
+cRW
 vgP
 ibD
 tUO
@@ -86046,7 +86148,7 @@ bZO
 bZO
 bZO
 eLw
-bQd
+fgo
 fGs
 gfK
 gBo
@@ -86564,9 +86666,9 @@ fhk
 fGV
 ggn
 gEU
-lgT
+hmU
 hKO
-ibZ
+cnP
 hZu
 fyz
 hZu
@@ -87080,7 +87182,7 @@ fJx
 gHM
 hmL
 hLe
-ibZ
+fsU
 wEa
 hZu
 hZu
@@ -87369,7 +87471,7 @@ vSO
 vSO
 vSO
 vSO
-vqz
+vLv
 vSO
 vSO
 vSO
@@ -87626,7 +87728,7 @@ hvF
 hvF
 rxJ
 scm
-dEs
+tIA
 scm
 scm
 ssM
@@ -87851,7 +87953,7 @@ dVX
 gIM
 lgT
 hLM
-ibZ
+uIT
 wEa
 wry
 wry
@@ -88108,7 +88210,7 @@ dVX
 gKg
 hnC
 hOK
-ibZ
+fsU
 ixW
 ygw
 wEa
@@ -89120,7 +89222,7 @@ kYl
 gwL
 dje
 gYF
-eVE
+eVT
 cOJ
 dbK
 cdS
@@ -89384,7 +89486,7 @@ ceP
 ckF
 iSB
 nyZ
-oPG
+pyT
 eoe
 fZx
 fmH
@@ -89641,7 +89743,7 @@ cfp
 ckF
 cRk
 nzv
-oPG
+xAr
 eoD
 tAb
 fnm
@@ -90411,11 +90513,11 @@ bHZ
 ckF
 cyw
 ckF
-ckF
+kqk
 oPG
 epY
 eSV
-fsU
+ftn
 fTF
 gkB
 gRY
@@ -90456,7 +90558,7 @@ tqv
 daA
 swv
 dFz
-qXn
+xGd
 yeV
 yeV
 jZn
@@ -90916,9 +91018,9 @@ lfc
 lfc
 lfc
 tgb
-aCZ
+fLJ
 aFO
-aQr
+wGt
 bcU
 bst
 bIn
@@ -92975,7 +93077,7 @@ rLe
 rLe
 aJX
 aJX
-bkB
+byP
 byP
 bSc
 ayH
@@ -93270,8 +93372,8 @@ rST
 tzW
 uqD
 uqD
-vWk
-ygB
+fEI
+haq
 yeV
 yeV
 tmx
@@ -93528,7 +93630,7 @@ yeV
 yeV
 yeV
 yeV
-yeV
+ydT
 yeV
 gNU
 qSY
@@ -93785,7 +93887,7 @@ hra
 yeV
 yeV
 yeV
-yeV
+ydT
 yeV
 xHC
 xae
@@ -94042,7 +94144,7 @@ rLe
 hra
 ygw
 wry
-ygB
+oNi
 yeV
 xHD
 iGO
@@ -94296,10 +94398,10 @@ wEa
 wEa
 hra
 rLe
-rLe
-wry
-mCZ
-yeV
+xpb
+jok
+eVE
+ydT
 yeV
 xHD
 iGO
@@ -94552,11 +94654,11 @@ mCZ
 mCZ
 mCZ
 mCZ
-mCZ
-mCZ
-mCZ
-mCZ
-yeV
+ivp
+bQd
+hug
+qdP
+bkB
 yeV
 xHD
 iGO

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -51,7 +51,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
@@ -183,11 +185,13 @@
 /area/surface/outpost/wall/checkpoint)
 "afd" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/window/reinforced/polarized/full,
@@ -305,7 +309,9 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/chapel/main)
 "ahR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -465,6 +471,17 @@
 /obj/structure/stairs/spawner/east,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"akZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "ale" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass{
@@ -901,7 +918,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/polarized/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -930,7 +947,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -979,10 +996,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -1113,8 +1134,8 @@
 	})
 "aCZ" = (
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -1126,11 +1147,6 @@
 	id = "security_lockdown";
 	name = "Security Blast Door";
 	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/hos)
@@ -1730,7 +1746,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -2275,7 +2293,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "bkA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2283,15 +2301,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
 "bkB" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
 "bkH" = (
 /obj/structure/railing/grey{
@@ -2602,12 +2613,12 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -2856,7 +2867,7 @@
 	dir = 8
 	},
 /obj/structure/hull_corner,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2870,10 +2881,14 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -3161,7 +3176,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3606,20 +3623,20 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "bQd" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating{
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/path/plains)
 "bQr" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/borderfloor/corner,
@@ -3878,7 +3895,9 @@
 /area/lawoffice)
 "bXs" = (
 /obj/structure/bed/chair/comfy/brown,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3920,7 +3939,7 @@
 "bYE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4585,7 +4604,7 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
 "clS" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -4741,24 +4760,6 @@
 /obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
-"cnP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "cnU" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -4827,7 +4828,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych)
 "coJ" = (
@@ -4998,11 +4999,15 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -5180,12 +5185,14 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/expoutpost/debriefing)
 "cuH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5194,6 +5201,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/railing,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "cvb" = (
@@ -5357,7 +5365,9 @@
 "cxB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -5639,7 +5649,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5687,7 +5699,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -5863,12 +5877,12 @@
 "cFU" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6007,7 +6021,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6058,7 +6074,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -6517,20 +6533,12 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cRW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/mininglockerroom)
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
 "cSp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6573,7 +6581,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "cTc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -6585,7 +6593,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6766,18 +6774,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -7079,7 +7084,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/medbay{
@@ -7324,7 +7331,9 @@
 "diI" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -7999,7 +8008,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8442,7 +8451,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8554,14 +8564,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
@@ -8669,6 +8685,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
+"dJg" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "dJK" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/bag/circuits/basic,
@@ -8970,7 +8997,7 @@
 	icon_state = "markerjade-on";
 	picked_color = "Jade"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -9244,6 +9271,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_5)
+"dST" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "dTe" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -9252,7 +9296,7 @@
 /area/surface/outpost/main/dorms/dorm_7)
 "dTB" = (
 /obj/structure/dispenser/oxygen,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -9524,7 +9568,7 @@
 "dXB" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -9603,7 +9647,7 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -9676,7 +9720,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -9788,6 +9834,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "efZ" = (
@@ -10134,7 +10183,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -10549,7 +10600,9 @@
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/mining_main)
 "esq" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -10708,6 +10761,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
+"evm" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "evo" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -10788,7 +10853,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10836,7 +10901,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/foyer)
 "eyV" = (
@@ -10855,7 +10920,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -11019,12 +11086,6 @@
 /area/surface/outside/plains/outpost)
 "eCy" = (
 /obj/structure/stairs/spawner/south,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
 "eDw" = (
@@ -11181,7 +11242,9 @@
 /area/surface/outpost/main/landing/two)
 "eHi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -11301,7 +11364,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11573,7 +11638,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/green,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "eQg" = (
@@ -11883,10 +11948,14 @@
 	name = "office door control";
 	pixel_y = 33
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -11945,10 +12014,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "eVE" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/dirt,
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "eVT" = (
 /obj/structure/cable/green{
@@ -12241,7 +12308,7 @@
 	dir = 4
 	},
 /obj/structure/railing/grey,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -12884,17 +12951,17 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/chapel/main)
 "fnu" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -13085,23 +13152,18 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/lawoffice)
 "fsU" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
+/turf/simulated/floor/plating/thor/planetuse,
+/area/surface/outside/path/plains)
 "fsV" = (
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
@@ -13262,13 +13324,24 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
+"fva" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "fvj" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -13305,7 +13378,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -13365,7 +13438,7 @@
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13644,23 +13717,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
-"fEI" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "fEJ" = (
 /obj/structure/flora/log2,
 /turf/simulated/floor/water/atoll,
@@ -13947,24 +14003,6 @@
 	special_temperature = null
 	},
 /area/surface/outside/plains/outpost)
-"fLJ" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "hosoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/sc/hos)
 "fLT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -14121,7 +14159,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -14603,7 +14643,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -14734,7 +14776,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -15059,7 +15103,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15248,7 +15294,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -15355,6 +15401,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3)
+"gnc" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet,
+/area/security/warden)
 "gnD" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -15527,7 +15581,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15762,7 +15818,7 @@
 	},
 /area/surface/outside/path/plains)
 "gxM" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -15841,7 +15897,9 @@
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -16190,7 +16248,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -16745,6 +16805,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"gUa" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "gUy" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -16892,7 +16963,7 @@
 /obj/item/ammo_magazine/ammo_box/b545/large/hunter,
 /obj/item/ammo_magazine/ammo_box/b545/large/hunter,
 /obj/item/ammo_magazine/ammo_box/b545/large/hunter,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16950,13 +17021,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Medbay Subgrid";
@@ -16979,7 +17048,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -16987,7 +17056,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
 "gXy" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
@@ -17094,17 +17165,6 @@
 /obj/effect/landmark/vines,
 /turf/simulated/floor/bmarble,
 /area/chapel/main)
-"haq" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "haH" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -17341,7 +17401,9 @@
 	name = "Medbay";
 	req_access = list(5)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -17361,7 +17423,9 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/dorms/dorm_8)
 "hdP" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17493,7 +17557,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -17525,7 +17591,7 @@
 /turf/simulated/wall,
 /area/surface/outside/plains/outpost)
 "hjg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -17739,7 +17805,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
@@ -17754,7 +17820,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18128,17 +18196,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
-"hug" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "hus" = (
 /turf/simulated/wall/r_wall{
 	cached_rad_resistance = 150
@@ -18279,7 +18336,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "hxh" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18362,7 +18421,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18562,7 +18623,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "hAX" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -18848,12 +18909,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19457,13 +19520,15 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "hWe" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
-/obj/structure/flora/ausbushes/grassybush{
-	opacity = 1
+/turf/simulated/open{
+	outdoors = 1
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "hWp" = (
 /obj/machinery/camera/network/exterior{
@@ -19479,7 +19544,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19498,7 +19563,7 @@
 	dir = 1
 	},
 /obj/effect/zone_divider,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19519,7 +19584,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19641,7 +19706,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19713,7 +19780,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19755,7 +19824,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19780,7 +19849,7 @@
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -19826,7 +19895,7 @@
 	name = "Exporation SMES Room";
 	req_one_access = list(11)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -19842,7 +19911,10 @@
 /area/crew_quarters/heads/sc/hor)
 "ibZ" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "detoffice"
 	},
@@ -19852,16 +19924,6 @@
 	id = "security_lockdown";
 	name = "Security Blast Door";
 	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
@@ -20042,7 +20104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20648,15 +20710,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/hallway)
 "iva" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"ivp" = (
-/obj/structure/railing/grey,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost)
 "ivq" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Engineering North 6";
@@ -20873,15 +20933,10 @@
 /turf/simulated/floor/bmarble,
 /area/chapel/main)
 "izx" = (
-/obj/structure/cable/green{
-	icon_state = "32-2";
-	d1 = 32;
-	d2 = 2
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost{
+	outdoors = -1
+	})
 "izC" = (
 /obj/structure/flora/tree/jungle{
 	icon_state = "tree3"
@@ -20911,7 +20966,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/green,
+/obj/structure/cable,
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -21333,7 +21388,9 @@
 /obj/effect/floor_decal/corner/pink/border{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -21638,7 +21695,9 @@
 /turf/simulated/floor/water,
 /area/surface/outside/plains/outpost)
 "iPx" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -21654,10 +21713,10 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
@@ -21691,6 +21750,9 @@
 "iQz" = (
 /mob/living/simple_mob/animal/passive/cat,
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "iQM" = (
@@ -21727,26 +21789,41 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "iRF" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
-"iRJ" = (
-/obj/structure/cable/green{
+	icon_state = "32-2";
 	d1 = 32;
-	d2 = 8;
-	icon_state = "32-8"
+	d2 = 2
 	},
+/obj/structure/lattice,
 /turf/simulated/open{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"iRJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "iRX" = (
 /turf/simulated/open{
 	outdoors = 1
@@ -22047,7 +22124,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "iWM" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -22166,7 +22245,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -22373,7 +22454,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -22687,17 +22768,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
-"jok" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/plains/outpost)
-"joo" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
 "jop" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -22888,11 +22958,6 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Command Substation Bypass"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
 "juH" = (
@@ -22902,7 +22967,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -22943,7 +23008,7 @@
 	dir = 4
 	},
 /obj/machinery/power/terminal,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -23067,7 +23132,9 @@
 "jzR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -23202,7 +23269,9 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -23219,7 +23288,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -23256,15 +23326,19 @@
 	outdoors = -1
 	})
 "jCC" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/dockhallway)
 "jCO" = (
 /obj/structure/lattice,
-/obj/structure/cable/blue{
-	icon_state = "32-8"
+/obj/structure/cable{
+	icon_state = "32-8";
+	d1 = 32;
+	d2 = 8
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -23403,7 +23477,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23572,7 +23648,9 @@
 /obj/machinery/holosign/surgery{
 	id = "surg1"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -23631,7 +23709,9 @@
 /area/rnd/research)
 "jLI" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -23808,7 +23888,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23854,7 +23936,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/rnd/research)
 "jPZ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -24022,12 +24104,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24053,7 +24135,7 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "jTP" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -24081,10 +24163,6 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Command"
@@ -24221,7 +24299,7 @@
 /area/crew_quarters/heads/sc/hop)
 "jVl" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Expedition Outpost - Port Solars";
+	RCon_tag = "Substation - Exploration";
 	charge = 2.5e+006;
 	input_attempt = 1;
 	input_level = 150000;
@@ -24409,7 +24487,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
 "kbG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -24538,7 +24616,9 @@
 /obj/machinery/holosign/surgery{
 	id = "surg2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -24697,7 +24777,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -24920,7 +25001,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -25006,7 +25089,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -25114,14 +25197,6 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/assembly/robotics)
-"kqk" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet,
-/area/security/warden)
 "kqt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25159,7 +25234,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled/techfloor,
@@ -25685,7 +25760,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -25859,12 +25936,6 @@
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "kEK" = (
-/obj/structure/cable/blue,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "kEX" = (
@@ -25970,7 +26041,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/green,
+/obj/structure/cable,
 /turf/simulated/floor,
 /area/maintenance/substation/command)
 "kHI" = (
@@ -26100,7 +26171,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -26436,7 +26509,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -26451,13 +26526,19 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Equipment Storage"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -26693,7 +26774,7 @@
 /area/surface/outpost/main/gym)
 "laN" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -26701,16 +26782,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/expoutpost/pathfinder)
-"lba" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
-	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
 "lbd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26796,12 +26867,12 @@
 	},
 /area/surface/outpost/main/dorms/dorm_9)
 "ldX" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -27168,10 +27239,9 @@
 /obj/effect/floor_decal/corner/pink/bordercorner2{
 	dir = 10
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/item/device/radio/intercom/department/medbay{
@@ -27452,7 +27522,9 @@
 	},
 /area/surface/outside/plains/outpost)
 "lpz" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -27591,7 +27663,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -27699,7 +27773,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "luC" = (
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
 	},
@@ -27787,7 +27861,7 @@
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -28082,7 +28156,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck/cargo)
 "lCY" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -28395,17 +28471,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -28557,11 +28633,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop)
 "lOz" = (
@@ -28605,11 +28676,6 @@
 	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -28625,7 +28691,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom/department/medbay{
@@ -28760,7 +28828,7 @@
 	makes_dirt = 0;
 	name = "Lomp"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -28809,18 +28877,19 @@
 /area/engineering/external_lights)
 "lSq" = (
 /obj/structure/railing,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/white/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/expoutpost/shuttle)
 "lSw" = (
 /obj/structure/bookcase{
@@ -29118,6 +29187,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
+"lZN" = (
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable,
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "mam" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29313,15 +29393,17 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d2 = 8;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/steel_dirty{
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -29521,7 +29603,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -29655,7 +29739,7 @@
 /obj/effect/floor_decal/corner/purple/border,
 /obj/effect/floor_decal/borderfloorblack/corner2,
 /obj/effect/floor_decal/corner/purple/bordercorner2,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -29680,7 +29764,7 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/polarized/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -29843,7 +29927,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -29905,12 +29989,6 @@
 /area/surface/outside/plains/outpost)
 "msJ" = (
 /obj/structure/stairs/spawner/east,
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "msS" = (
@@ -30192,7 +30270,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/lobby)
 "mzg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -30584,7 +30662,9 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "mGU" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -30701,12 +30781,14 @@
 /obj/machinery/sleep_console,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -30932,10 +31014,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -31049,7 +31136,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -31119,7 +31206,9 @@
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
 "mRs" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -31128,7 +31217,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -31149,7 +31238,9 @@
 	name = "Medical Lockdown";
 	opacity = 0
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -31378,7 +31469,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -31573,7 +31664,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "naq" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -31695,7 +31786,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "nef" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -31852,8 +31945,8 @@
 	c_tag = "CIV - Hangar Pad 1 Southeast";
 	dir = 8
 	},
-/obj/structure/cable/blue,
-/obj/structure/cable/blue{
+/obj/structure/cable,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -32223,7 +32316,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32405,7 +32500,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -32448,7 +32545,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -32812,7 +32909,7 @@
 /obj/effect/floor_decal/stairs/dark_stairs{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -32915,7 +33012,9 @@
 /turf/simulated/floor/bmarble,
 /area/chapel/office)
 "nGg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -33218,7 +33317,7 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Explo Subgrid";
+	name = "Powernet Sensor - Exploration Subgrid";
 	name_tag = "Exploration Subgrid"
 	},
 /turf/simulated/floor/plating,
@@ -33285,7 +33384,9 @@
 /area/medical/biostorage)
 "nNX" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33311,7 +33412,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -33391,17 +33492,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -34109,7 +34210,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -34122,7 +34223,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -34206,7 +34308,9 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/firstaid/adv,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -34221,10 +34325,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -34239,7 +34347,9 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -34362,7 +34472,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -34391,7 +34503,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/fulton_core,
@@ -34618,7 +34732,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34909,11 +35025,6 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Medical Substation Bypass"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "oHw" = (
@@ -35182,7 +35293,9 @@
 /turf/simulated/floor/plating,
 /area/rnd/research)
 "oME" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -35210,17 +35323,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
-"oNi" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "oNp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -35291,11 +35393,13 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/polarized/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -35317,11 +35421,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "oOF" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -35376,10 +35484,13 @@
 "oPG" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
 /obj/machinery/door/blast/shutters{
 	id = "Warden_Shutters";
 	name = "Warden Shutters"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -35619,7 +35730,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/medbay{
@@ -35653,16 +35766,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "oTp" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -35688,7 +35807,8 @@
 	name = "light switch ";
 	pixel_x = 36
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -35713,14 +35833,16 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "oVa" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -35744,7 +35866,7 @@
 	name = "Pathfinder";
 	req_one_access = list(62)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -35859,7 +35981,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35900,7 +36024,9 @@
 	})
 "oZM" = (
 /obj/structure/closet/l3closet/medical,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35927,7 +36053,8 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35969,6 +36096,16 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/cmo/quarters)
+"paM" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "paN" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -35995,7 +36132,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -36039,7 +36178,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -36081,7 +36222,9 @@
 	pixel_y = -30;
 	specialfunctions = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -36119,10 +36262,11 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/mob/living/simple_mob/animal/passive/cat/runtime,
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/mob/living/simple_mob/animal/passive/cat/runtime,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/cmo/quarters)
 "pel" = (
@@ -36903,7 +37047,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -36969,7 +37115,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -37080,7 +37228,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -37093,19 +37243,6 @@
 "pyQ" = (
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
-"pyT" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/shutters{
-	id = "Warden_Shutters";
-	name = "Warden Shutters"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/warden)
 "pyU" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -37216,7 +37353,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -37287,7 +37426,9 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9)
 "pBv" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -37346,11 +37487,6 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/external_lights)
 "pDx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Exploration Substation Bypass"
 	},
@@ -37450,7 +37586,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -37593,7 +37731,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -37674,10 +37812,14 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -37706,7 +37848,7 @@
 	c_tag = "CIV - Hangar Pad 2 Southwest";
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -37906,7 +38048,9 @@
 /obj/effect/floor_decal/corner/pink/border{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -38404,7 +38548,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -38487,7 +38631,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -38632,12 +38777,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "qct" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -38791,15 +38936,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "qdP" = (
-/obj/structure/cable/heavyduty{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/effect/zone_divider,
 /obj/structure/catwalk,
-/obj/structure/cable,
-/turf/simulated/floor/plating{
-	outdoors = 1
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
+/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "qea" = (
 /obj/machinery/door/firedoor/border_only,
@@ -38833,7 +38977,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -39004,7 +39150,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -39224,7 +39370,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -39661,18 +39809,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_8)
-"qvU" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
 "qvY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39903,7 +40039,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
@@ -39950,7 +40086,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/medbay{
@@ -40346,20 +40484,13 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "qOf" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/debriefing)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/sc/hos)
 "qOK" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -40418,7 +40549,9 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "qPf" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -40975,7 +41108,9 @@
 /obj/effect/landmark/start{
 	name = "Paramedic"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -41054,7 +41189,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -41066,7 +41203,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bmarble,
@@ -41078,7 +41217,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41096,11 +41237,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -41163,7 +41308,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41178,7 +41325,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41226,11 +41375,15 @@
 "rit" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41244,7 +41397,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41260,7 +41415,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41281,7 +41438,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41307,7 +41466,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41336,13 +41497,14 @@
 "rjL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41394,11 +41556,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
@@ -41461,7 +41627,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -41478,7 +41646,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -41519,7 +41689,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41559,7 +41731,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41599,7 +41773,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
 "rpD" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -41615,10 +41791,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41651,7 +41831,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41660,7 +41842,9 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/heads/sc/cmo)
 "rpW" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -41710,7 +41894,8 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/table/hardwoodtable,
@@ -42054,7 +42239,8 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -42257,7 +42443,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -42429,12 +42615,6 @@
 	c_tag = "EXP - Carrier Sling";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "rFp" = (
@@ -42576,7 +42756,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -42649,10 +42831,14 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "rKc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -42699,7 +42885,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -42707,7 +42895,8 @@
 "rLC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -42878,6 +43067,21 @@
 /obj/item/weapon/book/manual/hydroponics_pod_people,
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
+"rPl" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "rPn" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -43083,7 +43287,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -43105,12 +43309,7 @@
 "rUi" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -43335,7 +43534,7 @@
 	c_tag = "CIV - Hangar Pad 2 Southeast";
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -43349,7 +43548,9 @@
 "sch" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43687,7 +43888,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -43861,7 +44064,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/network/medbay{
@@ -43954,10 +44158,14 @@
 "spH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -44127,7 +44335,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -44410,7 +44618,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -44570,7 +44778,7 @@
 /area/surface/outpost/civilian/emergency_storage)
 "sAI" = (
 /obj/machinery/photocopier/faxmachine,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -44672,7 +44880,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "sCa" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44841,7 +45051,9 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -44893,7 +45105,9 @@
 "sGt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -44959,7 +45173,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -45013,7 +45227,7 @@
 /turf/simulated/floor/bmarble,
 /area/surface/outpost/main/dorms/dorm_9)
 "sJV" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -45027,7 +45241,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "sKw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -45140,7 +45354,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -45320,7 +45536,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -45530,7 +45748,7 @@
 "sUk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/expoutpost/debriefing)
 "sUt" = (
@@ -45776,7 +45994,9 @@
 "sZy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -46300,7 +46520,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -46537,12 +46759,14 @@
 "tqM" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -46580,16 +46804,15 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
 "tsy" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
-	d1 = 4;
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced/polarized/full,
 /turf/simulated/floor/plating,
@@ -47316,7 +47539,8 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -47456,7 +47680,7 @@
 /turf/simulated/floor/wood,
 /area/hallway/primary/thirddeck/stationgateway)
 "tGc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -47478,7 +47702,7 @@
 	id_tag = "needle_dock";
 	pixel_x = -26
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -47629,7 +47853,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -47646,22 +47872,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/cryo)
-"tIA" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "tIK" = (
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
@@ -47854,7 +48064,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -48261,7 +48473,7 @@
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "tXN" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -48474,6 +48686,23 @@
 /obj/item/weapon/flag,
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/path/plains)
+"ucl" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
 /area/surface/outside/path/plains)
 "ucD" = (
 /obj/structure/railing/grey,
@@ -48944,7 +49173,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -48972,7 +49203,7 @@
 	icon_state = "markerburgundy-on";
 	picked_color = "Burgundy"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -48997,10 +49228,6 @@
 	RCon_tag = "Substation - Medical"
 	},
 /obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "upx" = (
@@ -49137,7 +49364,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "utb" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49161,10 +49390,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49179,13 +49412,17 @@
 /obj/effect/landmark/start{
 	name = "Chemist"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "utD" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49268,11 +49505,15 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49494,10 +49735,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49508,7 +49748,9 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "uBA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49531,7 +49773,8 @@
 	pixel_x = 6;
 	pixel_y = -6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -49594,7 +49837,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -49615,7 +49860,9 @@
 /turf/simulated/floor/outdoors/grass/heavy/randomgen,
 /area/surface/outside/plains/outpost)
 "uCi" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -49699,7 +49946,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -49761,7 +50010,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -49791,7 +50042,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -49818,7 +50071,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -49847,7 +50102,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -49885,7 +50142,8 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/table/reinforced,
@@ -49904,7 +50162,9 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -50086,7 +50346,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -50118,7 +50380,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/department/medbay{
@@ -50127,26 +50391,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_restroom)
-"uIT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "uJg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -50158,7 +50402,9 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/sink{
@@ -50234,7 +50480,9 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
 "uKc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -50326,7 +50574,7 @@
 "uMD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -50378,7 +50626,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -50635,6 +50885,26 @@
 	outdoors = 1
 	},
 /area/surface/outside/path/plains)
+"uSO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "uSW" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -50695,7 +50965,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -50758,14 +51028,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uVp" = (
-/obj/structure/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/mininglockerroom)
 "uVr" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8";
@@ -50785,7 +51061,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -51162,6 +51440,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/bmarble,
 /area/security/lobby)
+"vbD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "vcc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -51199,7 +51495,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -51250,7 +51546,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/vines,
@@ -51299,7 +51597,7 @@
 /obj/effect/floor_decal/stairs/dark_stairs{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -51362,7 +51660,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/filingcabinet/medical{
@@ -51390,7 +51689,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -51462,7 +51763,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -51505,7 +51806,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -51746,7 +52049,9 @@
 	outdoors = -1
 	})
 "vlH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -51881,15 +52186,14 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/surface/outpost/civilian/sauna)
 "vnQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "vof" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -52008,21 +52312,28 @@
 	dir = 4;
 	pixel_y = 32
 	},
-/obj/structure/cable/blue{
-	d2 = 8;
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
 	icon_state = "16-0"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
 /area/medical/sleeper)
 "vqz" = (
+/obj/structure/railing/grey,
 /turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost{
-	outdoors = -1
-	})
+/area/surface/outside/plains/outpost)
 "vqI" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
@@ -52105,7 +52416,9 @@
 "vrc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -52304,7 +52617,8 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -52524,12 +52838,14 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "vyD" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -52608,7 +52924,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -52795,6 +53113,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
+"vEm" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -53077,21 +53411,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/path/plains)
-"vLv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "vLJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53239,12 +53558,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -53613,7 +53932,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/bed/chair/office/light{
@@ -53628,7 +53949,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -53771,7 +54094,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -53870,7 +54195,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -53953,7 +54280,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo)
 "wcI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -54040,9 +54367,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
@@ -54556,7 +54880,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -54688,7 +55012,9 @@
 /obj/effect/floor_decal/corner/pink/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -55019,7 +55345,8 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -55107,7 +55434,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55177,7 +55504,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55439,14 +55766,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
-"wGt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/sc/hos)
 "wGA" = (
 /obj/structure/boxingrope{
 	dir = 8
@@ -55497,7 +55816,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -55528,7 +55849,7 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_1)
 "wJb" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -55689,7 +56010,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -55717,7 +56038,7 @@
 "wLZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/expoutpost/prep/recovery)
 "wMu" = (
@@ -55737,7 +56058,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -55762,6 +56085,29 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
+"wOB" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "hosoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/hos)
 "wPd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55819,7 +56165,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -55833,7 +56181,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -56052,9 +56400,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
 "wWK" = (
@@ -56119,15 +56464,11 @@
 /area/medical/medical_lockerroom)
 "wZd" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/cable/green,
 /obj/structure/window/reinforced/polarized/full,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -56239,7 +56580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/blue,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_restroom)
 "xaG" = (
@@ -56426,7 +56767,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -56821,7 +57164,9 @@
 /area/engineering/foyer)
 "xkG" = (
 /obj/structure/table/woodentable,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -57026,7 +57371,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -57137,7 +57484,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -57518,7 +57867,9 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
 "xvA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -57588,7 +57939,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -57674,9 +58027,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
@@ -57814,7 +58164,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -57887,23 +58237,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/thirddeck/stationgateway)
-"xAr" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/blast/shutters{
-	id = "Warden_Shutters";
-	name = "Warden Shutters"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/warden)
 "xAC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
@@ -58101,7 +58434,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -58109,7 +58442,9 @@
 /obj/effect/landmark/start{
 	name = "Pathfinder"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -58264,18 +58599,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "xGd" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/thor/planetuse,
-/area/surface/outside/path/plains)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost)
 "xGB" = (
 /obj/structure/railing/grey,
 /obj/structure/table/rack/shelf/steel,
@@ -58495,9 +58823,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
 /obj/machinery/vending/blood,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -58508,7 +58833,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -58696,7 +59023,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -59010,13 +59337,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -59056,7 +59380,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -59231,11 +59555,12 @@
 /area/medical/medical_lockerroom)
 "xVD" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/sleeper)
 "xVT" = (
@@ -59497,14 +59822,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "ybn" = (
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/wood/alt/parquet,
+/area/library)
 "ybp" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
@@ -77707,9 +78032,9 @@ sYa
 sYa
 sYa
 sYa
-vqz
-vqz
-vqz
+izx
+izx
+izx
 mCZ
 mCZ
 eUh
@@ -77965,8 +78290,8 @@ vtd
 sYa
 sYa
 tgb
-vqz
-vqz
+izx
+izx
 mCZ
 mCZ
 eUh
@@ -78224,14 +78549,14 @@ uav
 iGL
 srG
 iGL
-uVp
-uVp
-lba
+vnQ
+vnQ
+qdP
 sop
-uVp
-uVp
-uVp
-qvU
+vnQ
+vnQ
+vnQ
+evm
 ybp
 ybp
 rLe
@@ -79516,7 +79841,7 @@ wtQ
 wNP
 wDK
 mCZ
-joo
+bkB
 ybp
 xZf
 xZf
@@ -79773,7 +80098,7 @@ wNP
 wNP
 wDK
 mCZ
-joo
+bkB
 ybp
 xZf
 xZf
@@ -80030,7 +80355,7 @@ wDK
 wDK
 wDK
 ttz
-joo
+bkB
 ybp
 uPu
 xZf
@@ -81057,8 +81382,8 @@ rGo
 lWU
 ksN
 gaF
-cRW
-cRW
+uVp
+uVp
 vgP
 ibD
 tUO
@@ -81864,7 +82189,7 @@ dzd
 oRY
 xin
 uos
-uos
+ybn
 eCy
 hwZ
 xZN
@@ -83408,8 +83733,8 @@ wvo
 xWe
 ait
 tAX
-izx
-aio
+fgo
+bGP
 fgv
 rLe
 rLe
@@ -83666,7 +83991,7 @@ rxk
 cnD
 tAX
 hWe
-sWR
+aio
 rLe
 rLe
 rLe
@@ -83922,7 +84247,7 @@ wvo
 cWm
 jIW
 tAX
-rLe
+vQW
 kwI
 rLe
 rLe
@@ -86668,7 +86993,7 @@ ggn
 gEU
 hmU
 hKO
-cnP
+vbD
 hZu
 fyz
 hZu
@@ -86925,7 +87250,7 @@ ggy
 gFN
 lgT
 hKV
-ibZ
+iRJ
 hZu
 hZu
 hZu
@@ -87182,7 +87507,7 @@ fJx
 gHM
 hmL
 hLe
-fsU
+ibZ
 wEa
 hZu
 hZu
@@ -87471,7 +87796,7 @@ vSO
 vSO
 vSO
 vSO
-vLv
+bQd
 vSO
 vSO
 vSO
@@ -87728,7 +88053,7 @@ hvF
 hvF
 rxJ
 scm
-tIA
+vEm
 scm
 scm
 ssM
@@ -87953,7 +88278,7 @@ dVX
 gIM
 lgT
 hLM
-uIT
+uSO
 wEa
 wry
 wry
@@ -88210,7 +88535,7 @@ dVX
 gKg
 hnC
 hOK
-fsU
+ibZ
 ixW
 ygw
 wEa
@@ -89486,7 +89811,7 @@ ceP
 ckF
 iSB
 nyZ
-pyT
+oPG
 eoe
 fZx
 fmH
@@ -89743,7 +90068,7 @@ cfp
 ckF
 cRk
 nzv
-xAr
+dST
 eoD
 tAb
 fnm
@@ -90513,8 +90838,8 @@ bHZ
 ckF
 cyw
 ckF
-kqk
-oPG
+gnc
+paM
 epY
 eSV
 ftn
@@ -90558,7 +90883,7 @@ tqv
 daA
 swv
 dFz
-xGd
+fsU
 yeV
 yeV
 jZn
@@ -91018,9 +91343,9 @@ lfc
 lfc
 lfc
 tgb
-fLJ
+aCZ
 aFO
-wGt
+qOf
 bcU
 bst
 bIn
@@ -91275,7 +91600,7 @@ tgb
 lfc
 tgb
 tgb
-aCZ
+wOB
 aHy
 aQr
 bel
@@ -93372,8 +93697,8 @@ rST
 tzW
 uqD
 uqD
-fEI
-haq
+ucl
+gUa
 yeV
 yeV
 tmx
@@ -94144,7 +94469,7 @@ rLe
 hra
 ygw
 wry
-oNi
+fva
 yeV
 xHD
 iGO
@@ -94399,8 +94724,8 @@ wEa
 hra
 rLe
 xpb
-jok
-eVE
+cRW
+xGd
 ydT
 yeV
 xHD
@@ -94654,11 +94979,11 @@ mCZ
 mCZ
 mCZ
 mCZ
-ivp
-bQd
-hug
-qdP
-bkB
+vqz
+rPl
+akZ
+lZN
+dJg
 yeV
 xHD
 iGO
@@ -97205,7 +97530,7 @@ dfk
 dfk
 fgv
 rLe
-rLe
+eVE
 iRF
 jAu
 jXJ
@@ -97463,7 +97788,7 @@ kGW
 fgv
 fgv
 iiF
-iRJ
+iRX
 uCw
 jYM
 kLd
@@ -101338,7 +101663,7 @@ sjS
 sjS
 tMJ
 uBb
-vnQ
+vpj
 wec
 wWC
 xwS
@@ -104692,7 +105017,7 @@ mCZ
 rLe
 mCZ
 mCZ
-ybn
+xZh
 mCZ
 mCZ
 tJc
@@ -104949,7 +105274,7 @@ mCZ
 mCZ
 mCZ
 mCZ
-ybn
+xZh
 mCZ
 mCZ
 tJc
@@ -111888,7 +112213,7 @@ ued
 iQW
 hvL
 niO
-qOf
+rUi
 rxu
 vNh
 vNh
@@ -112145,7 +112470,7 @@ ued
 jqA
 sOQ
 niO
-qOf
+rUi
 rxu
 ybp
 ybp
@@ -112402,7 +112727,7 @@ enG
 wVf
 wVf
 enG
-qOf
+rUi
 qbu
 ybp
 ybp

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -27,6 +27,14 @@
 "aaw" = (
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
+"aaD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "aaN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -694,9 +702,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "aqM" = (
@@ -3982,22 +3988,6 @@
 /obj/item/weapon/material/shard/shrapnel,
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/main/landing/two)
-"bZI" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	icon_state = "16-0";
-	d1 = 16;
-	d2 = 0
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/engineer_hallway)
 "bZO" = (
 /turf/simulated/wall/r_wall,
 /area/security/security_processing)
@@ -6131,10 +6121,19 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
 "cJW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -19412,19 +19411,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "hTU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/hallway/engineer_hallway)
 "hUa" = (
 /obj/item/weapon/flag,
 /obj/effect/zone_divider,
@@ -21331,17 +21319,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "iHc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/structure/railing,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 32;
+	d2 = 4;
+	icon_state = "32-4"
 	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/workshop)
 "iHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23353,9 +23350,6 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 4
 	},
@@ -23366,6 +23360,17 @@
 	d1 = 32;
 	d2 = 2;
 	icon_state = "32-2"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -28324,8 +28329,13 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
 "lHS" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/hallway/engineer_hallway)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "lHV" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
@@ -30040,14 +30050,6 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
-"mvE" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
 "mvU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -30129,6 +30131,24 @@
 /area/surface/outpost/wall)
 "mxj" = (
 /obj/structure/railing/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "mxU" = (
@@ -32075,8 +32095,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main)
 "nkH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -33115,14 +33138,19 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/secondary/cryostorage_hallway)
 "nKV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
+/area/engineering/hallway/atmos_hallway)
 "nLa" = (
 /obj/effect/floor_decal/emblem/nt2,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -34605,8 +34633,8 @@
 	dir = 8
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Engineering Subgrid";
-	name_tag = "Engineering Subgrid"
+	name = "Powernet Sensor - Master Grid";
+	name_tag = "Master"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -35278,6 +35306,12 @@
 	dir = 1
 	},
 /obj/structure/railing/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "oNR" = (
@@ -39981,6 +40015,15 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"qFq" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "qFS" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/psych)
@@ -42898,6 +42941,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "rPv" = (
@@ -44247,19 +44291,19 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
 "sul" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/structure/cable{
-	d1 = 1;
+/obj/structure/cable/green{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -44877,6 +44921,14 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Lighting Subgrid";
+	name_tag = "Engineering Subgrid"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/external_lights)
 "sGt" = (
@@ -45271,6 +45323,11 @@
 	dir = 8
 	},
 /obj/structure/railing/grey,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "sPE" = (
@@ -45808,6 +45865,11 @@
 	dir = 1
 	},
 /obj/structure/railing/grey,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "tai" = (
@@ -45819,6 +45881,11 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -53353,26 +53420,21 @@
 	},
 /area/surface/outside/plains/outpost)
 "vTi" = (
-/obj/structure/lattice,
-/obj/structure/railing{
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/railing,
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 4;
-	icon_state = "32-4"
+/obj/structure/cable/cyan{
+	icon_state = "16-0";
+	d1 = 16;
+	d2 = 0
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 4
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 4
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/engineering/workshop)
+/turf/simulated/floor/plating,
+/area/engineering/hallway/engineer_hallway)
 "vTj" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/light_switch{
@@ -75628,9 +75690,9 @@ ygj
 rLe
 hQZ
 gBS
-iHc
-hTU
-cJW
+sul
+nKV
+lHS
 gBS
 sqM
 nxV
@@ -75887,9 +75949,9 @@ qAQ
 wcw
 qDe
 rzh
-mvE
-sul
-nKV
+aaD
+cJW
+qFq
 sYa
 sYa
 sYa
@@ -78207,7 +78269,7 @@ uMn
 vtR
 woc
 vtd
-vTi
+iHc
 yag
 cCP
 hDM
@@ -80255,7 +80317,7 @@ oOQ
 oOQ
 oOQ
 oOQ
-bZI
+vTi
 suJ
 fWW
 eFA
@@ -81028,7 +81090,7 @@ qLd
 oOQ
 nWc
 ujc
-lHS
+hTU
 eFA
 uVm
 vCn
@@ -81285,7 +81347,7 @@ oTY
 oOQ
 ugF
 nPC
-lHS
+hTU
 eFA
 xFu
 yaQ

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -28,10 +28,19 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
 "aaD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -66,10 +75,10 @@
 /turf/simulated/floor/outdoors/grass/heavy/randomgen,
 /area/surface/outside/plains/normal)
 "aaX" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/cryopod{
 	pixel_x = 32
@@ -953,8 +962,8 @@
 /obj/structure/railing/grey,
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1013,7 +1022,9 @@
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "aAm" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -1081,7 +1092,9 @@
 /obj/machinery/door/airlock/glass{
 	name = "Gym"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
@@ -1196,7 +1209,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "aFO" = (
@@ -1709,14 +1722,16 @@
 	},
 /area/surface/outside/path/plains)
 "aTm" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	opacity = 1
-	},
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
+	icon_state = "32-8"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
 /area/surface/outside/plains/outpost)
 "aUl" = (
 /turf/simulated/wall/r_wall,
@@ -1896,7 +1911,7 @@
 	c_tag = "CIV - Cafeteria East";
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2248,7 +2263,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main)
 "bky" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -2465,7 +2482,9 @@
 /area/assembly/robotics)
 "bnC" = (
 /obj/machinery/scale,
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/white{
@@ -3032,9 +3051,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -3136,7 +3152,7 @@
 /area/hydroponics)
 "bEi" = (
 /obj/item/weapon/stool/padded,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3988,6 +4004,15 @@
 /obj/item/weapon/material/shard/shrapnel,
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/main/landing/two)
+"bZI" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "bZO" = (
 /turf/simulated/wall/r_wall,
 /area/security/security_processing)
@@ -4283,7 +4308,7 @@
 /obj/effect/landmark/start{
 	name = "Botanist"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4374,6 +4399,11 @@
 	name = "Sauna"
 	},
 /obj/structure/fans/tiny,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/civilian/sauna)
 "cik" = (
@@ -5794,7 +5824,7 @@
 "cEQ" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/mob_spawner/mouse_nest,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6121,19 +6151,10 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
 "cJW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -6871,7 +6892,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/hallway)
 "cYo" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6891,7 +6912,9 @@
 /obj/structure/bed/chair/backed_red{
 	dir = 4
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
@@ -8665,15 +8688,14 @@
 /area/medical/cryo/autoresleeve)
 "dIU" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -8772,7 +8794,7 @@
 /area/chapel/office)
 "dKL" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8817,7 +8839,7 @@
 /area/holodeck_control)
 "dLr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8860,7 +8882,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "dMR" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -9752,7 +9774,10 @@
 /area/surface/outside/path/plains)
 "eeL" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -9841,7 +9866,7 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "egY" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -9877,7 +9902,7 @@
 	req_access = list(28)
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -9960,7 +9985,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_processing)
 "ekO" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -10964,10 +10991,15 @@
 /area/shuttle/minoutpost/base)
 "eAI" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
 /area/hallway/primary/thirddeck/stationgateway)
@@ -11143,7 +11175,7 @@
 "eFf" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/bed/chair/sofa/left/orange,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11274,12 +11306,12 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "eIv" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11360,7 +11392,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/suit_cycler/medical,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11542,7 +11574,7 @@
 /area/rnd/research_lockerroom)
 "ePs" = (
 /obj/item/weapon/stool/padded,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11794,7 +11826,9 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9)
 "eTj" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -12300,7 +12334,9 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
 "fcq" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -12509,7 +12545,7 @@
 	name = "Security Hardsuits";
 	req_access = list(1)
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -12526,7 +12562,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/lobby)
 "ffw" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12537,12 +12573,12 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "ffz" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13100,7 +13136,9 @@
 /area/surface/outpost/main/dorms/dorm_4)
 "frO" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/orange{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13669,7 +13707,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "fEq" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -14459,11 +14497,6 @@
 	c_tag = "EXT - Civ Bar/Kitchen West 2";
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "6-8";
-	d1 = 6;
-	d2 = 8
-	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -14518,6 +14551,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
@@ -15644,7 +15680,7 @@
 	name = "Engineering Hardsuits";
 	req_one_access = list(11,24)
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -15685,17 +15721,17 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "gvV" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -15734,7 +15770,7 @@
 /area/library)
 "gwl" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -15803,15 +15839,14 @@
 /area/expoutpost/prep)
 "gxN" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -16235,11 +16270,6 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Dorms Substation Bypass"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "gHM" = (
@@ -16381,7 +16411,7 @@
 /area/surface/outpost/civilian/sauna)
 "gKP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17467,10 +17497,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Dorms"
 	},
@@ -17483,12 +17509,11 @@
 /area/ai_monitored/storage/eva)
 "hgg" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable,
+/obj/structure/cable/green,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 1;
+/obj/structure/cable/green{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
@@ -17822,7 +17847,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -18004,7 +18031,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -18110,7 +18137,9 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/rnd/research)
 "hsW" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -18159,7 +18188,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18400,7 +18429,7 @@
 "hyg" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18516,7 +18545,7 @@
 /area/surface/outside/plains/outpost)
 "hzk" = (
 /obj/item/weapon/stool/padded,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -18767,7 +18796,7 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "hFT" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18983,7 +19012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -19149,13 +19178,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
 "hOG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -19411,8 +19435,15 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "hTU" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/hallway/engineer_hallway)
+/obj/structure/cable/green{
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "hUa" = (
 /obj/item/weapon/flag,
 /obj/effect/zone_divider,
@@ -19451,11 +19482,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -19697,7 +19723,7 @@
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Hardsuits"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -20663,11 +20689,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/foyer)
 "iuE" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
@@ -20698,32 +20719,17 @@
 	c_tag = "EXT - Engineering North 6";
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-5";
-	d1 = 1;
-	d2 = 5
-	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
 /area/engineering/foyer)
 "ivu" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -20734,11 +20740,6 @@
 /obj/structure/table/reinforced,
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/camera/network/command{
 	c_tag = "COM - EVA South";
@@ -22124,7 +22125,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -22240,10 +22241,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/fans/tiny,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ai_monitored/storage/eva)
@@ -22357,7 +22368,15 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "jcL" = (
 /obj/machinery/camera/network/exterior{
@@ -23479,7 +23498,7 @@
 "jHY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24736,15 +24755,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
 "khQ" = (
+/obj/structure/bed/padded,
 /obj/structure/cable/green{
-	d1 = 32;
-	d2 = 8;
-	icon_state = "32-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/plating,
+/area/surface/outpost/civilian/emergency_storage)
 "khY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25236,7 +25254,7 @@
 	d1 = 4;
 	d2 = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25504,7 +25522,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -25669,7 +25687,9 @@
 /obj/structure/bed/chair/backed_red{
 	dir = 8
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start{
@@ -25683,11 +25703,6 @@
 "kBb" = (
 /obj/machinery/station_map{
 	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "6-9";
-	d1 = 6;
-	d2 = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -26145,13 +26160,6 @@
 /obj/machinery/suit_cycler/medical,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
-"kNg" = (
-/obj/structure/fitness/punchingbag,
-/obj/structure/cable/pink{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/surface/outpost/main/gym)
 "kNj" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8";
@@ -26245,16 +26253,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "kQH" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/secondary/cryostorage_hallway)
+/turf/simulated/floor/wood/alt/panel,
+/area/surface/outpost/civilian/sauna)
 "kQN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27761,7 +27766,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -28180,6 +28185,12 @@
 /obj/effect/landmark{
 	name = "JoinLateCryo"
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/cryostorage_hallway)
 "lEV" = (
@@ -28329,13 +28340,8 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
 "lHS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/hallway/engineer_hallway)
 "lHV" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
@@ -28758,7 +28764,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "lRo" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -28808,6 +28814,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -29134,7 +29145,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "mam" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29147,6 +29160,7 @@
 	c_tag = "EXT - Gym North 4";
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -29348,21 +29362,6 @@
 	},
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
-"mgN" = (
-/obj/structure/cable/green{
-	icon_state = "2-9";
-	d1 = 2;
-	d2 = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "mhw" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -29878,14 +29877,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
 "msl" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/pink{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -29940,7 +29940,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "msS" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -30050,6 +30050,20 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
+"mvE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "mvU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -30507,7 +30521,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "mEZ" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -30533,6 +30549,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -30670,11 +30691,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -31568,22 +31584,14 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "mZv" = (
-/obj/structure/cable/pink{
-	icon_state = "4-8"
+/obj/structure/flora/ausbushes/grassybush{
+	opacity = 1
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/zone_divider,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "mZJ" = (
 /obj/effect/floor_decal/rust,
@@ -31801,7 +31809,9 @@
 /area/surface/outside/path/plains)
 "nfc" = (
 /obj/structure/table/woodentable,
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/white{
@@ -33009,14 +33019,18 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "nIm" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/fancy{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "nJs" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/folder/yellow,
@@ -33138,19 +33152,14 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/secondary/cryostorage_hallway)
 "nKV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/flora/ausbushes/grassybush{
+	opacity = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/railing/grey{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
 "nLa" = (
 /obj/effect/floor_decal/emblem/nt2,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -33633,7 +33642,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -34380,11 +34389,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating{
 	outdoors = 1
@@ -35188,9 +35192,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "oLV" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -35485,11 +35489,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction,
@@ -36019,17 +36018,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/foyer)
-"pbb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/hallway/primary/thirddeck/stationgateway)
 "pbk" = (
 /obj/machinery/door/airlock/medical{
 	name = "Autoresleever Access";
@@ -36471,7 +36459,7 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -36762,7 +36750,7 @@
 	},
 /area/surface/outside/path/plains)
 "psR" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -37686,7 +37674,7 @@
 /obj/machinery/computer/HolodeckControl{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -37722,6 +37710,7 @@
 /obj/structure/flora/ausbushes/grassybush{
 	opacity = 1
 	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "pLO" = (
@@ -37949,7 +37938,9 @@
 /area/surface/outpost/main/dorms/dorm_7)
 "pPY" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/white{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating{
@@ -38289,11 +38280,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -39247,7 +39233,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -39514,9 +39500,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "qrC" = (
@@ -39535,8 +39518,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
@@ -39547,7 +39532,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -39570,9 +39557,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
@@ -39640,9 +39624,6 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "qsR" = (
@@ -39667,24 +39648,28 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "qtP" = (
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "16-0";
+	d1 = 16;
+	d2 = 0
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/surface/outpost/main/garage)
+/area/engineering/hallway/engineer_hallway)
 "qtR" = (
 /obj/random/mob/mouse,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
-	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
@@ -39740,9 +39725,6 @@
 /obj/effect/floor_decal/rust/color_rusted{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "qwp" = (
@@ -39758,25 +39740,28 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/rnd/research)
 "qwS" = (
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/turf/simulated/wall,
-/area/surface/outpost/main/garage)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "qxh" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/expoutpost/debriefing)
-"qxp" = (
-/obj/structure/cable/blue{
-	icon_state = "32-8"
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "qxA" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -40016,14 +40001,9 @@
 	},
 /area/surface/outside/plains/outpost)
 "qFq" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/pipedispenser/disposal,
 /turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
+/area/engineering/engine_eva)
 "qFS" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/psych)
@@ -40427,12 +40407,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -40460,7 +40440,9 @@
 "qPd" = (
 /obj/effect/floor_decal/rust,
 /obj/random/tech_supply,
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -40528,6 +40510,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/machinery/disposal,
 /turf/simulated/floor/plating/thor/planetuse,
 /area/surface/outside/path/plains)
 "qRw" = (
@@ -40563,7 +40546,7 @@
 /area/quartermaster/mininglockerroom)
 "qSr" = (
 /obj/random/tech_supply,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -40848,7 +40831,7 @@
 	},
 /area/surface/outside/path/plains)
 "qYW" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -41174,14 +41157,14 @@
 /area/shuttle/needle)
 "rfp" = (
 /obj/structure/cable/green{
-	icon_state = "4-5";
-	d1 = 4;
-	d2 = 5
+	icon_state = "5-6";
+	d1 = 5;
+	d2 = 6
 	},
 /obj/structure/cable/green{
-	icon_state = "4-10";
-	d1 = 4;
-	d2 = 10
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -41933,13 +41916,8 @@
 	anchored = 1;
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/rust/color_rusted,
 /obj/structure/loot_pile/maint/technical,
-/obj/structure/cable/blue,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "rtc" = (
@@ -41988,6 +41966,11 @@
 /area/surface/outpost/mining_main/refinery)
 "rtZ" = (
 /obj/effect/floor_decal/rust/color_rusted,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "rut" = (
@@ -42445,9 +42428,18 @@
 	},
 /area/maintenance/substation/command)
 "rDp" = (
-/obj/machinery/pipedispenser/disposal,
-/turf/simulated/floor/plating,
-/area/engineering/engine_eva)
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "rDV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43474,10 +43466,6 @@
 	id = "sauna_tint2"
 	},
 /obj/structure/cable/heavyduty,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -43785,6 +43773,11 @@
 "skE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/civilian/sauna)
@@ -44111,9 +44104,6 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "sqM" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
@@ -44121,6 +44111,14 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable/heavyduty{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
@@ -44170,7 +44168,7 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "ssv" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -44291,22 +44289,20 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
 "sul" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	icon_state = "2-9";
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 9
 	},
-/turf/simulated/floor/plating,
-/area/engineering/hallway/atmos_hallway)
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "sur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44344,6 +44340,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hallway/engineer_hallway)
 "suQ" = (
@@ -44598,9 +44595,9 @@
 /area/maintenance/substation/firstdeck/cargo)
 "sAE" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
@@ -44671,7 +44668,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -44893,20 +44890,15 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sFn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 6;
+	icon_state = "1-6"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "sFu" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -45089,11 +45081,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -45155,11 +45142,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -45211,7 +45193,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -45225,7 +45207,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -45245,11 +45227,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/kitchen)
 "sOc" = (
@@ -45266,19 +45243,21 @@
 /turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
 "sOK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "6-9";
+	d1 = 6;
+	d2 = 9
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/area/surface/outside/path/plains)
 "sOQ" = (
 /obj/item/weapon/pen/blue,
 /obj/structure/table/hardwoodtable,
@@ -45447,7 +45426,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/green,
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/device/multitool,
 /turf/simulated/floor/tiled/hydro,
@@ -46024,16 +46003,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna)
 "tdh" = (
-/obj/structure/cable/yellow{
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -46141,7 +46115,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -46737,7 +46711,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "tum" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46815,7 +46789,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46823,7 +46797,7 @@
 /mob/living/simple_mob/animal/goat{
 	name = "Pete"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -46848,7 +46822,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46867,7 +46841,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46897,11 +46871,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46967,7 +46936,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46999,7 +46968,9 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/medical/foyer)
 "tvT" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -47022,7 +46993,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research_restroom_sc)
 "twk" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -47169,7 +47140,7 @@
 /area/surface/outside/path/plains)
 "tzr" = (
 /obj/machinery/light/no_nightshift,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -47270,13 +47241,11 @@
 /turf/simulated/wall/bay/purple,
 /area/surface/outpost/main/dorms/dorm_6)
 "tBc" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
+/area/ai_monitored/storage/eva)
 "tBi" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Locker Room";
@@ -47451,6 +47420,11 @@
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/civilian/sauna)
 "tED" = (
@@ -47562,7 +47536,7 @@
 "tGw" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -48342,13 +48316,16 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/civilian/sauna)
@@ -48870,7 +48847,7 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
 "ukA" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -48880,7 +48857,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "ukO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -48892,7 +48869,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "ulx" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -48950,7 +48927,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "unl" = (
-/obj/structure/cable/orange{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/rust,
@@ -48965,7 +48944,7 @@
 	},
 /area/surface/outside/path/plains)
 "uno" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -49000,18 +48979,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -49911,9 +49885,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "uGd" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -50092,7 +50063,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/suit_cycler/exploration,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -50225,17 +50196,6 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
-"uJA" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "uJG" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -50464,7 +50424,7 @@
 	icon_state = "pipe-j2"
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -50523,9 +50483,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/research)
 "uPc" = (
-/obj/structure/cable/pink{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
@@ -51124,7 +51081,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -51545,6 +51502,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/mininglockerroom)
 "vgV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/civilian/sauna)
 "vhp" = (
@@ -51586,7 +51548,7 @@
 	icon_state = "pipe-j2"
 	},
 /obj/item/device/radio/beacon,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -51968,9 +51930,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
 "vpi" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Gym"
 	},
@@ -52309,7 +52268,9 @@
 /turf/simulated/wall,
 /area/engineering/workshop)
 "vtG" = (
-/obj/structure/cable/orange{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -52513,11 +52474,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/dorms/dorm_9)
 "vwI" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
-	},
+/obj/structure/cable/heavyduty,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -52618,7 +52575,8 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/white{
@@ -52646,23 +52604,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "vzI" = (
-/obj/structure/railing/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/hallway/engineer_hallway)
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "vAp" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -52704,7 +52652,7 @@
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -52763,7 +52711,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research_restroom_sc)
 "vCI" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -53129,16 +53079,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
 "vKE" = (
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
+	icon_state = "32-8"
+	},
+/obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating{
+/turf/simulated/open{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -53174,13 +53125,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "vLU" = (
-/obj/structure/cable/pink{
-	icon_state = "32-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ai_monitored/storage/eva)
 "vMt" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Library East 1";
@@ -53195,7 +53147,7 @@
 "vMZ" = (
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -53320,18 +53272,14 @@
 	name = "Exploration Substation"
 	})
 "vQW" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/flora/ausbushes/grassybush{
+	opacity = 1
 	},
-/obj/structure/cryofeed,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/secondary/cryostorage_hallway)
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
 "vQX" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/shipsensors/weak,
@@ -53349,7 +53297,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -53421,19 +53369,21 @@
 /area/surface/outside/plains/outpost)
 "vTi" = (
 /obj/structure/railing/grey,
-/obj/structure/railing/grey{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "16-0";
-	d1 = 16;
-	d2 = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "vTj" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -53452,7 +53402,7 @@
 /area/crew_quarters/bar)
 "vTx" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -54136,7 +54086,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -54442,7 +54392,7 @@
 	name = "Cryogenic Storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -54475,7 +54425,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "wlT" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
@@ -54635,7 +54587,9 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "wor" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55111,7 +55065,7 @@
 	},
 /area/storage/primary)
 "wyW" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55130,7 +55084,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/holodeck_control)
 "wzn" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -55198,7 +55154,7 @@
 /area/engineering/hallway/engineer_hallway)
 "wAt" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -55274,7 +55230,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55324,7 +55280,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55341,7 +55297,7 @@
 /obj/effect/landmark/start{
 	name = "Botanist"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55822,9 +55778,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "wPd" = (
-/obj/structure/cable/pink{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -56006,7 +55959,9 @@
 	},
 /area/surface/outpost/main/dorms/dorm_1)
 "wTR" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56020,7 +55975,7 @@
 "wUt" = (
 /obj/effect/floor_decal/stairs/dark_stairs,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -57253,7 +57208,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -57281,7 +57236,7 @@
 /area/surface/outpost/main/dorms/dorm_3)
 "xrz" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -57930,7 +57885,7 @@
 /turf/simulated/wall/bay/green,
 /area/surface/outpost/main/dorms/dorm_8)
 "xAm" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -58312,13 +58267,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/yellow,
 /obj/structure/cable/green{
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -59494,7 +59448,7 @@
 /area/library)
 "xZP" = (
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -59574,12 +59528,6 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/surface/outpost/civilian/sauna)
-"ybO" = (
-/obj/structure/cable/pink{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/surface/outpost/main/gym)
 "ybR" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/alarm{
@@ -60030,9 +59978,6 @@
 	},
 /area/surface/outside/path/plains)
 "yjt" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -61583,7 +61528,7 @@ isN
 uCa
 piy
 ybp
-tBc
+ncJ
 ybp
 ybp
 uCa
@@ -75690,9 +75635,9 @@ ygj
 rLe
 hQZ
 gBS
-sul
-nKV
-lHS
+qwS
+mvE
+cJW
 gBS
 sqM
 nxV
@@ -75949,9 +75894,9 @@ qAQ
 wcw
 qDe
 rzh
+vzI
 aaD
-cJW
-qFq
+bZI
 sYa
 sYa
 sYa
@@ -78260,9 +78205,9 @@ oOp
 oOp
 oOp
 lWw
-rDp
-rDp
-rDp
+qFq
+qFq
+qFq
 tau
 tUp
 uMn
@@ -79037,7 +78982,7 @@ nji
 nqs
 cEC
 bNe
-vzI
+vTi
 nNd
 tWF
 uRW
@@ -79294,7 +79239,7 @@ lbA
 wJc
 pym
 bNe
-vzI
+vTi
 qiX
 tWF
 lNx
@@ -80317,7 +80262,7 @@ oOQ
 oOQ
 oOQ
 oOQ
-vTi
+qtP
 suJ
 fWW
 eFA
@@ -81090,7 +81035,7 @@ qLd
 oOQ
 nWc
 ujc
-hTU
+lHS
 eFA
 uVm
 vCn
@@ -81328,7 +81273,7 @@ rLe
 rLe
 rLe
 rLe
-rLe
+cZP
 mCZ
 mCZ
 mCZ
@@ -81347,7 +81292,7 @@ oTY
 oOQ
 ugF
 nPC
-hTU
+lHS
 eFA
 xFu
 yaQ
@@ -81584,10 +81529,10 @@ uPu
 uPu
 rLe
 rLe
-rLe
-cZP
-mCZ
-mCZ
+hus
+hus
+hus
+hus
 mCZ
 nhN
 kPi
@@ -81834,7 +81779,7 @@ rLe
 hus
 hus
 dIU
-eeL
+tBc
 hus
 hus
 hus
@@ -81842,8 +81787,8 @@ hus
 hus
 hus
 hus
-hus
-hus
+hYS
+itO
 hus
 mCZ
 nhN
@@ -82099,8 +82044,8 @@ hus
 guT
 anw
 hus
-hYS
-itO
+egj
+egj
 hus
 wJG
 nhN
@@ -82608,13 +82553,13 @@ dLr
 egp
 hus
 feY
-eeL
+tBc
 hus
 guU
-eeL
+tBc
 hus
 iai
-eeL
+tBc
 hus
 qHv
 nhN
@@ -83386,7 +83331,7 @@ hge
 hGl
 iap
 ivA
-eeL
+vLU
 yeV
 nhN
 hrE
@@ -83641,7 +83586,7 @@ hus
 gxN
 hgg
 hgg
-eeL
+tBc
 hus
 hus
 yeV
@@ -86488,8 +86433,8 @@ vSO
 vSO
 vSO
 gvZ
-vSO
-vSO
+sFn
+yeV
 ivq
 hIw
 hIw
@@ -87004,7 +86949,7 @@ sAX
 tsb
 udl
 fWl
-wqX
+sOK
 wqX
 wqX
 wqX
@@ -87262,7 +87207,7 @@ ttD
 mpQ
 mpQ
 kBb
-yeV
+hTU
 yeV
 yeV
 vcm
@@ -87519,8 +87464,8 @@ ttU
 ufr
 mpQ
 ydd
-mgN
 vSO
+sul
 vSO
 dvO
 vSO
@@ -88546,7 +88491,7 @@ mpQ
 tvo
 mpQ
 mpQ
-vLU
+iRX
 iRX
 rLe
 eiZ
@@ -89083,7 +89028,7 @@ ufS
 jto
 yfT
 qrC
-vQW
+xLI
 xLI
 xgr
 rZT
@@ -89313,7 +89258,7 @@ vNa
 mpQ
 qPb
 qnH
-sFn
+sMO
 twk
 ukA
 uWy
@@ -89340,7 +89285,7 @@ gsG
 vZy
 naX
 qrC
-kQH
+xzl
 xzl
 xgr
 gcw
@@ -90621,7 +90566,7 @@ yeV
 jZn
 hJB
 oLV
-pbb
+hvT
 lFb
 sWJ
 hJB
@@ -91370,7 +91315,7 @@ mpQ
 qWs
 qnH
 sMO
-nIm
+qnH
 tdh
 eir
 vTx
@@ -91626,7 +91571,7 @@ psQ
 mpQ
 mpQ
 rOZ
-sNS
+sMO
 txC
 upx
 mpQ
@@ -92140,7 +92085,7 @@ yeV
 puU
 mpQ
 rQR
-sOK
+tyP
 txG
 xCr
 xMw
@@ -94774,7 +94719,7 @@ cbe
 iEJ
 ajd
 rLe
-mZv
+sWR
 rLe
 rLe
 rLe
@@ -95031,7 +94976,7 @@ plr
 plr
 plr
 rLe
-mZv
+sWR
 rLe
 rLe
 rLe
@@ -95288,7 +95233,7 @@ rLe
 rLe
 rLe
 rLe
-mZv
+sWR
 rLe
 rLe
 rLe
@@ -96320,7 +96265,7 @@ bky
 xUR
 wDm
 jxH
-ybO
+wDm
 tzk
 tpI
 eYj
@@ -96577,7 +96522,7 @@ mam
 xUR
 dWc
 jxH
-ybO
+wDm
 uiP
 vrr
 vrr
@@ -96834,7 +96779,7 @@ mEZ
 xsB
 kOW
 jxH
-ybO
+wDm
 uiP
 vrr
 vrr
@@ -97091,7 +97036,7 @@ mEZ
 xsB
 vDA
 jxH
-ybO
+wDm
 uiP
 vrr
 vrr
@@ -97348,7 +97293,7 @@ mEZ
 xsB
 kOW
 jxH
-ybO
+wDm
 eKw
 oNs
 oNs
@@ -97592,15 +97537,15 @@ eTj
 eTj
 vCI
 hsW
-uJA
-uJA
-uJA
-uJA
-uJA
-uJA
-uJA
-uJA
-uJA
+khi
+khi
+khi
+khi
+khi
+khi
+khi
+khi
+khi
 wlT
 xsB
 vDA
@@ -97862,7 +97807,7 @@ rLe
 xUR
 tvR
 hSZ
-kNg
+hSZ
 euH
 wDm
 iwx
@@ -98855,7 +98800,7 @@ rHE
 gKu
 uOr
 xoK
-vgV
+kQH
 imm
 bzp
 yeV
@@ -100423,7 +100368,7 @@ eZJ
 utN
 eZJ
 sAE
-eZJ
+khQ
 mgl
 eZJ
 eHz
@@ -100679,8 +100624,8 @@ wqn
 wqn
 wqn
 wqn
-wAF
 wqn
+wAF
 xHs
 wqn
 wqn
@@ -100936,7 +100881,7 @@ rJT
 nIk
 utN
 wqn
-khQ
+fgo
 jck
 fgv
 fgv
@@ -101195,7 +101140,7 @@ daI
 wqn
 nXu
 aTm
-kxS
+mZv
 uww
 uww
 uww
@@ -101451,7 +101396,7 @@ duO
 mCu
 wqn
 iTO
-fgv
+vQW
 rLe
 rLe
 rLe
@@ -106777,7 +106722,7 @@ rLe
 ygw
 ydT
 yeV
-yeV
+kPi
 mmb
 mGe
 mZt
@@ -107034,7 +106979,7 @@ rLe
 qiD
 ydT
 yeV
-yeV
+kPi
 ujd
 mGy
 mZJ
@@ -107291,7 +107236,7 @@ rLe
 ybp
 ydT
 yeV
-yeV
+kPi
 ujd
 mGy
 nar
@@ -107548,7 +107493,7 @@ ybp
 ybp
 ydT
 yeV
-yeV
+kPi
 ujd
 mGy
 nat
@@ -107557,7 +107502,7 @@ obk
 mYp
 mYp
 nSm
-qtP
+mYp
 rwT
 mGe
 xdA
@@ -107805,7 +107750,7 @@ ybp
 ybp
 ydT
 yeV
-yeV
+kPi
 ujd
 mGy
 naL
@@ -108062,7 +108007,7 @@ ybp
 ybp
 ydT
 yeV
-yeV
+kPi
 mmx
 mGe
 naT
@@ -108319,7 +108264,7 @@ ybp
 jaB
 kPX
 yeV
-yeV
+kPi
 mVF
 mGe
 mGe
@@ -108328,7 +108273,7 @@ mGe
 mGe
 mGe
 mGe
-qwS
+mGe
 mGe
 mGe
 uPu
@@ -108576,7 +108521,7 @@ wEa
 jbS
 yeV
 yeV
-yeV
+kPi
 ujd
 qiD
 ygw
@@ -108585,7 +108530,7 @@ rLe
 lFn
 fgv
 iRX
-qxp
+iRX
 rze
 fgv
 rLe
@@ -108833,7 +108778,7 @@ jBn
 jbS
 yeV
 yeV
-yeV
+kPi
 ujd
 yeV
 yeV
@@ -108842,8 +108787,8 @@ rLe
 rLe
 fgv
 pLD
-pLD
-fgv
+oIk
+nKV
 qiD
 rLe
 rLe
@@ -109090,16 +109035,16 @@ wEa
 jbS
 dyu
 dyu
-dyu
-ujd
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
+nIm
+eVi
+vSO
+vSO
+vSO
+vSO
+vSO
+vSO
+vSO
+rDp
 yeV
 yeV
 yeV

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -27,22 +27,6 @@
 "aaw" = (
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
-"aaD" = (
-/obj/structure/cable/yellow{
-	icon_state = "32-2";
-	d1 = 32;
-	d2 = 2
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 4
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/engineering/hallway/engineer_hallway)
 "aaN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -707,8 +691,11 @@
 	outdoors = -1
 	})
 "aqq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -1523,12 +1510,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -1677,12 +1664,12 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -3897,7 +3884,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -3996,22 +3983,21 @@
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/main/landing/two)
 "bZI" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
+/obj/structure/cable/cyan{
+	icon_state = "16-0";
+	d1 = 16;
+	d2 = 0
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_eva)
+/area/engineering/hallway/engineer_hallway)
 "bZO" = (
 /turf/simulated/wall/r_wall,
 /area/security/security_processing)
@@ -4187,7 +4173,7 @@
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "cdW" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -4199,12 +4185,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -4623,7 +4609,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6144,6 +6130,14 @@
 /obj/structure/prop/blackbox,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing/two)
+"cJW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "cKc" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -6661,7 +6655,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8939,11 +8933,19 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
@@ -10519,7 +10521,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10931,12 +10933,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -11153,7 +11155,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -12040,7 +12042,7 @@
 "eXm" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12321,7 +12323,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14110,7 +14112,7 @@
 /obj/item/weapon/folder/yellow_ce,
 /obj/item/weapon/pen/multi,
 /obj/item/weapon/stamp/ce,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -14242,6 +14244,12 @@
 "fRO" = (
 /obj/structure/railing/grey{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -14918,16 +14926,11 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "gdF" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 8
@@ -15925,7 +15928,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -18275,12 +18278,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/vines,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -18731,7 +18734,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/mininglockerroom)
 "hEJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19409,21 +19412,19 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "hTU" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "16-0";
-	d1 = 16;
-	d2 = 0
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/engineering/hallway/engineer_hallway)
+/area/engineering/hallway/atmos_hallway)
 "hUa" = (
 /obj/item/weapon/flag,
 /obj/effect/zone_divider,
@@ -20421,7 +20422,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "ioS" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -20565,7 +20566,7 @@
 /area/medical/reception)
 "isd" = (
 /obj/machinery/door/airlock/atmos,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20820,7 +20821,7 @@
 	name = "Atmos Room";
 	req_one_access = list(12)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20868,7 +20869,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -21074,7 +21075,7 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/heads/sc/chief)
 "iBg" = (
@@ -21329,6 +21330,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
+"iHc" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "iHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22037,7 +22050,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "iVY" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23335,16 +23348,28 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_3)
 "jEb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/lattice,
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/railing/grey{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "32-2"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
 /area/engineering/hallway/atmos_hallway)
 "jEG" = (
 /obj/structure/table/hardwoodtable,
@@ -23871,7 +23896,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -25028,7 +25053,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
 "kpm" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -25037,6 +25062,13 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "kpo" = (
@@ -25313,7 +25345,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/heads/sc/chief)
 "ktZ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -25863,7 +25895,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26200,6 +26232,10 @@
 	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Engineering"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
@@ -26691,7 +26727,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26939,7 +26975,7 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/toolbox/electrical,
-/obj/structure/cable/yellow,
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -27316,7 +27352,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
 "lnA" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -27359,7 +27395,7 @@
 	},
 /area/surface/outside/path/plains)
 "loH" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -28125,7 +28161,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "lDO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -28416,7 +28452,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "lMK" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -28478,6 +28514,14 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -29997,16 +30041,13 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "mvE" = (
-/obj/structure/cable/yellow{
-	icon_state = "32-1";
-	d1 = 32
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost{
-	outdoors = -1
-	})
+/turf/simulated/floor/plating,
+/area/engineering/hallway/atmos_hallway)
 "mvU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -30087,12 +30128,6 @@
 /turf/simulated/floor/water,
 /area/surface/outpost/wall)
 "mxj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -31187,7 +31222,7 @@
 	name = "Outpost SMES Room";
 	req_one_access = list(11)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -31359,6 +31394,12 @@
 /obj/machinery/light/no_nightshift,
 /obj/structure/railing/grey{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -31846,12 +31887,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -32035,10 +32076,7 @@
 /area/surface/outpost/mining_main)
 "nkH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -32261,7 +32299,7 @@
 	c_tag = "ENG - Engineering Break Room";
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -32986,12 +33024,7 @@
 "nJT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -33081,6 +33114,15 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/secondary/cryostorage_hallway)
+"nKV" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "nLa" = (
 /obj/effect/floor_decal/emblem/nt2,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -33544,16 +33586,16 @@
 	},
 /area/surface/outside/path/plains)
 "nSU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
@@ -35232,12 +35274,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/reception)
 "oNP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
@@ -35772,7 +35808,7 @@
 	c_tag = "ENG - Engineering Hallway 2";
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -35848,7 +35884,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -36264,7 +36300,7 @@
 	name = "Engineering Workshop";
 	req_one_access = list(11,24)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -37342,7 +37378,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "pEg" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -38587,7 +38623,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -39380,8 +39416,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "qpV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
@@ -39851,13 +39895,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/debriefing)
 "qDn" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
@@ -39937,14 +39981,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"qFq" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_eva)
 "qFS" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/psych)
@@ -40582,10 +40618,16 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
 "qUy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -41624,12 +41666,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "rpT" = (
@@ -42168,7 +42204,7 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "rzh" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -42300,13 +42336,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "rBB" = (
-/obj/structure/cable/yellow{
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/railing/grey{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -42334,7 +42376,7 @@
 /turf/simulated/floor/bmarble,
 /area/chapel/office)
 "rCI" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -42361,15 +42403,6 @@
 /area/maintenance/substation/command)
 "rDp" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "rDV" = (
@@ -42861,10 +42894,10 @@
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "rPn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing/grey{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "rPv" = (
@@ -43616,7 +43649,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -44041,6 +44074,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outside/path/plains)
 "srb" = (
@@ -44165,6 +44202,11 @@
 /area/surface/outside/path/plains)
 "stq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "stB" = (
@@ -44205,14 +44247,22 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
 "sul" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_eva)
+/area/engineering/hallway/atmos_hallway)
 "sur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44278,11 +44328,6 @@
 /area/surface/outpost/main/dorms/dorm_1)
 "svK" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
@@ -44824,7 +44869,7 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "sGf" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -45439,7 +45484,7 @@
 	},
 /area/engineering/external_lights)
 "sSH" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -45772,6 +45817,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "tas" = (
@@ -45786,11 +45834,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
@@ -45857,11 +45900,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Station Engineer"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/locker_room)
@@ -45960,17 +45998,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -45999,7 +46032,7 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46184,7 +46217,7 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46203,7 +46236,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46245,7 +46278,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46266,7 +46299,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "tnl" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -46319,7 +46352,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -46616,7 +46649,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -48113,11 +48146,6 @@
 /area/engineering/external_lights)
 "tUp" = (
 /obj/machinery/suit_cycler/engineering,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "tUF" = (
@@ -48352,7 +48380,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -48740,7 +48768,7 @@
 "ujO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -50251,6 +50279,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "uMn" = (
@@ -50266,7 +50299,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
 "uMD" = (
@@ -50311,7 +50343,7 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -50357,12 +50389,6 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uNI" = (
@@ -50398,12 +50424,8 @@
 /turf/simulated/floor/water,
 /area/surface/outside/plains/outpost)
 "uOo" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uOr" = (
@@ -50564,6 +50586,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
 "uSy" = (
@@ -50594,7 +50624,7 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/radiation,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -52178,7 +52208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -52200,6 +52230,11 @@
 "vsZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
@@ -52226,15 +52261,15 @@
 	},
 /area/surface/outside/path/plains)
 "vtR" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
@@ -52531,12 +52566,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -52551,7 +52586,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -52617,11 +52652,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "vBI" = (
@@ -52631,7 +52661,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -53063,15 +53093,17 @@
 	},
 /area/surface/outside/path/plains)
 "vLJ" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "vLU" = (
@@ -53321,28 +53353,26 @@
 	},
 /area/surface/outside/plains/outpost)
 "vTi" = (
-/obj/structure/railing/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/lattice,
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 32;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "32-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/hallway/engineer_hallway)
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/workshop)
 "vTj" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/light_switch{
@@ -53832,7 +53862,7 @@
 "wbn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -54426,11 +54456,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/suit_storage_unit/hazmat,
 /turf/simulated/floor/plating,
 /area/engineering/engine_eva)
@@ -54446,11 +54471,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/plating,
@@ -54522,11 +54542,6 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "ENG - Atmos South";
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -54660,7 +54675,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "wqs" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54672,11 +54687,6 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
@@ -54732,7 +54742,7 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54768,7 +54778,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -54951,7 +54961,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main)
 "wxh" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54961,7 +54971,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -55525,7 +55535,7 @@
 	name = "Exploration Substation"
 	})
 "wJc" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -55775,21 +55785,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo)
 "wQt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "32-2";
-	d1 = 32;
-	d2 = 2
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
+/turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
 "wQO" = (
 /turf/simulated/wall/wood,
@@ -56336,7 +56337,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "xcs" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -56383,12 +56384,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "xcM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -56442,11 +56443,6 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/medical/cryo/autoresleeve)
 "xex" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Lighting Substation Bypass"
 	},
@@ -56473,7 +56469,7 @@
 	},
 /area/surface/outside/plains/outpost)
 "xeM" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -56553,12 +56549,12 @@
 /area/expoutpost/bathroom)
 "xfq" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -56599,7 +56595,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -57952,7 +57948,7 @@
 	},
 /area/engineering/external_lights)
 "xBl" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -57967,7 +57963,7 @@
 	c_tag = "SUBS - Colony Lighting";
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -57992,7 +57988,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -59157,8 +59153,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -59166,6 +59164,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/workshop)
@@ -59268,14 +59271,20 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "xWJ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/no_nightshift,
 /obj/structure/railing/grey{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/atmos_hallway)
@@ -59764,7 +59773,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -75619,9 +75628,9 @@ ygj
 rLe
 hQZ
 gBS
-qDe
-rzh
-qDe
+iHc
+hTU
+cJW
 gBS
 sqM
 nxV
@@ -75878,9 +75887,9 @@ qAQ
 wcw
 qDe
 rzh
-qDe
-wcw
-sYa
+mvE
+sul
+nKV
 sYa
 sYa
 sYa
@@ -77683,8 +77692,8 @@ vsR
 uLM
 vsR
 wmt
-bZI
-mvE
+rzT
+vlF
 vlF
 xyQ
 xOA
@@ -78189,16 +78198,16 @@ oOp
 oOp
 oOp
 lWw
-qFq
 rDp
-sul
+rDp
+rDp
 tau
 tUp
 uMn
 vtR
 woc
 vtd
-ldg
+vTi
 yag
 cCP
 hDM
@@ -79222,8 +79231,8 @@ lbA
 lbA
 wJc
 pym
-aaD
-vTi
+bNe
+vzI
 qiX
 tWF
 lNx
@@ -80246,7 +80255,7 @@ oOQ
 oOQ
 oOQ
 oOQ
-hTU
+bZI
 suJ
 fWW
 eFA

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -471,17 +471,6 @@
 /obj/structure/stairs/spawner/east,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
-"akZ" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "ale" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass{
@@ -893,6 +882,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/outdoors/dirt,
 /area/engineering/external_lights)
+"auN" = (
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable,
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "auP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2212,6 +2212,10 @@
 "biK" = (
 /turf/simulated/wall/r_wall,
 /area/security/security_ses)
+"biM" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost)
 "biT" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
@@ -3584,6 +3588,15 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/gym)
+"bOQ" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/library)
 "bPi" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -3623,20 +3636,23 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "bQd" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
 	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
 	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "bQr" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/borderfloor/corner,
@@ -6533,12 +6549,20 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "cRW" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing/grey{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/plains/outpost)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start{
+	name = "Shaft Miner"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/mininglockerroom)
 "cSp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6916,12 +6940,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/security/armoury)
 "cZP" = (
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - EVA West 2";
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/ai_monitored/storage/eva)
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "hosoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/hos)
 "dag" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8";
@@ -8685,12 +8725,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
-"dJg" = (
+"dJt" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/heavyduty{
 	icon_state = "1-8"
-	},
-/obj/structure/railing/grey{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -9271,23 +9316,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_5)
-"dST" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/blast/shutters{
-	id = "Warden_Shutters";
-	name = "Warden Shutters"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/warden)
 "dTe" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -9892,6 +9920,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
+"ehe" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet,
+/area/security/warden)
 "ehU" = (
 /obj/structure/railing/grey,
 /obj/machinery/camera/network/civilian{
@@ -10761,18 +10797,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
-"evm" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/path/plains)
 "evo" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -11884,6 +11908,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
+"eTJ" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost{
+	outdoors = -1
+	})
 "eTK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13074,6 +13103,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/aid_station)
+"fpI" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "fqD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/table/marble,
@@ -13152,18 +13196,15 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/lawoffice)
 "fsU" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/thor/planetuse,
-/area/surface/outside/path/plains)
+/turf/simulated/floor/plating,
+/area/security/warden)
 "fsV" = (
 /obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
@@ -13331,17 +13372,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/pathfinder)
-"fva" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "fvj" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -15401,14 +15431,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3)
-"gnc" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet,
-/area/security/warden)
 "gnD" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -16805,17 +16827,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
-"gUa" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "gUy" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -17422,6 +17433,14 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/dorms/dorm_8)
+"hdI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/sc/hos)
 "hdP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -19911,10 +19930,7 @@
 /area/crew_quarters/heads/sc/hor)
 "ibZ" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/structure/cable/green,
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "detoffice"
 	},
@@ -19924,6 +19940,16 @@
 	id = "security_lockdown";
 	name = "Security Blast Door";
 	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
@@ -20933,10 +20959,16 @@
 /turf/simulated/floor/bmarble,
 /area/chapel/main)
 "izx" = (
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost{
-	outdoors = -1
-	})
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "izC" = (
 /obj/structure/flora/tree/jungle{
 	icon_state = "tree3"
@@ -21800,30 +21832,14 @@
 	},
 /area/surface/outside/plains/outpost)
 "iRJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/structure/cable/green{
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
-/area/security/detectives_office)
+/area/surface/outside/plains/outpost)
 "iRX" = (
 /turf/simulated/open{
 	outdoors = 1
@@ -23735,6 +23751,13 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/lobby)
+"jLX" = (
+/obj/machinery/camera/network/exterior{
+	c_tag = "EXT - EVA West 2";
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/ai_monitored/storage/eva)
 "jMr" = (
 /obj/structure/stairs/spawner/north,
 /obj/structure/railing/grey{
@@ -24299,11 +24322,7 @@
 /area/crew_quarters/heads/sc/hop)
 "jVl" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Exploration";
-	charge = 2.5e+006;
-	input_attempt = 1;
-	input_level = 150000;
-	output_level = 100000
+	RCon_tag = "Substation - Exploration"
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
@@ -27882,6 +27901,16 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
+"lxe" = (
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2";
+	d1 = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "lxg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28901,6 +28930,26 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
+"lSy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "lSL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -29187,17 +29236,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
-"lZN" = (
-/obj/structure/cable/heavyduty{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable,
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "mam" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34750,6 +34788,17 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_10)
+"oxU" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "oyJ" = (
 /obj/structure/table/glass,
 /obj/item/roller{
@@ -35484,6 +35533,10 @@
 "oPG" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/machinery/door/blast/shutters{
 	id = "Warden_Shutters";
 	name = "Warden Shutters"
@@ -35896,6 +35949,13 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
+"oWV" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/plains/outpost)
 "oXs" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36096,16 +36156,6 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/cmo/quarters)
-"paM" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
-/obj/machinery/door/blast/shutters{
-	id = "Warden_Shutters";
-	name = "Warden Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/security/warden)
 "paN" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -38936,15 +38986,22 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "qdP" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "qea" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -40394,7 +40451,7 @@
 /area/janitor)
 "qLB" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Outpost/Engineering Main";
+	RCon_tag = "Engine - Main";
 	charge = 2e+007;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -40484,13 +40541,18 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "qOf" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/sc/hos)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/thor/planetuse,
+/area/surface/outside/path/plains)
 "qOK" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -43067,21 +43129,6 @@
 /obj/item/weapon/book/manual/hydroponics_pod_people,
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"rPl" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "rPn" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -45094,7 +45141,7 @@
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Lighting Subgrid";
-	name_tag = "Engineering Subgrid"
+	name_tag = "Lighting Subgrid"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -46298,6 +46345,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/sleeper)
+"thc" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "thh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -48687,23 +48745,6 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
-"ucl" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
 "ucD" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/outdoors/grass/heavy,
@@ -50885,26 +50926,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/path/plains)
-"uSO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "uSW" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -51028,20 +51049,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "uVp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start{
-	name = "Shaft Miner"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/mininglockerroom)
+/turf/simulated/floor/outdoors/dirt,
+/area/surface/outside/plains/outpost)
 "uVr" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8";
@@ -51440,24 +51452,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/bmarble,
 /area/security/lobby)
-"vbD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "detoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/security/detectives_office)
 "vcc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -52186,14 +52180,20 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/surface/outpost/civilian/sauna)
 "vnQ" = (
-/obj/structure/catwalk,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2";
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "vof" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -52331,9 +52331,17 @@
 	},
 /area/medical/sleeper)
 "vqz" = (
-/obj/structure/railing/grey,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost)
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/path/plains)
 "vqI" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
@@ -53113,22 +53121,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
-"vEm" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -56085,29 +56077,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
-"wOB" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "hosoffice"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/sc/hos)
 "wPd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58599,11 +58568,23 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "xGd" = (
-/obj/structure/railing/grey{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/plains/outpost)
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "detoffice"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/security/detectives_office)
 "xGB" = (
 /obj/structure/railing/grey,
 /obj/structure/table/rack/shelf/steel,
@@ -59822,14 +59803,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "ybn" = (
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	id = "Warden_Shutters";
+	name = "Warden Shutters"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/library)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/warden)
 "ybp" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/path/plains)
@@ -60427,6 +60412,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
+"ylW" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/obj/structure/railing/grey{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -78032,9 +78028,9 @@ sYa
 sYa
 sYa
 sYa
-izx
-izx
-izx
+eTJ
+eTJ
+eTJ
 mCZ
 mCZ
 eUh
@@ -78290,8 +78286,8 @@ vtd
 sYa
 sYa
 tgb
-izx
-izx
+eTJ
+eTJ
 mCZ
 mCZ
 eUh
@@ -78549,14 +78545,14 @@ uav
 iGL
 srG
 iGL
-vnQ
-vnQ
-qdP
+iRJ
+iRJ
+lxe
 sop
-vnQ
-vnQ
-vnQ
-evm
+iRJ
+iRJ
+iRJ
+vqz
 ybp
 ybp
 rLe
@@ -81382,8 +81378,8 @@ rGo
 lWU
 ksN
 gaF
-uVp
-uVp
+cRW
+cRW
 vgP
 ibD
 tUO
@@ -81596,7 +81592,7 @@ rLe
 rLe
 rLe
 rLe
-cZP
+rLe
 mCZ
 mCZ
 mCZ
@@ -81852,10 +81848,10 @@ uPu
 uPu
 rLe
 rLe
-hus
-hus
-hus
-hus
+rLe
+jLX
+mCZ
+mCZ
 mCZ
 nhN
 kPi
@@ -82110,8 +82106,8 @@ hus
 hus
 hus
 hus
-hYS
-itO
+hus
+hus
 hus
 mCZ
 nhN
@@ -82189,7 +82185,7 @@ dzd
 oRY
 xin
 uos
-ybn
+bOQ
 eCy
 hwZ
 xZN
@@ -82367,8 +82363,8 @@ hus
 guT
 anw
 hus
-egj
-egj
+hYS
+itO
 hus
 wJG
 nhN
@@ -86993,7 +86989,7 @@ ggn
 gEU
 hmU
 hKO
-vbD
+xGd
 hZu
 fyz
 hZu
@@ -87250,7 +87246,7 @@ ggy
 gFN
 lgT
 hKV
-iRJ
+ibZ
 hZu
 hZu
 hZu
@@ -87507,7 +87503,7 @@ fJx
 gHM
 hmL
 hLe
-ibZ
+bQd
 wEa
 hZu
 hZu
@@ -87796,7 +87792,7 @@ vSO
 vSO
 vSO
 vSO
-bQd
+vnQ
 vSO
 vSO
 vSO
@@ -88053,7 +88049,7 @@ hvF
 hvF
 rxJ
 scm
-vEm
+dJt
 scm
 scm
 ssM
@@ -88278,7 +88274,7 @@ dVX
 gIM
 lgT
 hLM
-uSO
+lSy
 wEa
 wry
 wry
@@ -88535,7 +88531,7 @@ dVX
 gKg
 hnC
 hOK
-ibZ
+bQd
 ixW
 ygw
 wEa
@@ -89811,7 +89807,7 @@ ceP
 ckF
 iSB
 nyZ
-oPG
+ybn
 eoe
 fZx
 fmH
@@ -90068,7 +90064,7 @@ cfp
 ckF
 cRk
 nzv
-dST
+oPG
 eoD
 tAb
 fnm
@@ -90838,8 +90834,8 @@ bHZ
 ckF
 cyw
 ckF
-gnc
-paM
+ehe
+fsU
 epY
 eSV
 ftn
@@ -90883,7 +90879,7 @@ tqv
 daA
 swv
 dFz
-fsU
+qOf
 yeV
 yeV
 jZn
@@ -91345,7 +91341,7 @@ lfc
 tgb
 aCZ
 aFO
-qOf
+hdI
 bcU
 bst
 bIn
@@ -91600,7 +91596,7 @@ tgb
 lfc
 tgb
 tgb
-wOB
+cZP
 aHy
 aQr
 bel
@@ -93697,8 +93693,8 @@ rST
 tzW
 uqD
 uqD
-ucl
-gUa
+qdP
+izx
 yeV
 yeV
 tmx
@@ -94469,7 +94465,7 @@ rLe
 hra
 ygw
 wry
-fva
+thc
 yeV
 xHD
 iGO
@@ -94724,8 +94720,8 @@ wEa
 hra
 rLe
 xpb
-cRW
-xGd
+oWV
+uVp
 ydT
 yeV
 xHD
@@ -94979,11 +94975,11 @@ mCZ
 mCZ
 mCZ
 mCZ
-vqz
-rPl
-akZ
-lZN
-dJg
+biM
+fpI
+oxU
+auN
+ylW
 yeV
 xHD
 iGO

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -1368,7 +1368,7 @@
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - AI Subgrid";
-	name_tag = "Cargo Subgrid"
+	name_tag = "AI Chamber"
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -2788,7 +2788,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing)
 "fg" = (
@@ -3832,23 +3831,6 @@
 	outdoors = 1
 	},
 /area/library_conference_room)
-"hr" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/device/gps/security,
-/obj/item/clothing/accessory/badge/holo/cord,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
 "hs" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Virology Exterior North 3";
@@ -4597,13 +4579,15 @@
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "iF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/surface/outpost/main/landing)
 "iG" = (
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 3 North";
@@ -5137,23 +5121,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
-"jB" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/device/gps/security,
-/obj/item/clothing/accessory/badge/holo/cord,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
 "jC" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -7032,15 +6999,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "mX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -8277,14 +8236,21 @@
 	},
 /area/surface/outpost/main/landing)
 "oO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/light/no_nightshift,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/main/landing)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "oP" = (
 /obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8374,6 +8340,14 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outside/plains/outpost)
+"oY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "oZ" = (
 /obj/effect/floor_decal/rust,
 /obj/item/ammo_magazine/m41{
@@ -10153,11 +10127,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "sg" = (
-/obj/machinery/light/no_nightshift,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -11020,13 +10996,13 @@
 	},
 /area/surface/outpost/main/landing/three)
 "tR" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "tS" = (
 /obj/structure/closet/walllocker_double{
 	pixel_x = 32
@@ -11258,11 +11234,20 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "um" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/library_conference_room)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "un" = (
 /obj/machinery/gateway,
 /obj/effect/floor_decal/techfloor/orange,
@@ -11315,11 +11300,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "us" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11605,16 +11588,6 @@
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_lead,
 /area/engineering/engine_waste)
-"uT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/medical_lockerroom)
 "uU" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -12191,13 +12164,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "vW" = (
+/obj/structure/lattice,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "32-4";
+	d1 = 32;
+	d2 = 4
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost/sky)
 "vX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -14390,11 +14366,24 @@
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "Ai" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/surface/outpost/main/landing)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Aj" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
@@ -14445,14 +14434,15 @@
 	},
 /area/crew_quarters/cafeteria)
 "Ao" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outpost/main/landing)
 "Ap" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -14706,6 +14696,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blue,
 /area/bridge)
+"AS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "AT" = (
 /obj/machinery/computer/rcon{
 	dir = 4
@@ -14985,6 +14987,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
+"Br" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -16440,6 +16455,23 @@
 	outdoors = 1
 	},
 /area/surface/outpost/civilian/pool)
+"DW" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "DX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -16850,14 +16882,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost/sky)
-"EH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
 "EI" = (
 /obj/structure/bed/double/padded,
 /obj/machinery/light_switch{
@@ -17010,25 +17034,19 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "EU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
+/turf/simulated/floor/plating,
+/area/surface/outpost/main/landing)
 "EV" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -17444,7 +17462,7 @@
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Engine Input";
-	name_tag = "Civilian Subgrid"
+	name_tag = "Engine Input"
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -18248,6 +18266,12 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/bmarble,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
+"Hi" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/library_conference_room)
 "Hj" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/solgov/utility/army{
@@ -18764,11 +18788,13 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Il" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19025,19 +19051,25 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "IE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/machinery/door/airlock/glass_research{
+	name = "Expedition Shuttle";
+	req_access = list();
+	req_one_access = list(5,43,67)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/tiled/techmaint,
+/area/surface/outpost/main/landing)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19089,17 +19121,25 @@
 /turf/simulated/open,
 /area/engineering/engine_room)
 "IL" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "IM" = (
 /obj/structure/bed/chair/sofa/right/black{
 	dir = 4
@@ -19641,42 +19681,52 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "JQ" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/no_nightshift,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
-"JR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
+"JR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/surface/outpost/main/landing)
 "JS" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
+"JT" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "JU" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -20283,19 +20333,13 @@
 	},
 /area/surface/outside/plains/outpost)
 "Lb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Lc" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced{
@@ -21108,15 +21152,17 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "Mz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/security/security_lockerroom)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "MA" = (
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint{
@@ -23023,17 +23069,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"Qb" = (
-/obj/structure/lattice,
-/obj/structure/cable{
-	icon_state = "32-4";
-	d1 = 32;
-	d2 = 4
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost/sky)
 "Qc" = (
 /obj/machinery/seed_storage/xenobotany{
 	dir = 1
@@ -23478,11 +23513,13 @@
 "Ra" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -23722,6 +23759,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
+"Rw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/medical_lockerroom)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -23938,14 +23985,13 @@
 	},
 /area/surface/outside/plains/outpost)
 "RT" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/obj/structure/cable/green{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -24066,18 +24112,10 @@
 /turf/simulated/open,
 /area/medical/medical_lockerroom)
 "Se" = (
-/obj/machinery/light/no_nightshift,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -24945,13 +24983,11 @@
 "TD" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -25415,7 +25451,8 @@
 	},
 /obj/machinery/power/sensor{
 	long_range = 1;
-	name_tag = "Telecommunications"
+	name_tag = "Telecommunications";
+	name = "Powernet Sensor - Telecommunications"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/powercontrol)
@@ -25587,20 +25624,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
-"UM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/main/landing)
 "UN" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 8
@@ -25657,14 +25680,9 @@
 /obj/structure/catwalk,
 /obj/structure/lattice,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -25738,25 +25756,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
 "Vd" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Expedition Shuttle";
-	req_access = list();
-	req_one_access = list(5,43,67)
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/surface/outpost/main/landing)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Ve" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm{
@@ -26446,17 +26453,6 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
-"WA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "WB" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -26672,13 +26668,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "WX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -26986,15 +26983,22 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "XD" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing)
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "XE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -27112,18 +27116,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
 "XO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/security_lockerroom)
 "XP" = (
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/main/bar)
@@ -49640,7 +49641,7 @@ rZ
 qY
 Tr
 LM
-um
+Hi
 Eq
 Vg
 tk
@@ -57007,8 +57008,8 @@ xD
 ez
 od
 pq
-WA
-Lb
+RT
+Ik
 xD
 xD
 xD
@@ -57263,7 +57264,7 @@ xD
 xD
 xD
 te
-WX
+us
 xD
 xD
 xD
@@ -57520,7 +57521,7 @@ xD
 xD
 xD
 te
-WX
+us
 xD
 xD
 xD
@@ -57777,7 +57778,7 @@ xD
 xD
 xD
 te
-WX
+us
 xD
 xD
 xD
@@ -58032,9 +58033,9 @@ fo
 jw
 kE
 HX
-IE
+WX
 oh
-XO
+Br
 xD
 Vi
 sm
@@ -58051,14 +58052,14 @@ TR
 HO
 TR
 BQ
-Ra
-Ra
-Ra
-Ra
-Ra
+TD
+TD
+TD
+TD
+TD
 Hm
-Ao
-Ik
+Vd
+Mz
 XP
 Kh
 KQ
@@ -58333,10 +58334,10 @@ Ua
 UB
 UR
 Vk
+JT
 UU
-RT
-RT
-RT
+UU
+UU
 qb
 ZM
 Kx
@@ -58572,7 +58573,7 @@ fW
 Co
 PW
 XU
-tR
+Lb
 XP
 Kj
 KT
@@ -58829,7 +58830,7 @@ zv
 tU
 UQ
 XU
-sg
+JQ
 XP
 yg
 KV
@@ -59086,7 +59087,7 @@ zv
 tU
 If
 XU
-tR
+Lb
 XP
 XP
 oe
@@ -59343,19 +59344,19 @@ zv
 tU
 Ib
 Ib
-vW
+oY
 Js
 Kl
 Pu
 Pu
 MH
-EH
-JU
-EH
-EH
-JR
+Se
+sg
+Se
+Se
+AS
 RJ
-IL
+JU
 Tw
 eb
 eb
@@ -59569,7 +59570,7 @@ xD
 ua
 ua
 qu
-Mz
+XO
 JC
 ua
 ua
@@ -59612,7 +59613,7 @@ XU
 XU
 Rc
 RL
-Se
+oO
 PW
 Uh
 UG
@@ -59827,7 +59828,7 @@ ua
 hS
 qG
 cE
-jB
+XD
 Sz
 cJ
 lJ
@@ -60084,7 +60085,7 @@ ua
 im
 rL
 JP
-iF
+tR
 ud
 ua
 lL
@@ -60126,7 +60127,7 @@ pQ
 XU
 Re
 RS
-TD
+Ra
 TB
 PW
 WE
@@ -60341,7 +60342,7 @@ ua
 jn
 sE
 VU
-EU
+IL
 Ev
 df
 lQ
@@ -60383,7 +60384,7 @@ Ju
 XU
 Rf
 RS
-TD
+Ra
 ON
 gW
 zv
@@ -60598,7 +60599,7 @@ ua
 mU
 rL
 yZ
-iF
+tR
 NX
 ua
 lR
@@ -60640,7 +60641,7 @@ KF
 XU
 Rf
 RS
-TD
+Ra
 ON
 zv
 zv
@@ -60855,7 +60856,7 @@ ua
 pr
 rL
 yZ
-iF
+tR
 tT
 ua
 lS
@@ -61112,7 +61113,7 @@ ua
 px
 rL
 yZ
-iF
+tR
 on
 cJ
 lT
@@ -61154,7 +61155,7 @@ fW
 zv
 tU
 RS
-TD
+Ra
 ON
 zv
 zv
@@ -61369,7 +61370,7 @@ ua
 qp
 sO
 oL
-hr
+DW
 dt
 ua
 lV
@@ -61411,7 +61412,7 @@ zv
 EG
 se
 RS
-TD
+Ra
 Uo
 EG
 EG
@@ -61625,7 +61626,7 @@ xD
 ua
 ua
 ui
-Mz
+XO
 aV
 ua
 ua
@@ -61668,7 +61669,7 @@ tU
 xD
 xD
 ip
-WX
+us
 xD
 xD
 xD
@@ -61925,7 +61926,7 @@ tU
 xD
 xD
 ip
-WX
+us
 xD
 xD
 xD
@@ -62182,7 +62183,7 @@ tU
 xD
 xD
 ip
-WX
+us
 xD
 xD
 xD
@@ -62439,7 +62440,7 @@ tU
 xD
 xD
 ip
-WX
+us
 xD
 xD
 xD
@@ -62687,7 +62688,7 @@ zv
 zv
 zv
 zv
-Qb
+vW
 EG
 EG
 EG
@@ -62700,9 +62701,9 @@ SW
 fI
 fI
 fI
-RT
-RT
-RT
+UU
+UU
+UU
 WD
 Xm
 Yd
@@ -62953,7 +62954,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -63210,7 +63211,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -63467,7 +63468,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -63724,7 +63725,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -63980,8 +63981,8 @@ Sc
 Sc
 Sc
 Sc
-mX
-Lb
+Ai
+Ik
 xD
 xD
 xD
@@ -64237,7 +64238,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -64494,7 +64495,7 @@ xD
 xD
 xD
 xD
-WX
+us
 xD
 xD
 xD
@@ -64751,7 +64752,7 @@ xD
 xD
 Tx
 xD
-WX
+us
 xD
 xD
 xD
@@ -65008,7 +65009,7 @@ ED
 Wo
 Wo
 xD
-WX
+us
 PN
 PN
 PN
@@ -65265,7 +65266,7 @@ Od
 Lp
 PY
 YF
-WX
+us
 SX
 PB
 PB
@@ -65522,7 +65523,7 @@ ZK
 Kp
 vC
 YF
-WX
+us
 NC
 NC
 NC
@@ -65779,7 +65780,7 @@ MQ
 ZK
 vC
 YF
-WX
+us
 xD
 xD
 xD
@@ -66036,7 +66037,7 @@ ZK
 ZK
 vC
 YF
-WX
+us
 PN
 PN
 PN
@@ -66293,7 +66294,7 @@ ZK
 ZK
 vC
 YF
-WX
+us
 SX
 PB
 PB
@@ -66550,7 +66551,7 @@ MQ
 ZK
 vC
 YF
-WX
+us
 NC
 NC
 NC
@@ -66807,7 +66808,7 @@ ZK
 Ko
 vC
 YF
-WX
+us
 xD
 xD
 xD
@@ -67064,7 +67065,7 @@ Oh
 lh
 Qa
 YF
-WX
+us
 PN
 PN
 PN
@@ -67321,7 +67322,7 @@ Oi
 Ia
 Ia
 xD
-WX
+us
 SX
 PB
 PB
@@ -67574,10 +67575,10 @@ GH
 GH
 GH
 GH
-JQ
-WA
-WA
-WA
+mX
+RT
+RT
+RT
 RW
 NC
 NC
@@ -69377,7 +69378,7 @@ Om
 AO
 Qg
 Rq
-uT
+Rw
 SZ
 Ns
 xD
@@ -72946,7 +72947,7 @@ rX
 ht
 sS
 lX
-us
+um
 ON
 zv
 zv
@@ -73203,7 +73204,7 @@ ht
 ht
 lX
 sU
-us
+um
 ON
 zv
 zv
@@ -73460,7 +73461,7 @@ pi
 pi
 lX
 tz
-us
+um
 ON
 zv
 zv
@@ -73974,7 +73975,7 @@ ht
 ht
 sV
 lX
-us
+um
 ON
 zv
 zv
@@ -74231,7 +74232,7 @@ qM
 pi
 sX
 tD
-us
+um
 ON
 zv
 zv
@@ -74488,7 +74489,7 @@ ht
 pi
 lX
 tz
-us
+um
 ON
 zv
 zv
@@ -74745,7 +74746,7 @@ ht
 ht
 ta
 sU
-us
+um
 ON
 zv
 zv
@@ -75002,7 +75003,7 @@ sc
 ht
 lX
 lX
-us
+um
 ON
 zv
 zv
@@ -80940,9 +80941,9 @@ PE
 PE
 ag
 Cq
-oO
 ff
-UM
+iF
+EU
 Cq
 KN
 PE
@@ -81200,7 +81201,7 @@ TF
 uq
 Dg
 dW
-Ai
+JR
 Sl
 Sl
 Sl
@@ -81450,10 +81451,10 @@ uZ
 Cq
 Cq
 Sm
-XD
-XD
-XD
-Vd
+Ao
+Ao
+Ao
+IE
 mq
 Ch
 Ls

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -1695,16 +1695,16 @@
 /turf/simulated/floor/bluegrid,
 /area/ai/ai_upload)
 "dn" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
+/area/surface/outside/plains/outpost)
 "do" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
@@ -1933,10 +1933,6 @@
 /area/ai/ai_cyborg_station)
 "dN" = (
 /obj/machinery/atmospherics/unary/heater,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "dO" = (
@@ -2501,6 +2497,14 @@
 "eJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
@@ -3622,26 +3626,6 @@
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing/three)
-"ha" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "hb" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -4479,9 +4463,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "iz" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4896,25 +4890,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "ji" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -5085,7 +5073,17 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "jB" = (
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/atmos,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "jC" = (
 /obj/item/device/radio/intercom{
@@ -5231,17 +5229,6 @@
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - TCOMMS East 2";
 	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -6658,16 +6645,10 @@
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
 "mm" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
@@ -7795,7 +7776,7 @@
 /obj/structure/sign/directions/stairs_up{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_lead,
 /area/engineering/atmos/storage)
 "om" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8119,17 +8100,6 @@
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -8242,15 +8212,6 @@
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing)
-"oO" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 "oP" = (
 /obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8263,24 +8224,6 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
-"oQ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -9369,6 +9312,17 @@
 /area/surface/outside/plains/outpost)
 "qN" = (
 /obj/structure/railing/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "qO" = (
@@ -9415,20 +9369,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_isolation)
-"qT" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 "qU" = (
 /obj/effect/floor_decal/rust,
 /obj/item/ammo_magazine/m41{
@@ -9898,15 +9838,6 @@
 /area/quartermaster/storage)
 "rI" = (
 /obj/machinery/atmospherics/unary/freezer,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "rJ" = (
@@ -10116,7 +10047,13 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "sf" = (
-/turf/simulated/wall/r_lead,
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "sh" = (
 /obj/structure/cable/green{
@@ -10402,13 +10339,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
@@ -11861,30 +11795,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
-"vx" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/atmos,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
 "vy" = (
 /obj/structure/toilet{
 	dir = 1
@@ -12282,10 +12192,10 @@
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/heads/sc/sd)
 "wq" = (
-/obj/structure/lattice,
-/turf/simulated/open{
-	outdoors = 1
+/obj/structure/railing/grey{
+	dir = 4
 	},
+/turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "wr" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -12622,25 +12532,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "wQ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_room)
 "wR" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced,
@@ -12945,21 +12839,28 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xu" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/lattice,
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/railing/grey{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint{
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/open{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/atmos/storage)
 "xv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -13439,17 +13340,6 @@
 /area/quartermaster/storage)
 "yr" = (
 /obj/item/device/geiger/wall/west,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -13719,7 +13609,8 @@
 /area/library_conference_room)
 "yO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access"
+	name = "Roof Access";
+	rad_resistance = 150
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
@@ -14136,13 +14027,10 @@
 	c_tag = "ENG - Atmos Storage";
 	dir = 8
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
@@ -14268,15 +14156,14 @@
 	},
 /area/surface/outside/plains/outpost)
 "zW" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
 /obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
+/area/engineering/engine_room)
 "zX" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/space_heater,
@@ -14950,19 +14837,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"Br" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/engineering/engine_room)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -15735,7 +15609,12 @@
 /area/tcommsat/entrance)
 "CM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
@@ -16473,7 +16352,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Auxiliary Room";
-	req_one_access = list(11)
+	req_one_access = list(11);
+	rad_resistance = 150
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -16946,11 +16826,20 @@
 /area/surface/outpost/main/landing/three)
 "ET" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "EU" = (
+/obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_lead,
 /area/engineering/engine_monitoring)
 "EV" = (
@@ -17304,7 +17193,8 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Fuel Storage Room";
-	req_one_access = list(11)
+	req_one_access = list(11);
+	rad_resistance = 150
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -17586,7 +17476,8 @@
 "Gg" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Fuel Storage Room";
-	req_one_access = list(11)
+	req_one_access = list(11);
+	rad_resistance = 150
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -18206,13 +18097,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Hl" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating{
+	outdoors = 1
 	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
+/area/surface/outside/plains/outpost/sky)
 "Hm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -18484,14 +18374,20 @@
 	},
 /area/security/prison)
 "HR" = (
-/obj/item/device/geiger/wall/east,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Roof Access";
+	rad_resistance = 150
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_room)
 "HS" = (
 /obj/structure/railing,
@@ -18915,25 +18811,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "IE" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
+/obj/item/device/geiger/wall/east,
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18974,21 +18860,6 @@
 /turf/simulated/open,
 /area/engineering/engine_room)
 "IK" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/tiny,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/engine_room)
-"IL" = (
 /obj/structure/railing{
 	dir = 1
 	},
@@ -19221,7 +19092,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room Internal Access";
-	req_one_access = list(11)
+	req_one_access = list(11);
+	rad_resistance = 150
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19397,7 +19269,7 @@
 /area/security/security_lockerroom)
 "JD" = (
 /turf/simulated/wall/r_lead,
-/area/surface/outside/plains/outpost)
+/area/engineering/engine_room)
 "JE" = (
 /obj/machinery/computer/fusion_fuel_control{
 	id_tag = "Reactor Fuel Injectors"
@@ -19521,33 +19393,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
-"JR" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
 "JS" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
-"JU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
 "JV" = (
 /obj/structure/table/marble,
 /obj/random/cigarettes,
@@ -19826,7 +19677,8 @@
 "Kw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room External Access";
-	req_one_access = list(11)
+	req_one_access = list(11);
+	rad_resistance = 150
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20306,7 +20158,7 @@
 "Lq" = (
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_lead,
-/area/engineering/engine_monitoring)
+/area/engineering/atmos/storage)
 "Lr" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -20455,21 +20307,11 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "LH" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint{
+/obj/structure/catwalk,
+/turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/plains/outpost/sky)
 "LI" = (
 /obj/structure/railing{
 	dir = 4
@@ -20899,18 +20741,17 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "Mt" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - R-UST Exterior, East";
-	dir = 5
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced_phoron,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/area/engineering/atmos/storage)
 "Mu" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -21153,7 +20994,7 @@
 	},
 /area/tcommsat/chamber)
 "MS" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -21497,15 +21338,6 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
-"Nx" = (
-/obj/machinery/light/floortube{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
 "Ny" = (
 /obj/machinery/telecomms/bus/preset_two/southerncross,
 /turf/simulated/floor/tiled/dark{
@@ -21774,13 +21606,8 @@
 	},
 /area/surface/outside/plains/outpost)
 "NW" = (
-/mob/living/simple_mob/animal/passive/cat/bluespace{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_monitoring)
 "NX" = (
 /obj/structure/closet/l3closet/security,
 /obj/structure/window/reinforced{
@@ -22057,12 +21884,7 @@
 	},
 /area/tcommsat/chamber)
 "Oy" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -22324,7 +22146,8 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access"
+	name = "Roof Access";
+	rad_resistance = 150
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
@@ -23591,23 +23414,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Rv" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/camera/network/exterior{
+	c_tag = "EXT - R-UST Exterior, East";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -24025,27 +23845,6 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
-"Sk" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "Sl" = (
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -24238,13 +24037,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -24414,11 +24212,18 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "SQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/engineering/engine_room)
 "SR" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -25442,27 +25247,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
 "UM" = (
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/catwalk,
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - R-UST Exterior, West 3";
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/engineering/engine_room)
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "UN" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 8
@@ -25595,10 +25386,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
 "Vd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing/grey{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
+	icon_state = "32-4"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
 /area/engineering/atmos/storage)
 "Ve" = (
 /obj/machinery/computer/security/mining,
@@ -25705,13 +25504,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
 "Vp" = (
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/radproof{
-	rad_resistance = 150
+/mob/living/simple_mob/animal/passive/cat/bluespace{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26051,9 +25850,11 @@
 /area/surface/outpost/main/landing/three)
 "Wb" = (
 /obj/item/device/geiger/wall/north,
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 8
 	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "Wc" = (
 /obj/structure/bed/chair/office/dark,
@@ -26919,15 +26720,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
-"XO" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 "XP" = (
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/main/bar)
@@ -27416,16 +27208,7 @@
 	},
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
 "YV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_lead,
 /area/engineering/atmos/storage)
 "YW" = (
 /turf/simulated/wall,
@@ -41923,16 +41706,16 @@ zv
 zv
 io
 zv
-jB
-jB
-jB
-jB
-jB
-jB
-jB
-jB
-jB
-jB
+YV
+YV
+YV
+YV
+YV
+YV
+YV
+YV
+YV
+YV
 zv
 Wn
 IU
@@ -42180,16 +41963,16 @@ zv
 zv
 io
 zv
-jB
+YV
 Qu
 Qu
 Qu
 Qu
 Qu
 Pq
+Vd
 Pq
-Pq
-jB
+YV
 zv
 Wn
 IU
@@ -42437,16 +42220,16 @@ zv
 zv
 io
 zv
-jB
+YV
 ig
 ig
 ig
 ig
 ig
 aR
-Pq
+xu
 wq
-jB
+YV
 zv
 Wn
 IU
@@ -42694,7 +42477,7 @@ zv
 zv
 io
 zv
-jB
+YV
 mN
 mN
 mN
@@ -42703,7 +42486,7 @@ mN
 Pq
 qN
 ch
-jB
+YV
 zv
 Wn
 IU
@@ -42951,7 +42734,7 @@ zv
 zv
 io
 zv
-jB
+YV
 xq
 xq
 xq
@@ -42960,7 +42743,7 @@ xq
 aR
 qN
 ch
-jB
+YV
 zv
 Wn
 IU
@@ -43207,15 +42990,15 @@ zv
 zv
 zv
 io
-zv
-jB
+EG
+Lq
 dI
 dI
 dI
 dI
 dI
 Pq
-Pq
+ET
 Pq
 ol
 zv
@@ -43463,18 +43246,18 @@ zv
 zv
 zv
 zv
-io
-zv
+wU
+LH
 jB
 Pq
 aJ
 Pq
-Nx
-Vd
-Vd
+aJ
+Pq
+Pq
 ET
 fP
-jB
+YV
 zv
 Wn
 IU
@@ -43720,18 +43503,18 @@ zv
 zv
 zv
 zv
-io
-zv
-jB
+wU
+LH
+Mt
 hK
 dN
 gv
-SQ
+Pq
 VV
 Am
 eJ
 gL
-jB
+YV
 br
 Ub
 Ld
@@ -43977,18 +43760,18 @@ zv
 zv
 zv
 zv
-io
-zv
-jB
+wU
+LH
+Mt
 hK
 rI
 cK
-SQ
+Pq
 dB
 wr
 CM
 gL
-jB
+YV
 zv
 Ub
 Ld
@@ -44234,18 +44017,18 @@ io
 io
 io
 io
-io
-io
-jB
+wU
+Hl
+YV
 MS
 Oy
-Hl
-dn
+Oy
+Oy
 sK
 zK
 mm
 gL
-jB
+YV
 io
 Ub
 Ld
@@ -44491,18 +44274,18 @@ zv
 zv
 zv
 zv
-io
-EG
-jB
-jB
+wU
+LH
 YV
 YV
 YV
-jB
-jB
-vx
-jB
-jB
+YV
+YV
+YV
+YV
+YV
+YV
+YV
 EG
 Ub
 Ub
@@ -44757,10 +44540,10 @@ YK
 YK
 Vf
 YK
-UM
-oQ
-Sk
-IE
+Un
+YK
+Vf
+jj
 zb
 EG
 EG
@@ -45007,21 +44790,21 @@ YK
 xC
 JW
 OV
-sf
-sf
-sf
-sf
-sf
-sf
-sf
-sf
-sf
-sf
-wQ
-oQ
-oQ
+JD
+JD
+JD
+JD
+JD
+JD
+JD
+JD
+JD
+JD
+Ci
+YK
+YK
 oG
-IE
+jj
 Ub
 Ub
 Ub
@@ -45264,24 +45047,24 @@ yO
 uQ
 uQ
 uQ
-sf
-sf
-sf
-iz
-sf
-sf
-sf
-sf
-sf
-Lq
+JD
+JD
+JD
+wQ
+JD
+JD
+JD
+JD
+JD
 EU
+NW
 Kr
 Lg
-EU
-ha
+NW
+Rl
 yr
 jP
-xu
+xD
 CL
 tH
 Sx
@@ -45534,11 +45317,11 @@ Jh
 Jz
 Ks
 Li
-EU
+NW
 Rl
 xD
 xD
-LH
+xD
 CL
 CL
 SB
@@ -45778,7 +45561,7 @@ yP
 xH
 Bs
 CI
-sf
+JD
 EJ
 Fp
 Fx
@@ -45791,13 +45574,13 @@ Jh
 JE
 Kt
 Lj
-EU
+NW
 Nd
 YK
 YK
-Rv
-oQ
-ji
+YK
+YK
+jj
 SC
 Tt
 TS
@@ -46048,10 +45831,10 @@ Xk
 JG
 Kt
 Lk
-EU
-EU
-EU
-EU
+NW
+NW
+NW
+NW
 xD
 xD
 Rl
@@ -46292,7 +46075,7 @@ yR
 za
 Bv
 CP
-sf
+JD
 EJ
 Fw
 FZ
@@ -46308,7 +46091,7 @@ Lo
 Mr
 Ne
 vF
-EU
+NW
 jC
 xD
 Ci
@@ -46555,17 +46338,17 @@ ZC
 Ga
 Fx
 GR
-iz
+wQ
 HG
 Iv
 Jh
 JL
 nT
 yf
-Lq
+EU
 ho
 kX
-Lq
+EU
 xD
 xD
 xD
@@ -46806,24 +46589,24 @@ za
 Ap
 BA
 CU
-sf
-sf
+JD
+JD
 Fy
 Gb
 Fy
-iz
-sf
+wQ
+JD
 HH
 Iw
-EU
-EU
-Vp
-EU
-EU
+NW
+NW
+NW
+NW
+NW
 Gd
 NT
-EU
-xD
+NW
+Vp
 xD
 xD
 Rl
@@ -47063,7 +46846,7 @@ zc
 Aq
 BB
 CV
-sf
+JD
 EL
 FB
 Gc
@@ -47073,13 +46856,13 @@ Hd
 HJ
 Iz
 Ji
-JU
+iz
 Kw
 JM
 VB
 Gd
 ny
-EU
+NW
 PM
 xD
 xD
@@ -47326,12 +47109,12 @@ FE
 Gf
 Gy
 GT
-oO
+zW
 HN
 IC
-sf
-Lq
+JD
 EU
+NW
 ho
 Ms
 bB
@@ -47583,17 +47366,17 @@ FF
 Wl
 HN
 GU
-oO
+zW
 HN
 IF
-sf
-xD
+JD
+NW
+NW
+NW
+NW
 EU
-EU
-EU
-Lq
-EU
-EU
+NW
+NW
 PM
 xD
 xD
@@ -47843,15 +47626,15 @@ GV
 Hg
 HP
 IJ
-sf
-JN
-OH
-OH
-Mt
-OH
+JD
 NW
-OH
-OH
+NW
+EU
+NW
+NW
+NW
+NW
+JN
 OH
 OH
 ss
@@ -48095,20 +47878,20 @@ Wl
 EQ
 FI
 Wl
+JD
+JD
+IE
 sf
-sf
-HR
-XO
-IL
-sf
-JR
+IK
+JD
+JD
 xD
 xD
-xD
-xD
-xD
-xD
-xD
+Rv
+OH
+OH
+OH
+ss
 xD
 xD
 xD
@@ -48353,12 +48136,12 @@ ER
 FK
 Wl
 JD
-sf
-sf
-IK
-sf
-sf
-JR
+JD
+JD
+HR
+JD
+JD
+JD
 xD
 Lt
 Wb
@@ -48611,14 +48394,14 @@ Wl
 Wl
 wt
 yV
-Br
+SQ
 HU
-qT
+ji
 IO
-zW
-Wo
-Wo
-hT
+IO
+UM
+UM
+dn
 zC
 zC
 zC

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -206,7 +206,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -217,7 +217,7 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -229,7 +229,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -365,7 +365,7 @@
 	},
 /area/crew_quarters/cafeteria)
 "aN" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -419,6 +419,11 @@
 	icon_state = "0-8"
 	},
 /obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
 "aW" = (
@@ -473,7 +478,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -741,7 +746,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -793,7 +798,7 @@
 	icon_state = "motion0"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -902,7 +907,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -976,7 +981,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1036,7 +1041,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai)
 "cb" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1087,7 +1092,7 @@
 	},
 /area/engineering/atmos/storage)
 "ci" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1101,6 +1106,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -1175,7 +1185,7 @@
 /area/ai/ai_upload)
 "cr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1340,7 +1350,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1464,6 +1474,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -1524,7 +1539,7 @@
 /obj/machinery/porta_turret/ai_defense{
 	req_one_access = list(16)
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -1532,7 +1547,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/ai_upload)
 "db" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -1687,7 +1702,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -21
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1840,7 +1855,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "dC" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2061,7 +2076,7 @@
 /obj/machinery/camera/network/command{
 	c_tag = "AI - Upload Foyer"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2329,7 +2344,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2698,7 +2713,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2765,7 +2780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2826,7 +2841,7 @@
 /turf/simulated/wall/r_wall,
 /area/security/brig)
 "fo" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -2846,7 +2861,7 @@
 "fr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -3795,6 +3810,26 @@
 	outdoors = 1
 	},
 /area/library_conference_room)
+"hr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "hs" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Virology Exterior North 3";
@@ -4198,11 +4233,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "ic" = (
@@ -4278,16 +4308,6 @@
 "ik" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/security{
 	name = "Roof Access";
 	req_access = list(1)
@@ -4390,7 +4410,7 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "it" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -4469,6 +4489,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
+"iz" = (
+/obj/machinery/light/no_nightshift,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5034,6 +5063,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -5074,6 +5108,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
+"jB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "jC" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -5648,6 +5690,11 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -5700,9 +5747,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -6164,6 +6210,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
+"lB" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "lC" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - CIV Lounge South 5"
@@ -6942,6 +7005,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
+"mX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/security_lockerroom)
 "mY" = (
 /obj/machinery/shower{
 	pixel_y = 9
@@ -7604,14 +7677,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -7694,6 +7762,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -7738,19 +7811,14 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/main)
@@ -7774,8 +7842,8 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7884,11 +7952,6 @@
 "ot" = (
 /obj/structure/table/darkglass,
 /obj/item/weapon/folder/red,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7901,11 +7964,6 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7927,6 +7985,11 @@
 	c_tag = "CIV - Lounge North";
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "ow" = (
@@ -7934,11 +7997,6 @@
 /obj/item/clothing/glasses/hud/security,
 /obj/item/clothing/glasses/hud/security,
 /obj/item/clothing/glasses/hud/security,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7947,11 +8005,6 @@
 "ox" = (
 /obj/structure/table/darkglass,
 /obj/item/device/paicard,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7975,11 +8028,6 @@
 "oz" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8028,11 +8076,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "oC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8407,6 +8450,11 @@
 "po" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -8432,6 +8480,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -9509,6 +9562,11 @@
 "ri" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -9810,6 +9868,11 @@
 	dir = 4
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -9933,11 +9996,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/solars)
@@ -10134,9 +10192,8 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -10527,6 +10584,11 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -12057,6 +12119,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"vW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "vX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -13085,7 +13156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13841,7 +13912,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -14431,7 +14502,7 @@
 "AB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -14572,6 +14643,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blue,
 /area/bridge)
+"AS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "AT" = (
 /obj/machinery/computer/rcon{
 	dir = 4
@@ -14849,6 +14931,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
+"Br" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -15065,7 +15164,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -15104,6 +15203,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -15113,6 +15217,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating{
 	outdoors = 1
@@ -15793,7 +15902,7 @@
 /turf/simulated/floor/bmarble,
 /area/security/nuke_storage)
 "Df" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -15881,6 +15990,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -15891,6 +16005,11 @@
 /obj/random/drinkbottle,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	outdoors = 1
@@ -15903,6 +16022,11 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	outdoors = 1
@@ -16286,6 +16410,25 @@
 	outdoors = 1
 	},
 /area/surface/outpost/civilian/pool)
+"DW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "DX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -16396,7 +16539,7 @@
 	desc = "An sleek tidy briefcase.";
 	name = "secure briefcase"
 	},
-/obj/structure/cable,
+/obj/structure/cable/green,
 /turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "Ei" = (
@@ -16699,6 +16842,18 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost/sky)
+"EH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "EI" = (
 /obj/structure/bed/double/padded,
 /obj/machinery/light_switch{
@@ -17235,6 +17390,11 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/storage)
 "FJ" = (
@@ -17257,6 +17417,14 @@
 	dir = 4;
 	name = "Station Intercom (General)";
 	pixel_x = 21
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Input";
+	name_tag = "Civilian Subgrid"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/storage)
@@ -18056,6 +18224,20 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/bmarble,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
+"Hi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Hj" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/solgov/utility/army{
@@ -18120,6 +18302,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
 	name = "Lounge"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -18442,6 +18629,11 @@
 	c_tag = "EXT - Security Office 2";
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -18555,6 +18747,23 @@
 	outdoors = 1
 	},
 /area/crew_quarters/cafeteria)
+"Ik" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Il" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19168,6 +19377,11 @@
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "Jt" = (
@@ -19254,6 +19468,11 @@
 	icon_state = "0-4"
 	},
 /obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
 "JD" = (
@@ -19390,12 +19609,45 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
+"JQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "JS" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
+"JT" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
+"JU" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "JV" = (
 /obj/structure/table/marble,
 /obj/random/cigarettes,
@@ -19567,6 +19819,11 @@
 /obj/structure/bed/chair/sofa/black{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "Km" = (
@@ -19719,6 +19976,11 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -19993,6 +20255,22 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"Lb" = (
+/obj/machinery/light/no_nightshift,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Lc" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced{
@@ -20241,7 +20519,9 @@
 /area/crew_quarters/cafeteria)
 "LC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -20792,6 +21072,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
+"Mz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "MA" = (
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint{
@@ -20869,6 +21157,11 @@
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Lounge East";
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -22305,6 +22598,11 @@
 /obj/structure/bed/chair/sofa/black{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "Pv" = (
@@ -22356,6 +22654,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/zone_divider,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
@@ -22691,6 +22994,17 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"Qb" = (
+/obj/structure/lattice,
+/obj/structure/cable{
+	icon_state = "32-4";
+	d1 = 32;
+	d2 = 4
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost/sky)
 "Qc" = (
 /obj/machinery/seed_storage/xenobotany{
 	dir = 1
@@ -22714,14 +23028,14 @@
 	input_level = 150000;
 	output_level = 100000
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
 "Qf" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -22731,7 +23045,9 @@
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -23133,6 +23449,18 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
+"Ra" = (
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Rb" = (
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
@@ -23359,6 +23687,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
+"Rw" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -23486,6 +23825,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "RK" = (
@@ -23569,6 +23913,19 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"RT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "RU" = (
 /turf/simulated/wall/bay/blue,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
@@ -23585,6 +23942,11 @@
 "RW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -24178,6 +24540,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
 "SW" = (
@@ -24188,6 +24555,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -24455,11 +24827,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
 "Tw" = (
@@ -24527,6 +24894,21 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost/sky)
+"TD" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "TE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -25152,6 +25534,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
+"UM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "UN" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 8
@@ -25283,6 +25679,19 @@
 /obj/machinery/computer/supplycomp/control,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
+"Vd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Ve" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm{
@@ -25380,10 +25789,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
@@ -25888,6 +26297,11 @@
 	},
 /area/surface/outside/plains/outpost)
 "Wp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
 "Wq" = (
@@ -26173,22 +26587,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "WX" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "WY" = (
 /obj/machinery/camera/network/prison{
 	c_tag = "SEC - Prison Wing Exterior West 2";
@@ -26624,6 +27029,17 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
+"XR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "XS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -56490,15 +56906,15 @@ fG
 fG
 xD
 xD
-ip
+xD
 xD
 xD
 xD
 ez
 od
 pq
-GH
-Tg
+XR
+UM
 xD
 xD
 xD
@@ -56747,13 +57163,13 @@ xD
 xD
 xD
 xD
-ip
+xD
 xD
 xD
 xD
 xD
 te
-UX
+RT
 xD
 xD
 xD
@@ -57004,13 +57420,13 @@ xD
 xD
 xD
 xD
-ip
+xD
 xD
 xD
 xD
 xD
 te
-UX
+RT
 xD
 xD
 xD
@@ -57261,13 +57677,13 @@ xD
 xD
 xD
 xD
-ip
+xD
 xD
 xD
 xD
 xD
 te
-UX
+RT
 xD
 xD
 xD
@@ -57518,13 +57934,13 @@ xD
 xD
 xD
 xD
-ip
+fo
 jw
 kE
 HX
-Bx
+Hi
 oh
-UX
+Vd
 xD
 Vi
 sm
@@ -57541,14 +57957,14 @@ TR
 HO
 TR
 BQ
-EW
-EW
-EW
-EW
-EW
+JU
+JU
+JU
+JU
+JU
 Hm
-eb
-Jd
+vW
+EH
 XP
 Kh
 KQ
@@ -57775,7 +58191,7 @@ xD
 xD
 xD
 xD
-ip
+Wr
 jx
 kF
 kF
@@ -57823,7 +58239,7 @@ Ua
 UB
 UR
 Vk
-WX
+Ik
 UU
 UU
 UU
@@ -58028,10 +58444,10 @@ dA
 fa
 xD
 fo
-fI
-fI
-fI
-fI
+Sc
+Sc
+Sc
+Sc
 it
 Vh
 kF
@@ -58062,7 +58478,7 @@ fW
 Co
 PW
 XU
-XU
+WX
 XP
 Kj
 KT
@@ -58319,7 +58735,7 @@ zv
 tU
 UQ
 XU
-Je
+iz
 XP
 yg
 KV
@@ -58576,7 +58992,7 @@ zv
 tU
 If
 XU
-XU
+WX
 XP
 XP
 oe
@@ -58805,7 +59221,7 @@ xD
 xD
 xD
 xD
-kL
+kM
 lD
 na
 or
@@ -58833,19 +59249,19 @@ zv
 tU
 Ib
 Ib
-XU
+JT
 Js
 Kl
 Pu
 Pu
 MH
-XU
-IT
-XU
-XU
-IW
+Mz
+Rw
+Mz
+Mz
+JQ
 RJ
-SR
+Ra
 Tw
 eb
 eb
@@ -59059,7 +59475,7 @@ xD
 ua
 ua
 qu
-qu
+mX
 JC
 ua
 ua
@@ -59102,7 +59518,7 @@ XU
 XU
 Rc
 RL
-zU
+Lb
 PW
 Uh
 UG
@@ -59317,7 +59733,7 @@ ua
 hS
 qG
 cE
-qG
+Br
 Sz
 cJ
 lJ
@@ -59574,7 +59990,7 @@ ua
 im
 rL
 JP
-rL
+jB
 ud
 ua
 lL
@@ -59616,7 +60032,7 @@ pQ
 XU
 Re
 RS
-Vu
+TD
 TB
 PW
 WE
@@ -59831,7 +60247,7 @@ ua
 jn
 sE
 VU
-Ev
+hr
 Ev
 df
 lQ
@@ -59873,7 +60289,7 @@ Ju
 XU
 Rf
 RS
-Vu
+TD
 ON
 gW
 zv
@@ -60088,7 +60504,7 @@ ua
 mU
 rL
 yZ
-rL
+jB
 NX
 ua
 lR
@@ -60130,7 +60546,7 @@ KF
 XU
 Rf
 RS
-Vu
+TD
 ON
 zv
 zv
@@ -60345,7 +60761,7 @@ ua
 pr
 rL
 yZ
-rL
+jB
 tT
 ua
 lS
@@ -60602,7 +61018,7 @@ ua
 px
 rL
 yZ
-rL
+jB
 on
 cJ
 lT
@@ -60644,7 +61060,7 @@ fW
 zv
 tU
 RS
-Vu
+TD
 ON
 zv
 zv
@@ -60859,7 +61275,7 @@ ua
 qp
 sO
 oL
-sO
+lB
 dt
 ua
 lV
@@ -60901,7 +61317,7 @@ zv
 EG
 se
 RS
-Vu
+TD
 Uo
 EG
 EG
@@ -61115,7 +61531,7 @@ xD
 ua
 ua
 ui
-qu
+mX
 aV
 ua
 ua
@@ -61158,7 +61574,7 @@ tU
 xD
 xD
 ip
-UX
+RT
 xD
 xD
 xD
@@ -61415,7 +61831,7 @@ tU
 xD
 xD
 ip
-UX
+RT
 xD
 xD
 xD
@@ -61672,7 +62088,7 @@ tU
 xD
 xD
 ip
-UX
+RT
 xD
 xD
 xD
@@ -61929,7 +62345,7 @@ tU
 xD
 xD
 ip
-UX
+RT
 xD
 xD
 xD
@@ -62177,7 +62593,7 @@ zv
 zv
 zv
 zv
-Vy
+Qb
 EG
 EG
 EG
@@ -62434,6 +62850,7 @@ EG
 EG
 EG
 OY
+Wr
 xD
 xD
 xD
@@ -62442,8 +62859,7 @@ xD
 xD
 xD
 xD
-xD
-UX
+RT
 xD
 xD
 xD
@@ -62691,6 +63107,7 @@ xD
 xD
 xD
 xD
+Wr
 xD
 xD
 xD
@@ -62699,8 +63116,7 @@ xD
 xD
 xD
 xD
-xD
-UX
+RT
 xD
 xD
 xD
@@ -62948,6 +63364,7 @@ xD
 xD
 xD
 Km
+Wr
 xD
 xD
 xD
@@ -62956,8 +63373,7 @@ xD
 xD
 xD
 xD
-xD
-UX
+RT
 xD
 xD
 xD
@@ -63205,6 +63621,7 @@ xD
 xD
 xD
 Kn
+Wr
 xD
 xD
 xD
@@ -63213,8 +63630,7 @@ xD
 xD
 xD
 xD
-xD
-UX
+RT
 xD
 xD
 xD
@@ -63462,16 +63878,16 @@ xD
 xD
 xD
 xD
-xD
-xD
-xD
-xD
-xD
-xD
-xD
-xD
-NQ
-Tg
+Nq
+Sc
+Sc
+Sc
+Sc
+Sc
+Sc
+Sc
+DW
+UM
 xD
 xD
 xD
@@ -63727,7 +64143,7 @@ xD
 xD
 xD
 xD
-UX
+RT
 xD
 xD
 xD
@@ -63984,7 +64400,7 @@ xD
 xD
 xD
 xD
-UX
+RT
 xD
 xD
 xD
@@ -64241,7 +64657,7 @@ xD
 xD
 Tx
 xD
-UX
+RT
 xD
 xD
 xD
@@ -64498,7 +64914,7 @@ ED
 Wo
 Wo
 xD
-UX
+RT
 PN
 PN
 PN
@@ -64755,7 +65171,7 @@ Od
 Lp
 PY
 YF
-UX
+RT
 SX
 PB
 PB
@@ -65012,7 +65428,7 @@ ZK
 Kp
 vC
 YF
-UX
+RT
 NC
 NC
 NC
@@ -65269,7 +65685,7 @@ MQ
 ZK
 vC
 YF
-UX
+RT
 xD
 xD
 xD
@@ -65526,7 +65942,7 @@ ZK
 ZK
 vC
 YF
-UX
+RT
 PN
 PN
 PN
@@ -65783,7 +66199,7 @@ ZK
 ZK
 vC
 YF
-UX
+RT
 SX
 PB
 PB
@@ -66040,7 +66456,7 @@ MQ
 ZK
 vC
 YF
-UX
+RT
 NC
 NC
 NC
@@ -66297,7 +66713,7 @@ ZK
 Ko
 vC
 YF
-UX
+RT
 xD
 xD
 xD
@@ -66554,7 +66970,7 @@ Oh
 lh
 Qa
 YF
-UX
+RT
 PN
 PN
 PN
@@ -66811,7 +67227,7 @@ Oi
 Ia
 Ia
 xD
-UX
+RT
 SX
 PB
 PB
@@ -67064,10 +67480,10 @@ GH
 GH
 GH
 GH
-GH
-GH
-GH
-GH
+AS
+XR
+XR
+XR
 RW
 NC
 NC
@@ -67321,7 +67737,7 @@ xD
 xD
 xD
 xD
-xD
+Wr
 xD
 xD
 NQ

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -644,7 +644,7 @@
 	c_tag = "EXT - TCOMMS NORTH";
 	dir = 1
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/tcommsat/computer)
@@ -1694,6 +1694,9 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/ai_upload)
+"dn" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/atmos/storage)
 "do" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
@@ -3616,19 +3619,20 @@
 	},
 /area/surface/outpost/main/landing/three)
 "ha" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
+/obj/structure/catwalk,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
+	},
+/obj/machinery/camera/network/exterior{
+	c_tag = "EXT - R-UST Exterior, East";
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/area/engineering/engine_monitoring)
 "hb" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -4465,18 +4469,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
-"iz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4890,6 +4882,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
+"ji" = (
+/obj/structure/lattice,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/atmos/storage)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -5059,31 +5074,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
-"jB" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/atmos{
-	rad_resistance = 150
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
 "jC" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "jD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7281,7 +7280,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
@@ -7547,7 +7545,7 @@
 	c_tag = "EXT - TCOMMS NORTH 2";
 	dir = 1
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/tcommsat/chamber)
@@ -7765,7 +7763,9 @@
 /obj/structure/sign/directions/stairs_up{
 	dir = 8
 	},
-/turf/simulated/wall/r_lead,
+/turf/simulated/wall/r_wall{
+	cached_rad_resistance = 150
+	},
 /area/engineering/atmos/storage)
 "om" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8214,12 +8214,10 @@
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
 "oQ" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10044,11 +10042,12 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "sf" = (
+/obj/item/device/geiger/wall/east,
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -11792,6 +11791,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
+"vx" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/atmos,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/engineering/atmos/storage)
 "vy" = (
 /obj/structure/toilet{
 	dir = 1
@@ -12529,9 +12552,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "wQ" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_monitoring)
+/turf/simulated/wall/r_wall{
+	cached_rad_resistance = 150
+	},
+/area/engineering/atmos/storage)
 "wR" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced,
@@ -12836,19 +12860,23 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xu" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
 	},
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - R-UST Exterior, East";
-	dir = 5
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Roof Access"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_monitoring)
 "xv" = (
 /obj/structure/table/glass,
@@ -13598,8 +13626,7 @@
 /area/library_conference_room)
 "yO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access";
-	rad_resistance = 150
+	name = "Roof Access"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
@@ -14145,13 +14172,10 @@
 	},
 /area/surface/outside/plains/outpost)
 "zW" = (
-/mob/living/simple_mob/animal/passive/cat/bluespace{
-	dir = 4
+/turf/simulated/wall/r_wall{
+	cached_rad_resistance = 150
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/area/quartermaster/warehouse)
 "zX" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/space_heater,
@@ -16826,15 +16850,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
-"EU" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 "EV" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -17186,8 +17201,7 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Fuel Storage Room";
-	req_one_access = list(11);
-	rad_resistance = 150
+	req_one_access = list(11)
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -17469,8 +17483,7 @@
 "Gg" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Fuel Storage Room";
-	req_one_access = list(11);
-	rad_resistance = 150
+	req_one_access = list(11)
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -18090,10 +18103,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Hl" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
 	},
-/area/quartermaster/warehouse)
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "Hm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -18365,20 +18387,7 @@
 	},
 /area/security/prison)
 "HR" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access";
-	rad_resistance = 150
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/tiny,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_room)
 "HS" = (
 /obj/structure/railing,
@@ -18401,7 +18410,7 @@
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/engineering/engine_room)
+/area/surface/outside/plains/outpost)
 "HV" = (
 /obj/structure/marker_beacon{
 	icon_state = "markerjade-on";
@@ -18801,10 +18810,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
-"IE" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/atmos/storage)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18854,19 +18859,6 @@
 	d1 = 32
 	},
 /turf/simulated/open,
-/area/engineering/engine_room)
-"IL" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
 /area/engineering/engine_room)
 "IM" = (
 /obj/structure/bed/chair/sofa/right/black{
@@ -19090,8 +19082,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room Internal Access";
-	req_one_access = list(11);
-	rad_resistance = 150
+	req_one_access = list(11)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19266,8 +19257,16 @@
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
 "JD" = (
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_room)
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "JE" = (
 /obj/machinery/computer/fusion_fuel_control{
 	id_tag = "Reactor Fuel Injectors"
@@ -19391,20 +19390,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
-"JR" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 4;
-	icon_state = "32-4"
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/engineering/atmos/storage)
 "JS" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
@@ -19689,8 +19674,7 @@
 "Kw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room External Access";
-	req_one_access = list(11);
-	rad_resistance = 150
+	req_one_access = list(11)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20167,6 +20151,13 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
+"Lq" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "Lr" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -20314,6 +20305,16 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
+"LH" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "LI" = (
 /obj/structure/railing{
 	dir = 4
@@ -20743,19 +20744,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "Mt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_room)
 "Mu" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -21343,13 +21334,10 @@
 	},
 /area/tcommsat/chamber)
 "Nx" = (
-/obj/structure/railing,
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
@@ -21621,8 +21609,13 @@
 	},
 /area/surface/outside/plains/outpost)
 "NW" = (
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_monitoring)
+/mob/living/simple_mob/animal/passive/cat/bluespace{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "NX" = (
 /obj/structure/closet/l3closet/security,
 /obj/structure/window/reinforced{
@@ -22147,24 +22140,7 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "OZ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Roof Access";
-	rad_resistance = 150
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_monitoring)
 "Pa" = (
 /obj/machinery/door/firedoor/border_only,
@@ -23429,11 +23405,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Rv" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	outdoors = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
 	},
-/area/surface/outside/plains/outpost/sky)
+/turf/simulated/floor/plating,
+/area/engineering/atmos/storage)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -23852,28 +23834,19 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "Sk" = (
-/obj/structure/lattice,
-/obj/structure/railing/grey{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/engineering/atmos/storage)
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "Sl" = (
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -24241,15 +24214,9 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "SQ" = (
-/obj/item/device/geiger/wall/east,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_monitoring)
 "SR" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -25403,13 +25370,6 @@
 /obj/machinery/computer/supplycomp/control,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
-"Vd" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost/sky)
 "Ve" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm{
@@ -25515,9 +25475,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
 "Vp" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_room)
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
+	icon_state = "32-4"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/atmos/storage)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27215,8 +27185,14 @@
 	},
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
 "YV" = (
-/turf/simulated/wall/r_lead,
-/area/engineering/atmos/storage)
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "YW" = (
 /turf/simulated/wall,
 /area/quartermaster/storage)
@@ -40948,11 +40924,11 @@ zv
 zv
 zv
 zv
-zv
-zv
-zv
-zv
-zv
+xD
+xD
+xD
+xD
+xD
 Wn
 IU
 LU
@@ -41205,11 +41181,11 @@ zv
 zv
 zv
 zv
-zv
-zv
-zv
-zv
-zv
+xD
+xD
+xD
+xD
+xD
 Wn
 IU
 LW
@@ -41462,10 +41438,10 @@ zv
 zv
 zv
 zv
-zv
-zv
-zv
-zv
+xD
+xD
+xD
+xD
 nX
 Wn
 IU
@@ -41713,17 +41689,17 @@ zv
 zv
 io
 zv
-YV
-YV
-iz
-iz
-YV
-iz
-iz
-YV
-YV
-YV
-zv
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+xD
 Wn
 IU
 Ma
@@ -41970,17 +41946,17 @@ zv
 zv
 io
 zv
-YV
+dn
 Qu
 Qu
 Qu
 Qu
 Qu
 Pq
-JR
+Vp
 Pq
-YV
-zv
+wQ
+xD
 Wn
 IU
 Mb
@@ -42227,17 +42203,17 @@ zv
 zv
 io
 zv
-YV
+dn
 ig
 ig
 ig
 ig
 ig
 aR
-Sk
+ji
 wq
-YV
-zv
+wQ
+xD
 Wn
 IU
 Mc
@@ -42484,7 +42460,7 @@ zv
 zv
 io
 zv
-YV
+dn
 mN
 mN
 mN
@@ -42493,8 +42469,8 @@ mN
 Pq
 qN
 ch
-YV
-zv
+wQ
+xD
 Wn
 IU
 LX
@@ -42741,7 +42717,7 @@ zv
 zv
 io
 zv
-YV
+dn
 xq
 xq
 xq
@@ -42750,8 +42726,8 @@ xq
 aR
 qN
 ch
-YV
-zv
+wQ
+xD
 Wn
 IU
 Mf
@@ -42997,8 +42973,8 @@ zv
 zv
 zv
 io
-EG
-IE
+zv
+dn
 dI
 dI
 dI
@@ -43008,7 +42984,7 @@ Pq
 ET
 Pq
 ol
-zv
+xD
 Wn
 IU
 Mh
@@ -43253,9 +43229,9 @@ zv
 zv
 zv
 zv
-wU
-Rv
-jB
+io
+zv
+dn
 Pq
 aJ
 Pq
@@ -43264,8 +43240,8 @@ Pq
 Pq
 ET
 fP
-YV
-zv
+wQ
+xD
 Wn
 IU
 Mj
@@ -43510,9 +43486,9 @@ zv
 zv
 zv
 zv
-wU
-Rv
-YV
+io
+zv
+dn
 hK
 dN
 gv
@@ -43521,7 +43497,7 @@ VV
 Am
 eJ
 gL
-YV
+wQ
 br
 Ub
 Ld
@@ -43767,9 +43743,9 @@ zv
 zv
 zv
 zv
-wU
-Rv
-YV
+io
+zv
+dn
 hK
 rI
 cK
@@ -43778,8 +43754,8 @@ dB
 wr
 CM
 gL
-YV
-zv
+wQ
+xD
 Ub
 Ld
 Ml
@@ -44024,9 +44000,9 @@ io
 io
 io
 io
-wU
-Vd
-YV
+io
+io
+dn
 MS
 Oy
 Oy
@@ -44035,8 +44011,8 @@ sK
 zK
 mm
 gL
-YV
-io
+wQ
+wu
 Ub
 Ld
 Mo
@@ -44281,19 +44257,19 @@ zv
 zv
 zv
 zv
-wU
-Rv
-YV
-YV
-YV
-YV
-YV
-YV
-YV
-YV
-YV
-YV
+io
 EG
+dn
+dn
+Rv
+Rv
+Rv
+dn
+dn
+vx
+dn
+dn
+Wo
 Ub
 Ub
 Ub
@@ -44797,16 +44773,16 @@ YK
 xC
 JW
 OV
-JD
-JD
-JD
-JD
-JD
-JD
-JD
-JD
-JD
-JD
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
 Ci
 YK
 YK
@@ -45054,20 +45030,20 @@ yO
 uQ
 uQ
 uQ
-JD
-JD
-JD
-Vp
-JD
-JD
-JD
-JD
-JD
-wQ
-NW
+HR
+HR
+HR
+Mt
+HR
+HR
+HR
+HR
+HR
+SQ
+OZ
 Kr
 Lg
-NW
+OZ
 Rl
 yr
 jP
@@ -45324,7 +45300,7 @@ Jh
 Jz
 Ks
 Li
-NW
+OZ
 Rl
 xD
 xD
@@ -45568,7 +45544,7 @@ yP
 xH
 Bs
 CI
-JD
+HR
 EJ
 Fp
 Fx
@@ -45581,7 +45557,7 @@ Jh
 JE
 Kt
 Lj
-NW
+OZ
 Nd
 YK
 YK
@@ -45838,10 +45814,10 @@ Xk
 JG
 Kt
 Lk
-NW
-NW
-NW
-NW
+OZ
+OZ
+OZ
+OZ
 xD
 xD
 Rl
@@ -46082,7 +46058,7 @@ yR
 za
 Bv
 CP
-JD
+HR
 EJ
 Fw
 FZ
@@ -46098,8 +46074,8 @@ Lo
 Mr
 Ne
 vF
-NW
-jC
+OZ
+LH
 xD
 Ci
 jj
@@ -46345,20 +46321,20 @@ ZC
 Ga
 Fx
 GR
-Vp
+Mt
 HG
 Iv
 Jh
 JL
 nT
 yf
-wQ
+SQ
 ho
 kX
-wQ
+SQ
 xD
 xD
-xD
+NW
 Rl
 NV
 TS
@@ -46596,24 +46572,24 @@ za
 Ap
 BA
 CU
-JD
-JD
+HR
+HR
 Fy
 Gb
 Fy
-Vp
-JD
+Mt
+HR
 HH
 Iw
-NW
-NW
-NW
-NW
-NW
+OZ
+OZ
+OZ
+OZ
+OZ
 Gd
 NT
-NW
-zW
+OZ
+xD
 xD
 xD
 Rl
@@ -46853,7 +46829,7 @@ zc
 Aq
 BB
 CV
-JD
+HR
 EL
 FB
 Gc
@@ -46863,13 +46839,13 @@ Hd
 HJ
 Iz
 Ji
-Mt
+Sk
 Kw
 JM
 VB
 Gd
 ny
-NW
+OZ
 PM
 xD
 xD
@@ -47116,17 +47092,17 @@ FE
 Gf
 Gy
 GT
-EU
+jC
 HN
 IC
-JD
-wQ
-NW
-ho
+HR
+SQ
+OZ
+Lq
 Ms
 bB
 NU
-OZ
+xu
 fR
 fR
 fR
@@ -47373,17 +47349,17 @@ FF
 Wl
 HN
 GU
-EU
+jC
 HN
 IF
-JD
-NW
-NW
-NW
-NW
-wQ
-NW
-NW
+HR
+OZ
+OZ
+OZ
+OZ
+SQ
+OZ
+OZ
 PM
 xD
 xD
@@ -47633,17 +47609,17 @@ GV
 Hg
 HP
 IJ
-JD
-NW
-NW
-wQ
-NW
-NW
-NW
-NW
+HR
+OZ
+OZ
+SQ
+OZ
+OZ
+OZ
+OZ
+xD
+xD
 JN
-OH
-OH
 ss
 xD
 Za
@@ -47885,32 +47861,32 @@ Wl
 EQ
 FI
 Wl
-JD
-JD
-SQ
+HR
+HR
 sf
+YV
 IK
-JD
-JD
+HR
+HR
 xD
 xD
-xu
+ha
+OH
+OH
 OH
 OH
 OH
 ss
 xD
 xD
-xD
-xD
 Za
 ON
 nB
-Hl
-Hl
-Hl
-Hl
-Hl
+zW
+zW
+zW
+zW
+zW
 Yt
 QF
 QF
@@ -48142,13 +48118,13 @@ Wl
 ER
 FK
 Wl
-JD
-JD
-JD
 HR
-JD
-JD
-JD
+HR
+HR
+HR
+HR
+HR
+HR
 xD
 Lt
 Wb
@@ -48163,7 +48139,7 @@ xD
 Za
 ON
 zv
-Hl
+zW
 VC
 VG
 VG
@@ -48401,14 +48377,14 @@ Wl
 Wl
 wt
 yV
-IL
+YK
 HU
-ha
+Hl
 IO
 IO
-oQ
-oQ
 Nx
+Nx
+JD
 zC
 zC
 zC
@@ -48420,7 +48396,7 @@ xD
 Za
 ON
 zv
-Hl
+zW
 VD
 VG
 VG
@@ -48655,7 +48631,7 @@ Ci
 YK
 CK
 YK
-CK
+YK
 OV
 xD
 ZU
@@ -48677,7 +48653,7 @@ xD
 Za
 ON
 zv
-Hl
+zW
 yt
 Ws
 VG
@@ -48934,7 +48910,7 @@ xD
 Za
 ON
 zv
-Hl
+zW
 VM
 Wt
 WQ
@@ -69736,7 +69712,7 @@ xD
 xD
 xD
 xD
-xD
+oQ
 xD
 xD
 xD

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -1694,17 +1694,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/ai_upload)
-"dn" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
 "do" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
@@ -3626,6 +3615,20 @@
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing/three)
+"ha" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "hb" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -4463,19 +4466,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "iz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced_phoron,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/area/engineering/atmos/storage)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4889,20 +4890,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
-"ji" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -5080,7 +5067,9 @@
 	name = "Engineering Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/atmos,
+/obj/machinery/door/airlock/atmos{
+	rad_resistance = 150
+	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
@@ -8224,6 +8213,14 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
+"oQ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -12534,7 +12531,7 @@
 "wQ" = (
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_lead,
-/area/engineering/engine_room)
+/area/engineering/engine_monitoring)
 "wR" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced,
@@ -12839,28 +12836,20 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xu" = (
-/obj/structure/lattice,
-/obj/structure/railing/grey{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/structure/railing/grey{
-	dir = 1
+/obj/structure/catwalk,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 4
+/obj/machinery/camera/network/exterior{
+	c_tag = "EXT - R-UST Exterior, East";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/engineering/atmos/storage)
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "xv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -14156,14 +14145,13 @@
 	},
 /area/surface/outside/plains/outpost)
 "zW" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/mob/living/simple_mob/animal/passive/cat/bluespace{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "zX" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/space_heater,
@@ -16839,9 +16827,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "EU" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/engine_monitoring)
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "EV" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -18097,12 +18090,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Hl" = (
-/obj/effect/zone_divider,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	outdoors = 1
+/turf/simulated/wall/r_wall{
+	cached_rad_resistance = 150
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/quartermaster/warehouse)
 "Hm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -18811,15 +18802,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "IE" = (
-/obj/item/device/geiger/wall/east,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/atmos/storage)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18869,6 +18854,19 @@
 	d1 = 32
 	},
 /turf/simulated/open,
+/area/engineering/engine_room)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
 /area/engineering/engine_room)
 "IM" = (
 /obj/structure/bed/chair/sofa/right/black{
@@ -19393,6 +19391,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
+"JR" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
+	icon_state = "32-4"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/atmos/storage)
 "JS" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
@@ -20155,10 +20167,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"Lq" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_lead,
-/area/engineering/atmos/storage)
 "Lr" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -20306,12 +20314,6 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
-"LH" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost/sky)
 "LI" = (
 /obj/structure/railing{
 	dir = 4
@@ -20741,17 +20743,19 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "Mt" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
+/area/engineering/engine_monitoring)
 "Mu" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -21338,6 +21342,17 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
+"Nx" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/surface/outside/plains/outpost)
 "Ny" = (
 /obj/machinery/telecomms/bus/preset_two/southerncross,
 /turf/simulated/floor/tiled/dark{
@@ -23414,20 +23429,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "Rv" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
 /obj/structure/catwalk,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
+/turf/simulated/floor/plating{
+	outdoors = 1
 	},
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - R-UST Exterior, East";
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/area/surface/outside/plains/outpost/sky)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -23845,6 +23851,29 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
+"Sk" = (
+/obj/structure/lattice,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/engineering/atmos/storage)
 "Sl" = (
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
@@ -24212,17 +24241,14 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "SQ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/item/device/geiger/wall/east,
 /obj/structure/catwalk,
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating{
-	outdoors = 1
-	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "SR" = (
 /obj/structure/disposalpipe/junction{
@@ -25246,14 +25272,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
-"UM" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/surface/outside/plains/outpost)
 "UN" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 8
@@ -25386,19 +25404,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
 "Vd" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 4;
-	icon_state = "32-4"
-	},
-/turf/simulated/open{
+/obj/effect/zone_divider,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/engineering/atmos/storage)
+/area/surface/outside/plains/outpost/sky)
 "Ve" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm{
@@ -25504,13 +25515,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/solars)
 "Vp" = (
-/mob/living/simple_mob/animal/passive/cat/bluespace{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_room)
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -41708,11 +41715,11 @@ io
 zv
 YV
 YV
+iz
+iz
 YV
-YV
-YV
-YV
-YV
+iz
+iz
 YV
 YV
 YV
@@ -41970,7 +41977,7 @@ Qu
 Qu
 Qu
 Pq
-Vd
+JR
 Pq
 YV
 zv
@@ -42227,7 +42234,7 @@ ig
 ig
 ig
 aR
-xu
+Sk
 wq
 YV
 zv
@@ -42991,7 +42998,7 @@ zv
 zv
 io
 EG
-Lq
+IE
 dI
 dI
 dI
@@ -43247,7 +43254,7 @@ zv
 zv
 zv
 wU
-LH
+Rv
 jB
 Pq
 aJ
@@ -43504,8 +43511,8 @@ zv
 zv
 zv
 wU
-LH
-Mt
+Rv
+YV
 hK
 dN
 gv
@@ -43761,8 +43768,8 @@ zv
 zv
 zv
 wU
-LH
-Mt
+Rv
+YV
 hK
 rI
 cK
@@ -44018,7 +44025,7 @@ io
 io
 io
 wU
-Hl
+Vd
 YV
 MS
 Oy
@@ -44275,7 +44282,7 @@ zv
 zv
 zv
 wU
-LH
+Rv
 YV
 YV
 YV
@@ -45050,13 +45057,13 @@ uQ
 JD
 JD
 JD
+Vp
+JD
+JD
+JD
+JD
+JD
 wQ
-JD
-JD
-JD
-JD
-JD
-EU
 NW
 Kr
 Lg
@@ -46338,17 +46345,17 @@ ZC
 Ga
 Fx
 GR
-wQ
+Vp
 HG
 Iv
 Jh
 JL
 nT
 yf
-EU
+wQ
 ho
 kX
-EU
+wQ
 xD
 xD
 xD
@@ -46594,7 +46601,7 @@ JD
 Fy
 Gb
 Fy
-wQ
+Vp
 JD
 HH
 Iw
@@ -46606,7 +46613,7 @@ NW
 Gd
 NT
 NW
-Vp
+zW
 xD
 xD
 Rl
@@ -46856,7 +46863,7 @@ Hd
 HJ
 Iz
 Ji
-iz
+Mt
 Kw
 JM
 VB
@@ -47109,11 +47116,11 @@ FE
 Gf
 Gy
 GT
-zW
+EU
 HN
 IC
 JD
-EU
+wQ
 NW
 ho
 Ms
@@ -47366,7 +47373,7 @@ FF
 Wl
 HN
 GU
-zW
+EU
 HN
 IF
 JD
@@ -47374,7 +47381,7 @@ NW
 NW
 NW
 NW
-EU
+wQ
 NW
 NW
 PM
@@ -47629,7 +47636,7 @@ IJ
 JD
 NW
 NW
-EU
+wQ
 NW
 NW
 NW
@@ -47880,14 +47887,14 @@ FI
 Wl
 JD
 JD
-IE
+SQ
 sf
 IK
 JD
 JD
 xD
 xD
-Rv
+xu
 OH
 OH
 OH
@@ -47899,11 +47906,11 @@ xD
 Za
 ON
 nB
-QF
-QF
-QF
-QF
-QF
+Hl
+Hl
+Hl
+Hl
+Hl
 Yt
 QF
 QF
@@ -48156,7 +48163,7 @@ xD
 Za
 ON
 zv
-QF
+Hl
 VC
 VG
 VG
@@ -48394,14 +48401,14 @@ Wl
 Wl
 wt
 yV
-SQ
+IL
 HU
-ji
+ha
 IO
 IO
-UM
-UM
-dn
+oQ
+oQ
+Nx
 zC
 zC
 zC
@@ -48413,7 +48420,7 @@ xD
 Za
 ON
 zv
-QF
+Hl
 VD
 VG
 VG
@@ -48670,7 +48677,7 @@ xD
 Za
 ON
 zv
-QF
+Hl
 yt
 Ws
 VG
@@ -48927,7 +48934,7 @@ xD
 Za
 ON
 zv
-QF
+Hl
 VM
 Wt
 WQ
@@ -49184,7 +49191,7 @@ xD
 Za
 ON
 zv
-HT
+Vb
 Vb
 Vb
 WS

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -245,7 +245,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1062,7 +1062,7 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/library_conference_room)
 "cd" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1360,12 +1360,19 @@
 "cI" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - AI Subgrid";
+	name_tag = "Cargo Subgrid"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/ai_upload)
@@ -2023,6 +2030,16 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "dW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
 "dX" = (
@@ -2767,6 +2784,11 @@
 "ff" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing)
 "fg" = (
@@ -3811,22 +3833,19 @@
 	},
 /area/library_conference_room)
 "hr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
@@ -4489,15 +4508,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
-"iz" = (
-/obj/machinery/light/no_nightshift,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4586,6 +4596,14 @@
 /obj/item/weapon/circuitboard/telecomms/exonet_node,
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
+"iF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "iG" = (
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 3 North";
@@ -4620,7 +4638,8 @@
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -4998,6 +5017,16 @@
 "jq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
 "jr" = (
@@ -5109,6 +5138,15 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "jB" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/gps/security,
+/obj/item/clothing/accessory/badge/holo/cord,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -5196,7 +5234,7 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "jJ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -6210,23 +6248,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
-"lB" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/device/gps/security,
-/obj/item/clothing/accessory/badge/holo/cord,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
 "lC" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - CIV Lounge South 5"
@@ -6727,15 +6748,20 @@
 /area/security/prison)
 "mq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
@@ -7006,15 +7032,24 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "mX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/security/security_lockerroom)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "mY" = (
 /obj/machinery/shower{
 	pixel_y = 9
@@ -8228,7 +8263,9 @@
 "oM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8238,6 +8275,15 @@
 /turf/simulated/floor/reinforced{
 	outdoors = 1
 	},
+/area/surface/outpost/main/landing)
+"oO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/surface/outpost/main/landing)
 "oP" = (
 /obj/structure/bed/padded,
@@ -8314,6 +8360,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
 "oX" = (
@@ -8361,10 +8412,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
@@ -8630,7 +8681,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -8867,7 +8918,7 @@
 	c_tag = "MED - Virology Stairway";
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -8932,9 +8983,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = -3;
 	pixel_y = 20
-	},
-/obj/structure/cable/blue{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
@@ -9340,7 +9388,7 @@
 	icon_state = "markerjade-on";
 	picked_color = "Jade"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -10104,6 +10152,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"sg" = (
+/obj/machinery/light/no_nightshift,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "sh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10283,7 +10340,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -10711,7 +10768,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -10729,7 +10788,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -10749,7 +10808,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -10949,7 +11010,9 @@
 	id_tag = "ursula_dock";
 	pixel_x = -26
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -10957,20 +11020,13 @@
 	},
 /area/surface/outpost/main/landing/three)
 "tR" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing/three)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "tS" = (
 /obj/structure/closet/walllocker_double{
 	pixel_x = 32
@@ -10996,7 +11052,7 @@
 /obj/effect/floor_decal/steeldecal/monofloor{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11042,7 +11098,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11066,7 +11122,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -11103,14 +11161,12 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-8"
-	},
+/obj/structure/cable,
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 3 Southeast";
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -11142,7 +11198,9 @@
 	c_tag = "CIV - Hangar Pad 4 Southwest";
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -11180,7 +11238,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11200,20 +11258,11 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "um" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/carpet/blue2,
+/area/library_conference_room)
 "un" = (
 /obj/machinery/gateway,
 /obj/effect/floor_decal/techfloor/orange,
@@ -11230,15 +11279,22 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
 "uq" = (
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/blue{
-	d1 = 2;
+/obj/structure/cable/green{
+	d1 = 32;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "32-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
+/turf/simulated/open,
 /area/surface/outpost/main/landing)
 "ur" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -11264,7 +11320,9 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -11296,7 +11354,8 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/network/civilian{
@@ -11354,7 +11413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -11483,12 +11542,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/surface/outpost/main/teleporter)
 "uN" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced{
@@ -11544,6 +11605,16 @@
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_lead,
 /area/engineering/engine_waste)
+"uT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/medical_lockerroom)
 "uU" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -11601,6 +11672,15 @@
 /obj/machinery/camera/network/command{
 	c_tag = "COM - Teleporter Exterior";
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -11777,7 +11857,7 @@
 	icon_state = "markerburgundy-on";
 	picked_color = "Burgundy"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -12069,19 +12149,10 @@
 "vR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -12120,11 +12191,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "vW" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -12349,7 +12419,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "ww" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -12851,11 +12921,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "xl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
@@ -12997,7 +13062,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13618,7 +13683,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/virology)
 "yH" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -13946,9 +14011,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
@@ -14326,14 +14390,10 @@
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "Ai" = (
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
 /area/surface/outpost/main/landing)
 "Aj" = (
 /turf/simulated/floor/carpet/bcarpet,
@@ -14385,13 +14445,14 @@
 	},
 /area/crew_quarters/cafeteria)
 "Ao" = (
-/obj/structure/cable/blue{
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outpost/main/landing)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Ap" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -14610,13 +14671,15 @@
 	name = "Station Intercom (General)";
 	pixel_y = -21
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/gateway)
 "AO" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -14643,17 +14706,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blue,
 /area/bridge)
-"AS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "AT" = (
 /obj/machinery/computer/rcon{
 	dir = 4
@@ -14755,7 +14807,9 @@
 "Be" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/vials,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -14794,7 +14848,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14863,7 +14917,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14875,7 +14929,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14883,7 +14937,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Bo" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14913,7 +14967,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -14931,23 +14985,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"Br" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/device/gps/security,
-/obj/item/clothing/accessory/badge/holo/cord,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -15093,7 +15130,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "BG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15425,12 +15464,6 @@
 	dir = 1
 	},
 /obj/structure/railing,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 1
-	},
 /turf/simulated/open,
 /area/surface/outpost/main/landing)
 "Ci" = (
@@ -15914,9 +15947,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "32-1"
-	},
 /turf/simulated/open,
 /area/surface/outpost/main/landing)
 "Dh" = (
@@ -16379,7 +16409,7 @@
 	name = "Virology Emergency Quarantine Blast Doors";
 	opacity = 0
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16410,25 +16440,6 @@
 	outdoors = 1
 	},
 /area/surface/outpost/civilian/pool)
-"DW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "DX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -16437,7 +16448,7 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "DY" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -16623,11 +16634,6 @@
 /area/library_conference_room)
 "Eq" = (
 /obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -21
@@ -16718,7 +16724,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16768,7 +16774,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -16843,14 +16851,10 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "EH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
@@ -17005,6 +17009,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
+"EU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/security_lockerroom)
 "EV" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -17151,7 +17175,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17512,7 +17536,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17757,7 +17781,7 @@
 	name = "Virology Emergency Quarantine Blast Doors";
 	opacity = 0
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18224,20 +18248,6 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/bmarble,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
-"Hi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "Hj" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/solgov/utility/army{
@@ -18748,22 +18758,17 @@
 	},
 /area/crew_quarters/cafeteria)
 "Ik" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Il" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19019,6 +19024,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
+"IE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19069,6 +19088,18 @@
 	},
 /turf/simulated/open,
 /area/engineering/engine_room)
+"IL" = (
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "IM" = (
 /obj/structure/bed/chair/sofa/right/black{
 	dir = 4
@@ -19610,6 +19641,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "JQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
+"JR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -19627,27 +19669,17 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
-"JT" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
 "JU" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "JV" = (
 /obj/structure/table/marble,
 /obj/random/cigarettes,
@@ -20010,11 +20042,6 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttle3/start)
 "KD" = (
-/obj/structure/cable/green{
-	icon_state = "32-2";
-	d1 = 32;
-	d2 = 2
-	},
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Library Southeast";
 	dir = 8
@@ -20121,7 +20148,7 @@
 	name = "Virology Emergency Quarantine Blast Doors";
 	opacity = 0
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20170,10 +20197,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
-	d1 = 4;
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
@@ -20256,21 +20283,19 @@
 	},
 /area/surface/outside/plains/outpost)
 "Lb" = (
-/obj/machinery/light/no_nightshift,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Lc" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced{
@@ -20443,6 +20468,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/landing)
 "Lt" = (
@@ -20462,6 +20492,11 @@
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "Lw" = (
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
+	icon_state = "32-8"
+	},
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -20642,8 +20677,8 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/library_conference_room)
@@ -21054,7 +21089,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -21073,13 +21108,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "Mz" = (
-/obj/structure/cable{
-	d1 = 1;
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/security/security_lockerroom)
 "MA" = (
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint{
@@ -21575,7 +21612,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular{
@@ -21638,7 +21677,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/zone_divider,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -22057,13 +22096,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "2-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -22072,16 +22108,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -22092,9 +22125,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = 24
-	},
-/obj/structure/cable/blue{
-	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22495,9 +22525,6 @@
 /area/medical/medical_lockerroom)
 "Pg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
 "Ph" = (
@@ -22536,7 +22563,7 @@
 /area/medical/medical_lockerroom)
 "Pn" = (
 /obj/effect/zone_divider,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -22877,7 +22904,9 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "PS" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23059,7 +23088,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -23089,9 +23118,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -23450,17 +23476,18 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "Ra" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "Rb" = (
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
@@ -23544,7 +23571,9 @@
 	},
 /area/surface/outside/plains/outpost)
 "Rm" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23601,7 +23630,9 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
 	icon_state = "32-4"
 	},
 /obj/machinery/door/firedoor/glass,
@@ -23637,8 +23668,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -23654,9 +23692,6 @@
 "Rs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -23687,17 +23722,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
-"Rw" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
 "Rx" = (
 /obj/random/junk,
 /obj/random/toolbox,
@@ -23758,7 +23782,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -23914,15 +23938,14 @@
 	},
 /area/surface/outside/plains/outpost)
 "RT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint{
+/turf/simulated/open{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -24043,11 +24066,21 @@
 /turf/simulated/open,
 /area/medical/medical_lockerroom)
 "Se" = (
-/obj/structure/cable/blue{
-	icon_state = "1-2"
+/obj/machinery/light/no_nightshift,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/medical_lockerroom)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "Sf" = (
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 1;
@@ -24143,7 +24176,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -24605,6 +24639,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
 "Ta" = (
@@ -24618,6 +24657,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -24693,8 +24737,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-4"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
@@ -24705,7 +24751,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24932,8 +24980,9 @@
 "TF" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/landing)
@@ -24950,7 +24999,7 @@
 "TH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -24976,7 +25025,9 @@
 	name = "Morgue Access";
 	req_access = list(6)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25295,7 +25346,9 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "Up" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25535,19 +25588,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
 "UM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/plating,
+/area/surface/outpost/main/landing)
 "UN" = (
 /obj/structure/bed/chair/sofa/left/black{
 	dir = 8
@@ -25604,9 +25657,14 @@
 /obj/structure/catwalk,
 /obj/structure/lattice,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/open{
 	outdoors = 1
@@ -25680,18 +25738,25 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
 "Vd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/glass_research{
+	name = "Expedition Shuttle";
+	req_access = list();
+	req_one_access = list(5,43,67)
 	},
-/obj/structure/cable{
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
+/turf/simulated/floor/tiled/techmaint,
+/area/surface/outpost/main/landing)
 "Ve" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm{
@@ -25775,7 +25840,9 @@
 /area/surface/outside/plains/outpost)
 "Vn" = (
 /obj/machinery/light/no_nightshift,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25813,7 +25880,9 @@
 "Vq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26138,7 +26207,7 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/quartermaster/qm)
 "Wa" = (
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26230,7 +26299,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -26375,6 +26446,17 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
+"WA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "WB" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -26430,7 +26512,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -26452,7 +26536,8 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -26587,13 +26672,18 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "WX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/crew_quarters/cafeteria)
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "WY" = (
 /obj/machinery/camera/network/prison{
 	c_tag = "SEC - Prison Wing Exterior West 2";
@@ -26779,7 +26869,7 @@
 	icon_state = "markerburgundy-on";
 	picked_color = "Burgundy"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -26896,7 +26986,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_isolation)
 "XD" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -27019,6 +27111,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
+"XO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "XP" = (
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/main/bar)
@@ -27029,17 +27134,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
-"XR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "XS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27828,7 +27922,7 @@
 /obj/structure/railing,
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/cable/blue{
+/obj/structure/cable{
 	d1 = 32;
 	d2 = 2;
 	icon_state = "32-2"
@@ -49546,7 +49640,7 @@ rZ
 qY
 Tr
 LM
-LM
+um
 Eq
 Vg
 tk
@@ -56913,8 +57007,8 @@ xD
 ez
 od
 pq
-XR
-UM
+WA
+Lb
 xD
 xD
 xD
@@ -57169,7 +57263,7 @@ xD
 xD
 xD
 te
-RT
+WX
 xD
 xD
 xD
@@ -57426,7 +57520,7 @@ xD
 xD
 xD
 te
-RT
+WX
 xD
 xD
 xD
@@ -57683,7 +57777,7 @@ xD
 xD
 xD
 te
-RT
+WX
 xD
 xD
 xD
@@ -57938,9 +58032,9 @@ fo
 jw
 kE
 HX
-Hi
+IE
 oh
-Vd
+XO
 xD
 Vi
 sm
@@ -57957,14 +58051,14 @@ TR
 HO
 TR
 BQ
-JU
-JU
-JU
-JU
-JU
+Ra
+Ra
+Ra
+Ra
+Ra
 Hm
-vW
-EH
+Ao
+Ik
 XP
 Kh
 KQ
@@ -58239,10 +58333,10 @@ Ua
 UB
 UR
 Vk
-Ik
 UU
-UU
-UU
+RT
+RT
+RT
 qb
 ZM
 Kx
@@ -58478,7 +58572,7 @@ fW
 Co
 PW
 XU
-WX
+tR
 XP
 Kj
 KT
@@ -58735,7 +58829,7 @@ zv
 tU
 UQ
 XU
-iz
+sg
 XP
 yg
 KV
@@ -58992,7 +59086,7 @@ zv
 tU
 If
 XU
-WX
+tR
 XP
 XP
 oe
@@ -59249,19 +59343,19 @@ zv
 tU
 Ib
 Ib
-JT
+vW
 Js
 Kl
 Pu
 Pu
 MH
-Mz
-Rw
-Mz
-Mz
-JQ
+EH
+JU
+EH
+EH
+JR
 RJ
-Ra
+IL
 Tw
 eb
 eb
@@ -59475,7 +59569,7 @@ xD
 ua
 ua
 qu
-mX
+Mz
 JC
 ua
 ua
@@ -59518,7 +59612,7 @@ XU
 XU
 Rc
 RL
-Lb
+Se
 PW
 Uh
 UG
@@ -59733,7 +59827,7 @@ ua
 hS
 qG
 cE
-Br
+jB
 Sz
 cJ
 lJ
@@ -59990,7 +60084,7 @@ ua
 im
 rL
 JP
-jB
+iF
 ud
 ua
 lL
@@ -60247,7 +60341,7 @@ ua
 jn
 sE
 VU
-hr
+EU
 Ev
 df
 lQ
@@ -60504,7 +60598,7 @@ ua
 mU
 rL
 yZ
-jB
+iF
 NX
 ua
 lR
@@ -60761,7 +60855,7 @@ ua
 pr
 rL
 yZ
-jB
+iF
 tT
 ua
 lS
@@ -61018,7 +61112,7 @@ ua
 px
 rL
 yZ
-jB
+iF
 on
 cJ
 lT
@@ -61275,7 +61369,7 @@ ua
 qp
 sO
 oL
-lB
+hr
 dt
 ua
 lV
@@ -61531,7 +61625,7 @@ xD
 ua
 ua
 ui
-mX
+Mz
 aV
 ua
 ua
@@ -61574,7 +61668,7 @@ tU
 xD
 xD
 ip
-RT
+WX
 xD
 xD
 xD
@@ -61831,7 +61925,7 @@ tU
 xD
 xD
 ip
-RT
+WX
 xD
 xD
 xD
@@ -62088,7 +62182,7 @@ tU
 xD
 xD
 ip
-RT
+WX
 xD
 xD
 xD
@@ -62345,7 +62439,7 @@ tU
 xD
 xD
 ip
-RT
+WX
 xD
 xD
 xD
@@ -62606,9 +62700,9 @@ SW
 fI
 fI
 fI
-UU
-UU
-UU
+RT
+RT
+RT
 WD
 Xm
 Yd
@@ -62859,7 +62953,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -63116,7 +63210,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -63373,7 +63467,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -63630,7 +63724,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -63886,8 +63980,8 @@ Sc
 Sc
 Sc
 Sc
-DW
-UM
+mX
+Lb
 xD
 xD
 xD
@@ -64143,7 +64237,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -64400,7 +64494,7 @@ xD
 xD
 xD
 xD
-RT
+WX
 xD
 xD
 xD
@@ -64657,7 +64751,7 @@ xD
 xD
 Tx
 xD
-RT
+WX
 xD
 xD
 xD
@@ -64914,7 +65008,7 @@ ED
 Wo
 Wo
 xD
-RT
+WX
 PN
 PN
 PN
@@ -65171,7 +65265,7 @@ Od
 Lp
 PY
 YF
-RT
+WX
 SX
 PB
 PB
@@ -65428,7 +65522,7 @@ ZK
 Kp
 vC
 YF
-RT
+WX
 NC
 NC
 NC
@@ -65685,7 +65779,7 @@ MQ
 ZK
 vC
 YF
-RT
+WX
 xD
 xD
 xD
@@ -65942,7 +66036,7 @@ ZK
 ZK
 vC
 YF
-RT
+WX
 PN
 PN
 PN
@@ -66199,7 +66293,7 @@ ZK
 ZK
 vC
 YF
-RT
+WX
 SX
 PB
 PB
@@ -66456,7 +66550,7 @@ MQ
 ZK
 vC
 YF
-RT
+WX
 NC
 NC
 NC
@@ -66713,7 +66807,7 @@ ZK
 Ko
 vC
 YF
-RT
+WX
 xD
 xD
 xD
@@ -66970,7 +67064,7 @@ Oh
 lh
 Qa
 YF
-RT
+WX
 PN
 PN
 PN
@@ -67227,7 +67321,7 @@ Oi
 Ia
 Ia
 xD
-RT
+WX
 SX
 PB
 PB
@@ -67480,10 +67574,10 @@ GH
 GH
 GH
 GH
-AS
-XR
-XR
-XR
+JQ
+WA
+WA
+WA
 RW
 NC
 NC
@@ -68740,7 +68834,7 @@ ES
 ES
 gQ
 gQ
-tR
+ub
 ON
 zv
 vT
@@ -69254,7 +69348,7 @@ jZ
 Qk
 gQ
 gQ
-tR
+ub
 Uo
 EG
 vT
@@ -69283,7 +69377,7 @@ Om
 AO
 Qg
 Rq
-Us
+uT
 SZ
 Ns
 xD
@@ -69797,7 +69891,7 @@ Oo
 Pg
 Qj
 Rs
-Se
+Oj
 Th
 Nr
 Nr
@@ -70282,7 +70376,7 @@ jZ
 jZ
 gQ
 gQ
-tR
+ub
 Dq
 fW
 xa
@@ -72852,7 +72946,7 @@ rX
 ht
 sS
 lX
-um
+us
 ON
 zv
 zv
@@ -73109,7 +73203,7 @@ ht
 ht
 lX
 sU
-um
+us
 ON
 zv
 zv
@@ -73366,7 +73460,7 @@ pi
 pi
 lX
 tz
-um
+us
 ON
 zv
 zv
@@ -73880,7 +73974,7 @@ ht
 ht
 sV
 lX
-um
+us
 ON
 zv
 zv
@@ -74137,7 +74231,7 @@ qM
 pi
 sX
 tD
-um
+us
 ON
 zv
 zv
@@ -74394,7 +74488,7 @@ ht
 pi
 lX
 tz
-um
+us
 ON
 zv
 zv
@@ -80846,9 +80940,9 @@ PE
 PE
 ag
 Cq
+oO
 ff
-ff
-ff
+UM
 Cq
 KN
 PE
@@ -81101,12 +81195,12 @@ Cq
 OR
 Sl
 Sl
-Ai
+Sl
 TF
 uq
 Dg
 dW
-ff
+Ai
 Sl
 Sl
 Sl
@@ -81358,8 +81452,8 @@ Cq
 Sm
 XD
 XD
-Ao
-iN
+XD
+Vd
 mq
 Ch
 Ls

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -101,7 +101,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -320,7 +320,7 @@
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2671,10 +2671,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "32-8";
+/obj/structure/cable/green{
 	d1 = 32;
-	d2 = 8
+	d2 = 8;
+	icon_state = "32-8"
 	},
 /turf/simulated/open,
 /area/quartermaster/storage)
@@ -2895,7 +2895,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -3673,7 +3673,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4641,7 +4641,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5580,7 +5580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -5985,7 +5985,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6722,11 +6722,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
 "mx" = (
@@ -6835,7 +6830,7 @@
 "mK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7966,7 +7961,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -8851,7 +8846,7 @@
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outside/plains/outpost)
 "qb" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -9181,7 +9176,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11194,7 +11189,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11264,10 +11259,10 @@
 	d1 = 32;
 	d2 = 2
 	},
-/obj/effect/floor_decal/steeldecal/monofloor,
 /obj/structure/disposalpipe/down{
 	dir = 2
 	},
+/obj/structure/catwalk,
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -11561,6 +11556,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
@@ -11937,7 +11937,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -12152,7 +12152,7 @@
 "wk" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14067,7 +14067,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -14751,7 +14751,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -15851,7 +15851,7 @@
 "Dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16949,7 +16949,7 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "Fg" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17524,7 +17524,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -18276,10 +18276,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
@@ -18569,7 +18569,7 @@
 "Im" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -19309,7 +19309,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19455,7 +19455,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19687,7 +19687,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "Kx" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -19993,17 +19993,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"Lb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/floortube{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/storage)
 "Lc" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/reinforced{
@@ -21433,10 +21422,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/storage)
@@ -21539,7 +21528,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -22161,11 +22150,6 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "Pc" = (
@@ -22180,16 +22164,6 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "Pd" = (
-/obj/structure/lattice,
-/obj/structure/cable/yellow{
-	icon_state = "32-2";
-	d1 = 32;
-	d2 = 2
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/stairs/wood_stairs{
-	name = "wooden panel"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -22205,12 +22179,7 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/obj/structure/cable{
-	icon_state = "32-8";
-	d1 = 32;
-	d2 = 8
-	},
-/turf/simulated/open,
+/turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "Pe" = (
 /obj/structure/bed/chair/sofa/black{
@@ -22641,19 +22610,9 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "PU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -22674,11 +22633,6 @@
 	picked_color = "Teal";
 	pixel_x = 9;
 	pixel_y = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
@@ -23102,7 +23056,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -23174,17 +23128,6 @@
 	},
 /area/surface/outside/plains/outpost)
 "QZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/geo,
-/area/surface/outpost/main/bar)
-"Ra" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -23490,20 +23433,10 @@
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "RE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
@@ -23512,7 +23445,7 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "RG" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23521,12 +23454,12 @@
 /area/surface/outpost/main/bar)
 "RH" = (
 /obj/structure/bed/chair/comfy/black,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -23535,7 +23468,7 @@
 /area/surface/outpost/main/bar)
 "RI" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23547,7 +23480,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/bar)
 "RJ" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23562,7 +23495,7 @@
 /turf/simulated/floor/carpet/retro,
 /area/quartermaster/storage)
 "RL" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23583,7 +23516,7 @@
 	},
 /area/surface/outpost/main/landing)
 "RN" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23627,7 +23560,7 @@
 "RS" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -23636,21 +23569,11 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
-"RT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "RU" = (
 /turf/simulated/wall/bay/blue,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "RV" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -24174,7 +24097,7 @@
 	},
 /area/crew_quarters/cafeteria)
 "SN" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24207,7 +24130,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/green,
 /obj/machinery/light/floortube{
 	dir = 8
 	},
@@ -24258,7 +24181,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
 "SW" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24577,7 +24500,7 @@
 	},
 /area/engineering/engine_waste)
 "TA" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24604,16 +24527,6 @@
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost/sky)
-"TD" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "TE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -24853,7 +24766,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -24868,12 +24781,12 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "Ua" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -24895,7 +24808,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -24908,7 +24821,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -25138,7 +25051,7 @@
 /turf/simulated/open,
 /area/crew_quarters/cafeteria)
 "UB" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25269,7 +25182,7 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/cafeteria)
 "UR" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25294,7 +25207,7 @@
 "UU" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25419,7 +25332,7 @@
 /area/crew_quarters/cafeteria)
 "Vk" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -25694,7 +25607,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -25741,7 +25654,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -25888,6 +25801,11 @@
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
+	icon_state = "32-8"
+	},
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -25928,7 +25846,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26000,7 +25918,7 @@
 	pixel_x = 26;
 	req_access = list(31)
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -26017,7 +25935,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Ww" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -26054,7 +25972,7 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/quartermaster/qm)
 "WD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -26202,7 +26120,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -26237,7 +26155,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -26255,23 +26173,22 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "WX" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/storage)
+/turf/simulated/open{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "WY" = (
 /obj/machinery/camera/network/prison{
 	c_tag = "SEC - Prison Wing Exterior West 2";
@@ -26326,7 +26243,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -26392,7 +26309,7 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/quartermaster/qm)
 "Xm" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -26402,7 +26319,7 @@
 	},
 /area/surface/outpost/civilian/pool)
 "Xn" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26412,7 +26329,7 @@
 	},
 /area/surface/outpost/civilian/pool)
 "Xo" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -26442,7 +26359,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -26590,7 +26507,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/warehouse)
 "XF" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -26604,12 +26521,12 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora_isolation)
 "XI" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26626,7 +26543,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "XJ" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26660,7 +26577,7 @@
 "XL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26671,7 +26588,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "XM" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26687,7 +26604,7 @@
 	req_access = list(41)
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -26708,7 +26625,7 @@
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
 "XS" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -27007,7 +26924,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -27034,7 +26951,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -27071,7 +26988,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -27370,7 +27287,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Zs" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -27388,7 +27305,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -27421,12 +27338,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -27449,7 +27366,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -27511,7 +27428,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -27559,7 +27476,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -27569,7 +27486,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -27579,7 +27496,7 @@
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/barrestroom)
 "ZN" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -27666,12 +27583,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -27697,12 +27614,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -52518,7 +52435,7 @@ VE
 Xq
 ur
 HD
-WX
+LV
 LV
 Ng
 LV
@@ -52775,7 +52692,7 @@ Gx
 dw
 kQ
 va
-Lb
+Jt
 VE
 HI
 KY
@@ -57898,7 +57815,7 @@ Nk
 NZ
 Pd
 PU
-Ra
+QZ
 RE
 SN
 TA
@@ -57906,7 +57823,7 @@ Ua
 UB
 UR
 Vk
-UU
+WX
 UU
 UU
 UU
@@ -61240,7 +61157,7 @@ zv
 tU
 xD
 xD
-RT
+ip
 UX
 xD
 xD
@@ -61497,7 +61414,7 @@ zv
 tU
 xD
 xD
-RT
+ip
 UX
 xD
 xD
@@ -61754,7 +61671,7 @@ zv
 tU
 xD
 xD
-RT
+ip
 UX
 xD
 xD
@@ -62011,7 +61928,7 @@ zv
 tU
 xD
 xD
-RT
+ip
 UX
 xD
 xD
@@ -62270,9 +62187,9 @@ xD
 xD
 RV
 SW
-TD
-TD
-TD
+fI
+fI
+fI
 UU
 UU
 UU

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -102,6 +102,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/no_nightshift,
@@ -320,6 +321,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -412,6 +415,7 @@
 "aV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/wingrille_spawn/reinforced,
@@ -738,6 +742,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -759,6 +765,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -786,6 +794,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/greengrid,
@@ -1247,6 +1257,8 @@
 /obj/structure/table/darkglass,
 /obj/item/weapon/folder/red,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -1351,9 +1363,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -1510,12 +1525,16 @@
 	req_one_access = list(16)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/ai_upload)
 "db" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/bluegrid,
@@ -1561,6 +1580,8 @@
 	req_access = list(1)
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1851,6 +1872,8 @@
 /area/ai/ai_upload_foyer)
 "dE" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -1927,6 +1950,8 @@
 "dP" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -2025,6 +2050,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -2181,6 +2207,8 @@
 	req_access = list(55)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -2568,6 +2596,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
@@ -2581,6 +2611,8 @@
 	opacity = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
@@ -2588,6 +2620,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating,
@@ -2642,7 +2676,9 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "32-8"
+	icon_state = "32-8";
+	d1 = 32;
+	d2 = 8
 	},
 /turf/simulated/open,
 /area/quartermaster/storage)
@@ -2734,6 +2770,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -2793,6 +2831,8 @@
 /area/security/brig)
 "fo" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -2811,6 +2851,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -2858,6 +2900,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3049,6 +3093,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3309,14 +3355,19 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -3357,7 +3408,9 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/structure/cable/green{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /turf/simulated/open,
 /area/maintenance/security_port)
@@ -3463,6 +3516,8 @@
 /obj/item/weapon/stock_parts/subspace/analyzer,
 /obj/item/weapon/stock_parts/subspace/analyzer,
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
@@ -3628,6 +3683,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -3681,6 +3738,8 @@
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "hi" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -3822,6 +3881,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -3934,6 +3995,8 @@
 	pixel_y = 22
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3947,15 +4010,16 @@
 /area/security/prison)
 "hH" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/prison)
 "hI" = (
 /obj/structure/cable/green{
-	d2 = 4;
-	dir = 1;
-	icon_state = "0-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -4031,6 +4095,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -4063,9 +4129,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -4134,9 +4203,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4215,9 +4288,13 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -4276,6 +4353,8 @@
 /area/surface/outside/plains/outpost/sky)
 "ip" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -4296,6 +4375,8 @@
 	layer = 3
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -4319,6 +4400,8 @@
 /area/security/prison)
 "it" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -4342,6 +4425,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -4379,6 +4464,8 @@
 /area/surface/outpost/civilian/emergency_storage)
 "iy" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
@@ -4392,21 +4479,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "iz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/engineering/engine_monitoring)
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
+/area/engineering/engine_room)
 "iA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4415,6 +4490,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4436,6 +4513,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4459,12 +4538,18 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4504,6 +4589,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4544,12 +4631,18 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4562,6 +4655,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4608,6 +4703,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4623,6 +4720,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4832,6 +4931,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4856,6 +4956,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/closet/bombcloset/double,
@@ -4902,6 +5003,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -5045,6 +5148,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -5101,6 +5206,8 @@
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "jM" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5114,6 +5221,8 @@
 /area/security/prison)
 "jO" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5153,9 +5262,8 @@
 "jR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d2 = 4;
-	dir = 1;
-	icon_state = "0-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -5172,6 +5280,8 @@
 /area/crew_quarters/cafeteria)
 "jT" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -5218,6 +5328,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -5249,6 +5361,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -5265,6 +5379,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5282,6 +5398,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/red,
@@ -5489,6 +5606,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5518,6 +5637,8 @@
 /obj/item/ammo_magazine/m45/practice,
 /obj/item/ammo_magazine/m45/practice,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/ammo_magazine/ammo_box/b12g/practice,
@@ -5528,12 +5649,15 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
 "kC" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -5576,9 +5700,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -5594,9 +5721,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -5605,6 +5735,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -5617,6 +5748,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
@@ -5730,6 +5863,8 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -5876,6 +6011,8 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5909,12 +6046,18 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5934,6 +6077,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -5942,12 +6086,17 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -5971,6 +6120,7 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/alarm{
@@ -6005,6 +6155,8 @@
 "ly" = (
 /obj/structure/table/darkglass,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6031,6 +6183,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -6232,6 +6386,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6366,15 +6522,20 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "mc" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -6466,6 +6627,8 @@
 /area/library_conference_room)
 "mk" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/camera/network/prison{
@@ -6591,6 +6754,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -6635,6 +6800,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bmarble,
@@ -6700,6 +6867,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6734,6 +6903,8 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/gun/energy/laser/practice,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6777,6 +6948,8 @@
 /area/security/security_lockerroom)
 "mV" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -6820,6 +6993,8 @@
 "mZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6856,6 +7031,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -6875,6 +7051,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom{
@@ -6934,6 +7112,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -6973,6 +7153,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -6985,12 +7167,18 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7014,6 +7202,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/red,
@@ -7116,6 +7306,8 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -7358,6 +7550,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7400,6 +7594,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7424,6 +7620,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7433,15 +7631,23 @@
 /area/security/security_hallway)
 "ob" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -7459,6 +7665,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7479,6 +7687,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7517,6 +7727,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -7532,6 +7744,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/fans/tiny,
@@ -7556,15 +7770,23 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7581,9 +7803,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7601,6 +7827,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -7644,6 +7872,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7659,6 +7889,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7671,6 +7903,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7686,6 +7920,8 @@
 /obj/structure/table/darkglass,
 /obj/item/weapon/folder/red,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7701,6 +7937,8 @@
 	},
 /obj/item/weapon/pen,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7732,6 +7970,8 @@
 /obj/item/clothing/glasses/hud/security,
 /obj/item/clothing/glasses/hud/security,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7743,6 +7983,8 @@
 /obj/structure/table/darkglass,
 /obj/item/device/paicard,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7755,6 +7997,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -7768,6 +8012,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7818,6 +8064,8 @@
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "oC" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7858,6 +8106,8 @@
 	},
 /obj/structure/lattice,
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
 	icon_state = "32-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7895,6 +8145,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -7916,12 +8168,16 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7986,6 +8242,15 @@
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing)
+"oO" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "oP" = (
 /obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8192,6 +8457,8 @@
 /area/security/security_hallway)
 "pm" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8216,6 +8483,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -8265,6 +8534,8 @@
 /area/security/main)
 "pt" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -8274,6 +8545,8 @@
 /area/security/main)
 "pu" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8429,6 +8702,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -8482,6 +8757,8 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -8504,6 +8781,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack/corner2{
@@ -8635,6 +8914,8 @@
 /area/surface/outside/plains/outpost)
 "qb" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -8687,6 +8968,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -8743,6 +9025,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -8793,6 +9077,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/disposal/wall{
@@ -8852,6 +9138,7 @@
 "qu" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/wingrille_spawn/reinforced,
@@ -8934,6 +9221,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8955,6 +9244,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/floortube{
@@ -9118,10 +9409,26 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_isolation)
+"qT" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "qU" = (
 /obj/effect/floor_decal/rust,
 /obj/item/ammo_magazine/m41{
@@ -9202,6 +9509,8 @@
 /area/surface/outpost/civilian/pool)
 "rd" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9226,6 +9535,8 @@
 /area/surface/outside/plains/outpost/sky)
 "rf" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9250,6 +9561,8 @@
 /area/security/security_hallway)
 "rh" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9279,6 +9592,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -9297,6 +9612,8 @@
 "rk" = (
 /obj/structure/table/darkglass,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9308,6 +9625,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9323,6 +9642,8 @@
 "rn" = (
 /obj/machinery/light/no_nightshift,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9331,6 +9652,8 @@
 /area/security/main)
 "ro" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9339,6 +9662,8 @@
 /area/security/main)
 "rp" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9347,6 +9672,8 @@
 /area/security/main)
 "rq" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -9429,6 +9756,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9456,6 +9785,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -9510,12 +9841,18 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/red,
@@ -9580,9 +9917,13 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/red,
@@ -9744,6 +10085,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -9774,12 +10116,12 @@
 	},
 /area/surface/outside/plains/outpost/sky)
 "sf" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_room)
 "sh" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9829,6 +10171,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -9850,6 +10193,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -9858,9 +10202,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -9869,9 +10216,13 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green,
@@ -9956,6 +10307,8 @@
 /area/expoutpost/gateway)
 "sy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/red,
@@ -10007,6 +10360,8 @@
 /area/surface/outside/plains/outpost/sky)
 "sE" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10228,6 +10583,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -10331,6 +10688,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -10441,6 +10800,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -10813,6 +11174,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -10844,6 +11206,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -10901,6 +11265,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -10964,7 +11330,9 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/structure/cable/green{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /obj/effect/floor_decal/steeldecal/monofloor,
 /obj/structure/disposalpipe/down{
@@ -11043,6 +11411,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -11164,16 +11533,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/library_conference_room)
 "uQ" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_waste)
 "uR" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/grille,
+/obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 1
@@ -11185,13 +11548,14 @@
 	name = "Engineering Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/blast/radproof{
+	rad_resistance = 150
+	},
 /turf/simulated/floor/plating/thor/planetuse,
 /area/engineering/engine_waste)
 "uS" = (
 /obj/structure/sign/warning/radioactive,
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_waste)
 "uU" = (
 /obj/machinery/light/no_nightshift{
@@ -11234,6 +11598,8 @@
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
 	icon_state = "32-4"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
@@ -11277,6 +11643,8 @@
 /area/surface/outside/plains/outpost/sky)
 "vc" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/marker_beacon{
@@ -11294,6 +11662,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/camera/network/command{
@@ -11310,6 +11679,8 @@
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "vf" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -11383,7 +11754,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "32-1"
+	icon_state = "32-1";
+	d1 = 32
 	},
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -11561,6 +11933,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -11635,7 +12008,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -11705,6 +12078,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -11712,6 +12087,8 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -11726,6 +12103,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -11735,6 +12114,8 @@
 /area/medical/virology)
 "vU" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -11842,6 +12223,8 @@
 /obj/structure/catwalk,
 /obj/structure/lattice,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/zone_divider,
@@ -12020,6 +12403,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12058,6 +12443,8 @@
 /obj/item/weapon/storage/pill_bottle/spaceacillin,
 /obj/item/device/defib_kit/loaded,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12092,6 +12479,8 @@
 /area/surface/outside/plains/outpost/sky)
 "wG" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -12101,6 +12490,8 @@
 /area/bridge)
 "wH" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12134,9 +12525,13 @@
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/storage/secure/briefcase,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -12471,6 +12866,8 @@
 /area/medical/virology)
 "xl" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/status_display{
@@ -12781,9 +13178,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -12811,6 +13211,8 @@
 	req_access = list(20)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
@@ -12833,6 +13235,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bmarble,
@@ -12852,6 +13256,8 @@
 /area/expoutpost/gateway)
 "xY" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -12862,6 +13268,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12873,6 +13281,8 @@
 "ya" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -12914,6 +13324,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13081,6 +13493,8 @@
 /area/bridge)
 "yv" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13093,9 +13507,13 @@
 /area/bridge)
 "yw" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13117,6 +13535,8 @@
 /area/library_conference_room)
 "yy" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13129,9 +13549,13 @@
 /area/bridge)
 "yz" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13154,6 +13578,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -13359,6 +13784,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13438,6 +13865,8 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -13468,17 +13897,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "zg" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/radproof{
-	dir = 4;
-	id = "EngineReactor";
 	rad_resistance = 150
 	},
+/obj/effect/wingrille_spawn/reinforced_phoron,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "zh" = (
@@ -13545,6 +13968,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green,
@@ -13685,6 +14110,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -13737,6 +14164,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -13826,6 +14255,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
@@ -14071,6 +14502,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -14260,6 +14693,8 @@
 /area/crew_quarters/cafeteria)
 "AV" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
@@ -14418,6 +14853,8 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -14513,6 +14950,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
+"Br" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	outdoors = 1
+	},
+/area/engineering/engine_room)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
@@ -14551,6 +15001,8 @@
 	dir = 6
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -14567,6 +15019,8 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -14690,6 +15144,8 @@
 /obj/item/weapon/storage/laundry_basket,
 /obj/structure/table/woodentable,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
@@ -14937,6 +15393,8 @@
 /area/bridge)
 "Cd" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -15317,6 +15775,8 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -15501,6 +15961,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/floortube{
@@ -15780,6 +16242,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -15992,6 +16456,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -16079,6 +16545,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -16087,9 +16554,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -16098,12 +16568,15 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
 "Ep" = (
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -16138,6 +16611,8 @@
 	req_access = list(55)
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -16184,6 +16659,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16299,6 +16776,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -16362,6 +16841,8 @@
 	use_power = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -16470,9 +16951,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "EU" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_monitoring)
 "EV" = (
 /obj/machinery/status_display{
@@ -16574,6 +17053,8 @@
 /area/medical/virology)
 "Fg" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/zone_divider,
@@ -16692,6 +17173,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -17044,7 +17527,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -17144,6 +17628,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17626,16 +18112,17 @@
 /area/engineering/engine_room)
 "Hd" = (
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/obj/item/weapon/paper{
-	info = "Hey! Most of the base's old wiring was rotted out since htis place has been sitting so long. We're idiots and couldn't figure out how to get the wiring to work good, so we wired the engine output into the grid up here to power tcomms and the monitoring room/gyrotron. If you come up with a better solution, snap some pictures and fax it to us! Thanks. -- Lazy CC engineers";
-	name = "note from a lazy engineer"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -17660,7 +18147,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/obj/item/device/geiger/wall/east,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "Hh" = (
@@ -17851,6 +18342,7 @@
 	id_tag = "Reactor Gyrotron"
 	},
 /obj/structure/cable/cyan{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -17882,6 +18374,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -17894,6 +18388,8 @@
 /area/engineering/engine_waste)
 "HF" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -17965,18 +18461,18 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/structure/cable/yellow{
-	icon_state = "32-1"
+	icon_state = "32-1";
+	d1 = 32
 	},
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/open,
 /area/engineering/engine_room)
 "HQ" = (
@@ -17988,15 +18484,14 @@
 	},
 /area/security/prison)
 "HR" = (
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8
+/obj/item/device/geiger/wall/east,
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
+/turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "HS" = (
 /obj/structure/railing,
@@ -18019,7 +18514,7 @@
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/engine_room)
 "HV" = (
 /obj/structure/marker_beacon{
 	icon_state = "markerjade-on";
@@ -18179,6 +18674,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18233,6 +18730,8 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
@@ -18351,6 +18850,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -18466,11 +18967,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/catwalk,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/turf/simulated/open,
 /area/engineering/engine_room)
 "IK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -18488,9 +18989,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_room)
 "IL" = (
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
+/obj/structure/railing{
+	dir = 1
 	},
+/obj/structure/lattice,
+/obj/structure/cable/cyan{
+	icon_state = "32-1";
+	d1 = 32
+	},
+/turf/simulated/open,
 /area/engineering/engine_room)
 "IM" = (
 /obj/structure/bed/chair/sofa/right/black{
@@ -18766,6 +19273,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18880,15 +19389,14 @@
 "JC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/security_lockerroom)
 "JD" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/surface/outside/plains/outpost)
 "JE" = (
 /obj/machinery/computer/fusion_fuel_control{
@@ -18933,6 +19441,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -19024,6 +19534,20 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
+"JU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_monitoring)
 "JV" = (
 /obj/structure/table/marble,
 /obj/random/cigarettes,
@@ -19084,6 +19608,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/no_nightshift{
@@ -19243,15 +19769,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/blast/radproof{
-	dir = 4;
 	rad_resistance = 150
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
@@ -19300,6 +19818,7 @@
 	outputting = 1
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/shuttle/plating,
@@ -19321,6 +19840,8 @@
 /area/engineering/engine_monitoring)
 "Kx" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19380,7 +19901,9 @@
 /area/shuttle/shuttle3/start)
 "KD" = (
 /obj/structure/cable/green{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Library Southeast";
@@ -19624,6 +20147,8 @@
 /area/surface/outside/plains/outpost)
 "Lb" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/floortube{
@@ -19661,9 +20186,7 @@
 /area/shuttle/shuttle3/start)
 "Lg" = (
 /obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_monitoring)
 "Lh" = (
 /obj/structure/cable/green{
@@ -19760,6 +20283,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
@@ -19779,15 +20304,8 @@
 	},
 /area/surface/outside/plains/outpost)
 "Lq" = (
-/obj/structure/lattice,
-/obj/structure/cable/cyan{
-	icon_state = "32-8"
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/open,
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/wall/r_lead,
 /area/engineering/engine_monitoring)
 "Lr" = (
 /obj/structure/bedsheetbin,
@@ -19798,6 +20316,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -19831,6 +20350,7 @@
 /area/library_conference_room)
 "Lx" = (
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -19936,6 +20456,8 @@
 /area/surface/outpost/main/bar)
 "LH" = (
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20036,6 +20558,7 @@
 "LP" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -20769,6 +21292,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -20800,6 +21325,8 @@
 /area/quartermaster/storage)
 "Nh" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
@@ -20896,7 +21423,8 @@
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "Nq" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -21071,7 +21599,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -21176,6 +21705,8 @@
 	dir = 9
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21192,6 +21723,8 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -21525,9 +22058,13 @@
 /area/tcommsat/chamber)
 "Oy" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -21811,6 +22348,8 @@
 	pixel_y = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/geo,
@@ -21829,7 +22368,9 @@
 "Pd" = (
 /obj/structure/lattice,
 /obj/structure/cable/yellow{
-	icon_state = "32-2"
+	icon_state = "32-2";
+	d1 = 32;
+	d2 = 2
 	},
 /obj/structure/catwalk,
 /obj/effect/floor_decal/stairs/wood_stairs{
@@ -21851,7 +22392,9 @@
 	pixel_y = 4
 	},
 /obj/structure/cable{
-	icon_state = "32-8"
+	icon_state = "32-8";
+	d1 = 32;
+	d2 = 8
 	},
 /turf/simulated/open,
 /area/surface/outpost/main/bar)
@@ -22051,6 +22594,8 @@
 /area/tcommsat/computer)
 "PA" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/camera/network/prison{
@@ -22283,12 +22828,16 @@
 	pixel_y = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/geo,
 /area/surface/outpost/main/bar)
 "PU" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -22601,6 +23150,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
@@ -22739,7 +23289,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	dir = 8
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22816,6 +23367,8 @@
 /area/surface/outpost/main/bar)
 "Ra" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -22877,7 +23430,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -22986,6 +23539,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -23128,12 +23683,18 @@
 /area/surface/outpost/main/bar)
 "RE" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/geo,
@@ -23144,6 +23705,8 @@
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "RG" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/geo,
@@ -23151,9 +23714,13 @@
 "RH" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/geo,
@@ -23161,6 +23728,8 @@
 "RI" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced/polarized/full{
@@ -23171,6 +23740,8 @@
 /area/surface/outpost/main/bar)
 "RJ" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23184,6 +23755,8 @@
 /area/quartermaster/storage)
 "RL" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -23203,6 +23776,8 @@
 /area/surface/outpost/main/landing)
 "RN" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass{
@@ -23245,6 +23820,8 @@
 /obj/structure/catwalk,
 /obj/structure/lattice,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/open{
@@ -23253,6 +23830,8 @@
 /area/surface/outside/plains/outpost)
 "RT" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -23264,6 +23843,8 @@
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "RV" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -23280,9 +23861,13 @@
 /area/surface/outside/plains/outpost)
 "RX" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -23313,7 +23898,7 @@
 	pixel_y = -22
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -23339,11 +23924,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/medical_lockerroom)
 "Sb" = (
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
+/obj/structure/cable/cyan,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -23502,12 +24083,16 @@
 /area/tcommsat/entrance)
 "Sq" = (
 /obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "Sr" = (
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23517,6 +24102,8 @@
 	dir = 5
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -23533,6 +24120,8 @@
 /area/surface/outside/plains/outpost)
 "St" = (
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -23561,6 +24150,8 @@
 /area/quartermaster/storage)
 "Sv" = (
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -23580,6 +24171,8 @@
 /area/library_conference_room)
 "Sx" = (
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23627,6 +24220,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23639,6 +24234,8 @@
 /area/tcommsat/entrance)
 "SC" = (
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/cyan{
@@ -23673,6 +24270,8 @@
 	dir = 10
 	},
 /obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -23730,6 +24329,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -23774,6 +24375,8 @@
 /area/crew_quarters/cafeteria)
 "SN" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23858,6 +24461,8 @@
 /area/crew_quarters/cafeteria)
 "SW" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23887,6 +24492,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular{
@@ -23949,6 +24556,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -24107,6 +24716,8 @@
 /area/tcommsat/entrance)
 "Tu" = (
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -24169,6 +24780,8 @@
 /area/engineering/engine_waste)
 "TA" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
@@ -24195,6 +24808,8 @@
 /area/surface/outside/plains/outpost/sky)
 "TD" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -24209,6 +24824,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24252,6 +24869,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating{
@@ -24324,6 +24943,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -24341,6 +24962,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -24378,6 +25001,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24431,6 +25056,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24444,9 +25071,13 @@
 /area/crew_quarters/cafeteria)
 "Ua" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -24467,6 +25098,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -24478,7 +25111,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d2 = 0;
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -24514,6 +25147,8 @@
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
 "Uj" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating{
@@ -24599,6 +25234,8 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -24614,6 +25251,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -24702,6 +25341,8 @@
 /area/crew_quarters/cafeteria)
 "UB" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -24720,9 +25361,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24849,6 +25494,8 @@
 /area/crew_quarters/cafeteria)
 "UR" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -24872,6 +25519,8 @@
 /obj/structure/catwalk,
 /obj/structure/lattice,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/open{
@@ -25001,6 +25650,8 @@
 "Vk" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -25022,6 +25673,8 @@
 /area/surface/outside/plains/outpost)
 "Vm" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating{
@@ -25055,7 +25708,6 @@
 /obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/radproof{
-	dir = 4;
 	rad_resistance = 150
 	},
 /turf/simulated/floor/plating,
@@ -25103,6 +25755,8 @@
 	pixel_x = 21
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25161,6 +25815,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25225,6 +25881,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25261,6 +25919,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25307,6 +25966,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25326,6 +25986,8 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25489,6 +26151,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25502,14 +26166,14 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "Wl" = (
-/turf/simulated/wall/r_wall{
-	cached_rad_resistance = 150
-	},
+/turf/simulated/wall/r_lead,
 /area/surface/outpost/engineering/storage)
 "Wm" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -25536,7 +26200,8 @@
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "Wr" = (
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -25558,6 +26223,8 @@
 	req_access = list(31)
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25573,6 +26240,8 @@
 /area/quartermaster/office)
 "Ww" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25608,6 +26277,8 @@
 /area/quartermaster/qm)
 "WD" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -25722,6 +26393,8 @@
 /area/medical/morgue)
 "WM" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -25736,7 +26409,8 @@
 	name = "EXT - TCOMMS SOUTH 3"
 	},
 /obj/structure/cable{
-	d2 = 0;
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint{
@@ -25751,6 +26425,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25784,6 +26460,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -25810,6 +26488,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -25869,6 +26549,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -25934,6 +26615,8 @@
 /area/quartermaster/qm)
 "Xm" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -25942,6 +26625,8 @@
 /area/surface/outpost/civilian/pool)
 "Xn" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -25950,6 +26635,8 @@
 /area/surface/outpost/civilian/pool)
 "Xo" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -25978,6 +26665,8 @@
 	dir = 10
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26008,6 +26697,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -26123,6 +26813,8 @@
 /area/quartermaster/warehouse)
 "XF" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
@@ -26135,9 +26827,13 @@
 /area/rnd/xenobiology/xenoflora_isolation)
 "XI" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
@@ -26153,6 +26849,8 @@
 /area/quartermaster/office)
 "XJ" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -26185,6 +26883,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26194,6 +26894,8 @@
 /area/quartermaster/office)
 "XM" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26208,6 +26910,8 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26215,6 +26919,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/qm)
+"XO" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "XP" = (
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/main/bar)
@@ -26227,6 +26940,8 @@
 /area/shuttle/shuttle3/start)
 "XS" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26327,6 +27042,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -26384,6 +27101,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/blue{
@@ -26455,6 +27174,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -26519,6 +27239,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -26544,6 +27266,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -26579,6 +27303,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
@@ -26879,6 +27605,8 @@
 /area/quartermaster/warehouse)
 "Zs" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/vending/wardrobe/cargodrobe,
@@ -26895,6 +27623,8 @@
 	dir = 5
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
@@ -26926,9 +27656,13 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/status_display{
@@ -26950,6 +27684,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -26970,6 +27706,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -27008,6 +27746,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27054,6 +27794,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -27063,6 +27804,8 @@
 	name = "Unisex Restrooms"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
@@ -27071,6 +27814,8 @@
 /area/crew_quarters/barrestroom)
 "ZN" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/civilian{
@@ -27156,9 +27901,13 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
@@ -27183,9 +27932,13 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -44514,13 +45267,13 @@ uQ
 sf
 sf
 sf
-Ec
+iz
 sf
 sf
 sf
 sf
 sf
-Xk
+Lq
 EU
 Kr
 Lg
@@ -45802,17 +46555,17 @@ ZC
 Ga
 Fx
 GR
-Ec
+iz
 HG
 Iv
 Jh
 JL
 nT
 yf
-Xk
+Lq
 ho
 kX
-Xk
+Lq
 xD
 xD
 xD
@@ -46058,7 +46811,7 @@ sf
 Fy
 Gb
 Fy
-Ec
+iz
 sf
 HH
 Iw
@@ -46320,9 +47073,9 @@ Hd
 HJ
 Iz
 Ji
-JM
+JU
 Kw
-iz
+JM
 VB
 Gd
 ny
@@ -46573,13 +47326,13 @@ FE
 Gf
 Gy
 GT
-HN
+oO
 HN
 IC
 sf
-Xk
-EU
 Lq
+EU
+ho
 Ms
 bB
 NU
@@ -46830,7 +47583,7 @@ FF
 Wl
 HN
 GU
-HN
+oO
 HN
 IF
 sf
@@ -46838,7 +47591,7 @@ xD
 EU
 EU
 EU
-Xk
+Lq
 EU
 EU
 PM
@@ -47344,9 +48097,9 @@ FI
 Wl
 sf
 sf
-sf
-sf
-IK
+HR
+XO
+IL
 sf
 JR
 xD
@@ -47601,10 +48354,10 @@ FK
 Wl
 JD
 sf
-JD
-HR
-IL
-HR
+sf
+IK
+sf
+sf
 JR
 xD
 Lt
@@ -47858,9 +48611,9 @@ Wl
 Wl
 wt
 yV
-YK
+Br
 HU
-IO
+qT
 IO
 zW
 Wo

--- a/maps/relic_base/relicbase-6.dmm
+++ b/maps/relic_base/relicbase-6.dmm
@@ -25,6 +25,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -138,6 +140,8 @@
 	name = "Mine Outpost SMES"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
@@ -495,6 +499,8 @@
 /area/surface/outpost/research/xenoarcheology/isolation_c)
 "fF" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -873,6 +879,8 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -997,9 +1005,13 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -1185,10 +1197,14 @@
 /obj/structure/cable/green,
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/fiftyspawner/phoron,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -1280,6 +1296,7 @@
 "mK" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -2205,6 +2222,8 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -2323,6 +2342,8 @@
 /area/surface/outpost/research/xenoarcheology)
 "vr" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -2349,6 +2370,8 @@
 /area/surface/outpost/research/xenoarcheology)
 "vy" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -2492,6 +2515,8 @@
 /area/surface/outpost/research/xenoarcheology/smes)
 "xj" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
@@ -2571,6 +2596,8 @@
 /area/surface/cave/unexplored/normal)
 "yg" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -2920,6 +2947,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -3281,6 +3310,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/fiftyspawner/phoron,
@@ -3663,6 +3694,8 @@
 /obj/structure/cable/green,
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -3892,6 +3925,8 @@
 "Or" = (
 /obj/machinery/mining/brace,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,

--- a/maps/relic_base/relicbase-6.dmm
+++ b/maps/relic_base/relicbase-6.dmm
@@ -42,7 +42,7 @@
 /area/surface/outpost/research/xenoarcheology/longtermstorage)
 "aw" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -89,7 +89,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "aR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -188,7 +188,7 @@
 	name = "First-Aid Station";
 	req_one_access = newlist()
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -209,12 +209,12 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/emergencystorage)
 "cL" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -278,7 +278,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -294,7 +294,7 @@
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -305,7 +305,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "dw" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -332,7 +332,7 @@
 "dY" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -340,7 +340,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -384,7 +384,7 @@
 /turf/simulated/shuttle/plating,
 /area/surface/outpost/mining_main/crew_area)
 "eu" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -472,7 +472,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -532,7 +532,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -36
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -602,7 +602,7 @@
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -629,11 +629,11 @@
 	},
 /area/surface/cave/unexplored/deep)
 "gq" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -643,7 +643,7 @@
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -686,18 +686,18 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "gJ" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -749,7 +749,7 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_b)
 "hb" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -905,7 +905,7 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_a)
 "jl" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -946,7 +946,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "jq" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -991,7 +991,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -999,11 +999,6 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "jQ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -1048,7 +1043,7 @@
 	name = "Sample Preparation";
 	req_access = list(65)
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1059,7 +1054,7 @@
 /area/surface/outpost/research/xenoarcheology/analysis)
 "kh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1081,7 +1076,7 @@
 "kp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1132,7 +1127,7 @@
 /obj/machinery/cell_charger,
 /obj/random/powercell,
 /obj/random/maintenance/clean,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1202,11 +1197,6 @@
 	icon_state = "1-2"
 	},
 /obj/fiftyspawner/phoron,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
 "mc" = (
@@ -1216,7 +1206,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -1230,7 +1220,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1243,7 +1233,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "mB" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1261,12 +1251,12 @@
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -1277,7 +1267,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "mI" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1294,16 +1284,12 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "mK" = (
-/obj/machinery/power/smes/buildable/outpost_substation{
-	RCon_tag = "Outpost - Xenoarch";
-	charge = 500000;
-	input_attempt = 1;
-	input_level = 150000;
-	output_level = 150000
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
@@ -1315,7 +1301,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/emergencystorage)
 "mR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1344,7 +1330,7 @@
 "nh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1428,7 +1414,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -1505,7 +1491,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1579,7 +1565,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1624,7 +1610,7 @@
 /obj/machinery/door/airlock{
 	name = "Research Restroom"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1640,12 +1626,16 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
 "pg" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/power/smes/buildable/outpost_substation{
+	RCon_tag = "Outpost - Xenoarch";
+	charge = 500000;
+	input_attempt = 1;
+	input_level = 150000;
+	output_level = 150000
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
@@ -1670,7 +1660,7 @@
 "pt" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1758,7 +1748,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "ql" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1888,7 +1878,7 @@
 /area/surface/outpost/mining_main/crew_area)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1947,7 +1937,7 @@
 /area/surface/outpost/mining_main/crew_area)
 "sA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -1982,7 +1972,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -1990,7 +1980,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -2004,7 +1994,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2042,7 +2032,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "tc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2064,7 +2054,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -36
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -2075,7 +2065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2119,7 +2109,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "tS" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2247,7 +2237,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -2308,7 +2298,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2322,7 +2312,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/mining_main/crew_area)
 "vg" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2380,11 +2370,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
 "vG" = (
@@ -2415,7 +2400,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "vT" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2471,7 +2456,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2572,7 +2557,7 @@
 /area/surface/outpost/research/xenoarcheology)
 "xK" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2666,7 +2651,7 @@
 /area/surface/outpost/research/xenoarcheology/restroom)
 "zC" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2680,7 +2665,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "zG" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2712,7 +2697,7 @@
 /area/surface/cave/unexplored/deep)
 "Ag" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -2773,7 +2758,7 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_c)
 "AR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2784,11 +2769,6 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/analysis)
 "AW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -2804,7 +2784,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2876,7 +2856,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2887,7 +2867,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "CD" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -2922,7 +2902,7 @@
 "De" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3042,7 +3022,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3131,7 +3111,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3144,7 +3124,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -3156,7 +3136,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_a)
 "Fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3281,7 +3261,7 @@
 /obj/machinery/door/airlock{
 	name = "Emergency Storage"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3295,7 +3275,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -3348,7 +3328,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "HT" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -3366,7 +3346,7 @@
 	pixel_x = 36
 	},
 /obj/structure/table/standard,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -3383,7 +3363,7 @@
 /area/surface/outpost/research/xenoarcheology)
 "If" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3438,7 +3418,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3492,7 +3472,7 @@
 /area/surface/outpost/research/xenoarcheology/medical)
 "Jv" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3522,7 +3502,7 @@
 /area/surface/outpost/research/xenoarcheology/exp_prep)
 "JA" = (
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3567,7 +3547,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "KA" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3594,12 +3574,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -3675,7 +3655,7 @@
 /area/surface/outpost/research/xenoarcheology/smes)
 "Lr" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3683,7 +3663,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -3699,11 +3679,6 @@
 "LB" = (
 /obj/structure/cable/green,
 /obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
 "LJ" = (
@@ -3717,7 +3692,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_c)
 "LU" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3748,7 +3723,7 @@
 /area/surface/outpost/research/xenoarcheology/medical)
 "Mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -3817,7 +3792,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -3838,6 +3813,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/crew_area)
 "NP" = (
@@ -3845,7 +3825,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -3920,7 +3900,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -3958,7 +3938,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4010,7 +3990,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4020,19 +4000,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
-"Pa" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid{
-	temperature = 393.15
-	},
-/area/surface/outpost/mining_main/cave)
 "Pf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -4112,12 +4079,12 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -4220,7 +4187,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4228,14 +4195,14 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "RR" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -4246,7 +4213,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4322,7 +4289,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4343,7 +4310,7 @@
 	input_level = 150000;
 	output_level = 150000
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -4370,7 +4337,8 @@
 	pixel_x = 11;
 	pixel_y = 24
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -4388,7 +4356,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -4643,7 +4611,7 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -4656,7 +4624,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "YL" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4667,7 +4635,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -4687,23 +4655,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_b)
-"YY" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/obj/effect/zone_divider,
-/turf/simulated/floor/plating{
-	temperature = 393.15
-	},
-/area/surface/outpost/mining_main/cave)
 "Za" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -4729,7 +4680,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4774,7 +4725,7 @@
 	name = "light switch ";
 	pixel_x = 36
 	},
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -27032,7 +26983,7 @@ NZ
 NZ
 Bv
 ge
-oZ
+pg
 mK
 lV
 LB
@@ -27290,7 +27241,7 @@ NZ
 Bv
 ge
 NB
-pg
+vy
 vy
 vy
 bH
@@ -29355,7 +29306,7 @@ ey
 yg
 yg
 yg
-YY
+yg
 Jb
 yZ
 yf
@@ -29612,7 +29563,7 @@ Yr
 Xs
 Xs
 Xs
-xj
+Xs
 Xs
 ym
 wR
@@ -29869,7 +29820,7 @@ ej
 ej
 Xs
 Xs
-xj
+Xs
 Xs
 ym
 wR
@@ -30116,16 +30067,16 @@ pv
 pv
 yZ
 vb
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
-Pa
+AW
+AW
+AW
+AW
+AW
+AW
+AW
+AW
+AW
+AW
 AW
 EJ
 yZ

--- a/maps/relic_base/relicbase-6.dmm
+++ b/maps/relic_base/relicbase-6.dmm
@@ -1294,7 +1294,13 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
 "mK" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes/buildable/outpost_substation{
+	RCon_tag = "Outpost - Xenoarch";
+	charge = 500000;
+	input_attempt = 1;
+	input_level = 150000;
+	output_level = 150000
+	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -4331,7 +4337,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "Tf" = (
 /obj/machinery/power/smes/buildable/outpost_substation{
-	RCon_tag = "Outpost - Xenoarch";
+	RCon_tag = "Outpost - Mining";
 	charge = 500000;
 	input_attempt = 1;
 	input_level = 150000;


### PR DESCRIPTION
## About The Pull Request
Hihi I was bored so I'm putting this together. The aim is to make the wires and pipes more intuitive as well as fix a few issues and try and prevent the second floor from becoming irradiated by the R-UST. Will add things as I go.

Some things tested a bit and all seems to be working, but if any issues are spotted will try and fix em asap
## Changelog
:cl:
add: Added a missing bin
add: Adding a substation for atmospherics
add: Adds powernet sensors to grids that were previously missing them
del: Removed the lazy engineer note as no longer relevant
del: Removed some excess and unused cables
qol: Removed excess and broken wiring prefabs from the map for ease of future mapping
fix: Fixes incorrectly wired powernet sensors
fix: Fixed the incorrectly wired grid checker
fix: Added some missing atmos pipes
fix: Renamed the solars RCON tag at the main base to no longer be named as "Expedition Outpost Solars"
fix: Added missing cable on engineering substation
fix: Fixed a broken airlock helper setup
fix: Replace the outpost mining SMES with a buildable SMES
fix: Fixed some incorrectly wired subgrid breakers
fix: Redirected solars to mains grid
maptweak: Reworked engine wiring to not be hotwired to the grid - input to be controlled by a renamed Input SMES initially set at low output to conserve power when there's no roundstart engineer
maptweak: Replaced the R-UST's walls with reinforced lead for better radiation protection. Also re-bound and replaced some oddly located shutters to be more in line with the other reactor shutters, to be controlled from the reactor control room.
maptweak: Altering the paths of some cables and pipes to attempt to avoid pulling them up stairs or through floors where possible (apartments and some other places left untouched for now because... it would be too difficult to do so without ruining the look of the apartments I feel)
maptweak: Recoloured cables to be consistent throughout the station for ease of grid troubleshooting, management and expansion. Red and heavy duty cables are the mains/master grid. Green cables are the department subgrids. Yellow cables are engine output. Cyan cables are engine input/tcomms.
maptweak: AI SMES connected to mains grid instead of sec grid
/:cl:
