### PR TITLE
Map Cleanup

### DIFF
--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -6994,11 +6994,6 @@
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
-"gqL" = (
-/turf/simulated/open,
-/area/maintenance/firstdeck/centralport{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
 "gsl" = (
 /obj/effect/floor_decal/rust,
 /obj/random/trash,
@@ -40733,8 +40728,8 @@ yhF
 yjd
 tdi
 sTQ
-gqL
-gqL
+lll
+lll
 lJk
 rlb
 rlb

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -21367,6 +21367,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
 	dir = 4
 	},
+/obj/structure/inflatable,
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -27266,6 +27267,11 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 8;
 	pixel_x = -21
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -40676,9 +40682,8 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/machinery/disposal,
 /turf/simulated/floor/plating/thor/planetuse,
-/area/engineering/external_lights)
+/area/surface/outside/path/plains)
 "qRw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -58824,6 +58829,10 @@
 	pixel_y = 24
 	},
 /obj/machinery/vending/blood,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "xKe" = (

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -36749,6 +36749,7 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/item/device/lightreplacer,
 /turf/simulated/floor/tiled,
 /area/janitor)
 "ppA" = (
@@ -44751,6 +44752,7 @@
 /obj/item/weapon/tool/crowbar,
 /obj/item/weapon/tool/crowbar/red,
 /obj/item/weapon/storage/box/lights/mixed,
+/obj/item/device/lightreplacer,
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/engineering/workshop)
 "syN" = (

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -419,6 +419,9 @@
 	c_tag = "MED - Medical Foyer";
 	dir = 1
 	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "aiU" = (
@@ -3377,6 +3380,12 @@
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/primary/thirddeck/stationgateway)
+"bIF" = (
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/surface/outpost/main/gym)
 "bJe" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -3442,6 +3451,19 @@
 "bJR" = (
 /turf/simulated/floor/water/atoll,
 /area/surface/outside/plains/outpost)
+"bKk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/wallmed1{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 3
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/engineering/break_room)
 "bKH" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -7393,6 +7415,9 @@
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/adv,
 /obj/item/weapon/storage/firstaid/adv,
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/aid_station)
 "djz" = (
@@ -31384,6 +31409,11 @@
 	c_tag = "CIV - Cafeteria Lobby East";
 	dir = 8
 	},
+/obj/machinery/vending/wallmed1{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 3
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "mTk" = (
@@ -38586,6 +38616,26 @@
 	outdoors = -1
 	},
 /area/medical/medbay_primary_storage)
+"pYy" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/zone_divider,
+/obj/machinery/vending/wallmed1{
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "pYz" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning,
@@ -41644,10 +41694,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/timeclock/premade/north,
-/obj/machinery/computer/id_restorer{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -58807,6 +58853,9 @@
 	},
 /obj/effect/floor_decal/corner/purple/bordercorner2{
 	dir = 1
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -79839,7 +79888,7 @@ gBl
 ioS
 ioS
 sid
-ioS
+bKk
 oZD
 pSB
 rpQ
@@ -93770,7 +93819,7 @@ qiD
 yeV
 yeV
 yeV
-pKL
+pYy
 plr
 mnr
 mnr
@@ -96610,7 +96659,7 @@ xUR
 xsB
 bky
 xUR
-wDm
+bIF
 jxH
 wDm
 tzk

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -40677,7 +40677,7 @@
 /obj/structure/catwalk,
 /obj/machinery/disposal,
 /turf/simulated/floor/plating/thor/planetuse,
-/area/surface/outside/path/plains)
+/area/engineering/external_lights)
 "qRw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -44197,6 +44197,23 @@
 /obj/item/tape/engineering,
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
+"soQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/seconddeck/dockhallway)
 "spv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -111663,7 +111680,7 @@ rLe
 sct
 rLe
 iTg
-jCC
+soQ
 klz
 uMN
 kSF

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -8263,12 +8263,6 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
-"oQ" = (
-/obj/structure/sign/warning/radioactive,
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -23086,7 +23080,7 @@
 /area/crew_quarters/cafeteria)
 "Qe" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Expedition Outpost - Port Solars";
+	RCon_tag = "Medical Roof Solars";
 	charge = 2.5e+006;
 	input_attempt = 1;
 	input_level = 150000;
@@ -70140,7 +70134,7 @@ xD
 xD
 xD
 xD
-oQ
+xD
 xD
 xD
 xD

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -5453,6 +5453,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
 "kg" = (
@@ -8263,6 +8266,12 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/security/prison)
+"oQ" = (
+/obj/structure/sign/warning/radioactive,
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -12555,6 +12564,9 @@
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "COM - Bridge North"
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -20486,6 +20498,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "Lr" = (
@@ -23080,7 +23095,7 @@
 /area/crew_quarters/cafeteria)
 "Qe" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Medical Roof Solars";
+	RCon_tag = "Expedition Outpost - Port Solars";
 	charge = 2.5e+006;
 	input_attempt = 1;
 	input_level = 150000;
@@ -27129,6 +27144,12 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/blue,
 /area/shuttle/shuttle3/start)
+"XR" = (
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/crew_quarters/cafeteria)
 "XS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -58566,7 +58587,7 @@ fW
 fW
 Co
 PW
-XU
+XR
 Lb
 XP
 Kj
@@ -70134,7 +70155,7 @@ xD
 xD
 xD
 xD
-xD
+oQ
 xD
 xD
 xD

--- a/maps/relic_base/relicbase-5.dmm
+++ b/maps/relic_base/relicbase-5.dmm
@@ -39997,8 +39997,8 @@ K
 K
 K
 K
-K
-K
+M
+M
 M
 M
 M
@@ -40254,8 +40254,8 @@ K
 K
 K
 K
-K
-K
+M
+M
 M
 M
 M
@@ -40511,8 +40511,8 @@ K
 K
 K
 K
-K
-K
+M
+M
 M
 M
 M


### PR DESCRIPTION
## About The Pull Request
Fixing a few oversights missed in my previous mapping PR. I got other ideas of things that could be added but for now, just a few small adjustments.
## Changelog
:cl:
add: Added light replacers at round start for janitor and engineering to allow easier light fixing.
add: Added nanomed stations to a few public areas and areas that may need them for basic first aid. no more screaming at medical from rat bruises getting infected.
del: Removed accidental radiation warning placed above med solars
fix: Fixed and closed up a hole to nowhere on floor B1
~~fix: Fixed outdoor bin in front of bar not being powered due to area shenanigans~~
del: removed the outdoor bin as I confused an upwards pipe for a trunk guh
fix: Added missing APC to surface level tram station - this should fix the door to the maintenance wire section not being powered due to being it's own area.
fix: Fixed the medbay treatment room APC not being wired up to the subgrid, oops
fix: Added missing roof above medical solars control room
maptweak: Renamed the medical solars RCON tag to not be expedition outpost, for reals this time. Not sure why that change was missing from my original PR lol
maptweak: Added an inflatable wall over the opening in engineering tool storage to keep the room from getting cold due to connections to outdoors
/:cl:
