### PR TITLE
Service Rework (And a couple of misc map fixes)

### DIFF
--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -5857,10 +5857,10 @@
 /area/engineering/atmos)
 "fbL" = (
 /obj/structure/kitchenspike,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/light/no_nightshift,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "fdu" = (
@@ -13475,13 +13475,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nJF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "nKa" = (

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -442,8 +442,20 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aqc" = (
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Bar Storage"
+	},
+/obj/machinery/vending/wallmed1{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/stairs_up{
+	dir = 8;
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "aqM" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -497,12 +509,15 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "aug" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "auo" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/port_gen/pacman,
@@ -1529,6 +1544,13 @@
 /area/security/tactical{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"bay" = (
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "baO" = (
 /obj/structure/bed/chair/sofa/black{
 	dir = 4
@@ -3140,14 +3162,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "cIK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/wall,
+/area/crew_quarters/bar)
 "cJe" = (
 /obj/structure/handrail{
 	dir = 8
@@ -3164,8 +3180,9 @@
 "cJA" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/area/crew_quarters/seconddeck/barrestroom)
 "cJC" = (
 /obj/machinery/light_construct/floortube{
 	dir = 4
@@ -3225,6 +3242,18 @@
 /area/maintenance/firstdeck/fore{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"cMU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/mob/living/simple_mob/animal/goat{
+	name = "Pete"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "cNj" = (
 /obj/structure/grille/rustic{
 	health = 25;
@@ -3274,10 +3303,23 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "cRk" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "cTd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -3910,10 +3952,8 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "dvZ" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "dwa" = (
 /obj/random/trash_pile,
 /obj/random/junk,
@@ -3969,6 +4009,18 @@
 /area/hallway/primary/firstdeck/auxdockaft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"dyD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "dzk" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/firstdeck/forestarboard{
@@ -4894,6 +4946,25 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"emX" = (
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "eoM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -5049,21 +5120,11 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
 "euG" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/honey_extractor,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/table/standard,
+/obj/random/soap,
+/obj/random/soap,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "euQ" = (
 /obj/random/trash_pile,
 /obj/effect/floor_decal/rust,
@@ -5794,6 +5855,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"fbL" = (
+/obj/structure/kitchenspike,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "fdu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -5892,19 +5961,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fjf" = (
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/bench/glass,
+/obj/structure/flora/pottedplant/bamboo{
+	pixel_y = 10
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "fjL" = (
 /obj/effect/zone_divider,
 /obj/effect/floor_decal/rust,
@@ -6251,6 +6314,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"fAj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "fCf" = (
 /obj/machinery/light/small/readylight{
 	dir = 8;
@@ -6455,6 +6527,10 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"fOY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "fPD" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/seconddeck/dockhallway{
@@ -6505,6 +6581,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/foreport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"fRF" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/random/mob/mouse,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fRL" = (
@@ -6782,20 +6877,8 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "gfD" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/crew_quarters/kitchen)
 "gfF" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/rust,
@@ -6814,6 +6897,13 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /obj/random/cigarettes,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -7116,6 +7206,21 @@
 /obj/random/junk,
 /obj/random/junk,
 /obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"gyc" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/mob/mouse,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -7704,18 +7809,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "gWU" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/no_nightshift{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "gYI" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
@@ -9745,6 +9846,23 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"iSZ" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "iTh" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate,
@@ -9790,6 +9908,23 @@
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aft{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"iTH" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "iTS" = (
@@ -10120,18 +10255,12 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jmv" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 5
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 5
-	},
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "jmA" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/steel_reinforced,
@@ -10464,6 +10593,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"jGu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "jGU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10624,6 +10762,31 @@
 /area/maintenance/firstdeck/forestarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"jRS" = (
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Kitchen Cold Room";
+	dir = 1
+	},
+/obj/structure/closet/chefcloset,
+/obj/item/glass_jar,
+/obj/item/device/retail_scanner/civilian,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "jSk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = null
@@ -10750,6 +10913,24 @@
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"jYn" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "jZt" = (
@@ -10978,15 +11159,8 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kkS" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/wall,
+/area/crew_quarters/seconddeck/barrestroom)
 "klf" = (
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/tiled/techfloor,
@@ -11052,23 +11226,13 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "ktE" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 8
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "ktS" = (
 /obj/machinery/light,
 /obj/item/device/radio/intercom{
@@ -11172,10 +11336,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kEK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "kES" = (
 /turf/simulated/wall/rplastitanium,
 /area/rnd/xenobiology{
@@ -11358,6 +11531,24 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"kPG" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kRa" = (
 /obj/effect/floor_decal/rust,
 /obj/random/contraband,
@@ -11422,14 +11613,24 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "kZB" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/random/trash,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 10
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "kZR" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight,
@@ -11685,17 +11886,17 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lxR" = (
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/no_nightshift{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -21
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "lyn" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
@@ -11739,6 +11940,25 @@
 /obj/random/mob/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/fore{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"lEU" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/obj/random/trash,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "lGF" = (
@@ -11880,8 +12100,9 @@
 	})
 "lWy" = (
 /obj/structure/stairs/spawner/west,
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/area/crew_quarters/seconddeck/barrestroom)
 "lWM" = (
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
@@ -12403,20 +12624,25 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mEJ" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 21
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Maintenance";
+	req_access = list(28)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/crew_quarters/kitchen)
 "mEX" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight{
@@ -12437,6 +12663,27 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -22;
+	pixel_y = 21
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21;
+	pixel_y = -31
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
@@ -12567,18 +12814,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "mNQ" = (
-/obj/machinery/seed_storage/garden,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/structure/closet/gmcloset,
+/obj/item/glass_jar,
+/obj/item/device/retail_scanner/civilian,
+/obj/item/device/retail_scanner/civilian,
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "mNW" = (
 /obj/machinery/light_construct/floortube{
 	dir = 8
@@ -12708,9 +12956,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "mYQ" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/light/small/readylight{
 	dir = 4;
 	light_color = "#AF2A2A"
@@ -12858,6 +13103,15 @@
 /area/rnd/xenobiology{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"nhR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "nin" = (
 /obj/effect/floor_decal/rust,
 /obj/random/obstruction,
@@ -12918,12 +13172,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nlZ" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "nnX" = (
 /obj/effect/zone_divider,
 /turf/simulated/wall/r_wall,
@@ -12931,15 +13182,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "npz" = (
-/obj/structure/stairs/spawner/south,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/turf/simulated/wall,
+/area/crew_quarters/kitchen)
 "npN" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /turf/simulated/open,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -12967,18 +13212,18 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nsF" = (
-/obj/machinery/biogenerator,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/table/woodentable,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/weapon/gun/projectile/shotgun/doublebarrel,
+/obj/item/device/retail_scanner/civilian,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "ntK" = (
 /obj/structure/catwalk,
 /obj/item/device/radio/intercom{
@@ -13229,6 +13474,16 @@
 /area/rnd/xenobiology{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"nJF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "nKa" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/outdoors/rocks/caves{
@@ -13344,6 +13599,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
+"nQT" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "nQU" = (
@@ -13634,9 +13904,17 @@
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos)
 "onC" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "ooA" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/border_only,
@@ -13883,8 +14161,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna/cryosauna)
 "oyQ" = (
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "ozy" = (
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/plating,
@@ -14138,20 +14419,26 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "oRK" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/bordercorner{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "oSr" = (
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/sink{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "oSO" = (
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
@@ -14415,8 +14702,12 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "phO" = (
-/turf/simulated/wall/r_wall,
-/area/hydroponics)
+/obj/machinery/alarm/freezer{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "pig" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/zone_divider,
@@ -14507,15 +14798,19 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "poK" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "pqd" = (
 /turf/simulated/wall,
 /area/maintenance/firstdeck/centralport{
@@ -15134,8 +15429,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pTQ" = (
-/turf/simulated/wall,
-/area/hydroponics)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "pVL" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -15207,17 +15513,22 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "pYz" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen cold room";
+	req_access = list(28)
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/hardlight/colorable{
+	light_color = "#D7D7D7"
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/kitchen)
 "pYD" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -15239,6 +15550,19 @@
 /area/maintenance/firstdeck/centralstarboard{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"pZZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "qax" = (
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/plating,
@@ -15409,22 +15733,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qnX" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = -13
-	},
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "qor" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -15898,6 +16209,23 @@
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"qVW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/kitchen)
 "qWC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15977,23 +16305,33 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "qYq" = (
+/obj/machinery/door/airlock{
+	name = "Bar Backroom";
+	req_access = list(25)
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 8
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "qYQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "qZb" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/maintenance/firstdeck/forestarboard{
@@ -16495,6 +16833,20 @@
 "rJE" = (
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
+"rJZ" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/kitchen)
 "rKT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16755,6 +17107,12 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"rXH" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "rXR" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -17150,20 +17508,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "sBN" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/effect/floor_decal/techfloor/hole/right,
+/obj/effect/floor_decal/techfloor/hole,
+/obj/machinery/shower{
+	pixel_y = 9
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/curtain/open/shower/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/seconddeck/barrestroom)
 "sBW" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
@@ -17216,25 +17568,12 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "sEO" = (
-/obj/structure/table/standard,
-/obj/item/weapon/material/knife/machete/hatchet,
-/obj/item/weapon/material/knife/machete/hatchet,
-/obj/item/weapon/material/minihoe,
-/obj/item/weapon/material/minihoe,
-/obj/item/weapon/plantspray/pests,
-/obj/item/weapon/tool/wirecutters/clippers/trimmers,
-/obj/item/weapon/tool/wirecutters/clippers,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+/obj/structure/closet/secure_closet/bar,
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Bar Basement"
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "sFs" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -18601,6 +18940,10 @@
 /area/maintenance/firstdeck/aftport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"ujw" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "ujN" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/readylight{
@@ -18619,6 +18962,20 @@
 /area/maintenance/firstdeck/aft{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"uky" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "ulR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -18829,14 +19186,12 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uzz" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "uAz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19016,17 +19371,9 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "uJh" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/floor_decal/rust,
-/obj/effect/landmark{
-	name = "maint_pred"
-	},
+/obj/structure/stairs/spawner/south,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/area/crew_quarters/kitchen)
 "uJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -19057,6 +19404,17 @@
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"uKC" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -1;
+	pixel_x = 28
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "uKE" = (
 /obj/machinery/suit_cycler/engineering,
 /turf/simulated/floor/plating,
@@ -19181,18 +19539,24 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "uVm" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/floor_decal/borderfloorblack{
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/random/trash,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/floor_decal/corner/lime/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "uVv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -19293,6 +19657,21 @@
 /area/rnd/research/firstdeck/hallway{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"uZB" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restroom and Showers"
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/wood,
+/area/crew_quarters/seconddeck/barrestroom)
 "vak" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -19956,6 +20335,20 @@
 /area/rnd/mixing{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"vQr" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "vQU" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small/readylight{
@@ -20327,6 +20720,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"wmR" = (
+/turf/simulated/mineral/cave,
+/area/crew_quarters/barrestroom)
 "wnl" = (
 /obj/effect/decal/cleanable/filth,
 /obj/item/clothing/head/helmet/space/syndicate/black/orange,
@@ -20868,6 +21264,23 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/civilian/sauna/cryosauna)
+"wLa" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck{
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
+	})
 "wLb" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -21015,6 +21428,10 @@
 /area/rnd/storage{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"wTR" = (
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "wUd" = (
 /obj/structure/table/hardwoodtable,
 /obj/structure/dancepole{
@@ -21114,13 +21531,23 @@
 	})
 "xaC" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Hydroponics Maintenance";
-	req_access = newlist();
-	req_one_access = list(35,28)
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/hydroponics)
+/area/crew_quarters/seconddeck/barrestroom)
 "xaJ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -21364,6 +21791,12 @@
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"xjW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "xkg" = (
 /obj/item/weapon/stool,
 /obj/effect/floor_decal/rust,
@@ -21503,6 +21936,10 @@
 /area/rnd/storage{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"xqX" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "xri" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -21515,6 +21952,10 @@
 /area/rnd/storage{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"xrm" = (
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "xsZ" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "ATMTK - Air"
@@ -21767,6 +22208,17 @@
 /obj/structure/catwalk,
 /obj/random/maintenance/misc,
 /obj/random/maintenance,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
@@ -22046,15 +22498,15 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/civilian/sauna/cryosauna)
 "xQj" = (
-/obj/machinery/seed_extractor,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/machinery/gibber,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21;
+	pixel_y = -31
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/kitchen)
 "xQt" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small,
@@ -22131,21 +22583,19 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "xTH" = (
-/obj/effect/floor_decal/rust,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck{
-	base_turf = /turf/simulated/floor/outdoors/rocks/caves
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/kitchen)
 "xUe" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -22264,6 +22714,18 @@
 /area/maintenance/firstdeck/centralport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"xXr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/seconddeck/barrestroom)
 "xXC" = (
 /obj/random/trash_pile,
 /obj/random/trash,
@@ -48689,11 +49151,11 @@ rlb
 lJk
 qHZ
 qHZ
-lJk
-rlb
-rlb
-rlb
-lJk
+npz
+npz
+npz
+npz
+npz
 qHZ
 qHZ
 lJk
@@ -48946,11 +49408,11 @@ rlb
 rlb
 lju
 lju
-rlb
-rlb
-rlb
-rlb
-rlb
+npz
+xqX
+phO
+jRS
+npz
 lll
 lll
 ykN
@@ -49203,11 +49665,11 @@ rlb
 rlb
 lju
 lju
-rlb
-rlb
-rlb
-rlb
-rlb
+npz
+nJF
+fAj
+fbL
+npz
 lll
 lhE
 ykN
@@ -49460,11 +49922,11 @@ rlb
 rlb
 ohZ
 wFq
-rlb
-rlb
-rlb
-rlb
-lJk
+npz
+wTR
+cMU
+xrm
+npz
 ycA
 pyT
 lJk
@@ -49717,11 +50179,11 @@ rlb
 rlb
 wFq
 wFq
-rlb
-rlb
-rlb
-rlb
-lJk
+npz
+nhR
+pZZ
+xQj
+npz
 qVD
 ycA
 lJk
@@ -49974,11 +50436,11 @@ rlb
 rlb
 wFq
 wFq
-lJk
-rlb
-rlb
-rlb
-lJk
+npz
+pYz
+npz
+npz
+npz
 tuI
 ycA
 lJk
@@ -50231,11 +50693,11 @@ rlb
 rlb
 ycA
 wFq
-pyL
-pyL
-pyL
-pyL
-pyL
+npz
+rJZ
+emX
+ujw
+npz
 ycA
 ycA
 lJk
@@ -50488,11 +50950,11 @@ rlb
 rlb
 ycA
 wJw
-uWQ
-uWQ
-uWQ
-uWQ
-uWQ
+npz
+qVW
+npz
+npz
+npz
 tuI
 ycA
 lJk
@@ -50745,11 +51207,11 @@ rlb
 lJk
 pyL
 kZR
-uWQ
+npz
 xTH
 gfD
 uJh
-uWQ
+npz
 ycA
 ycA
 lJk
@@ -51002,11 +51464,11 @@ rlb
 pyL
 ycA
 lUp
-uWQ
-mEJ
-gRe
 npz
-uWQ
+mEJ
+npz
+npz
+npz
 tuI
 ycA
 lJk
@@ -51258,8 +51720,8 @@ rlb
 rlb
 pyL
 ycA
-ycA
-tCN
+iSZ
+iTH
 mFy
 mYQ
 npN
@@ -51515,7 +51977,7 @@ rlb
 rlb
 pyL
 ycA
-ycA
+wLa
 uWQ
 uWQ
 uWQ
@@ -52029,7 +52491,7 @@ rlb
 rlb
 pyL
 ycA
-wFq
+kPG
 rlb
 rlb
 rlb
@@ -52286,7 +52748,7 @@ rlb
 uWQ
 pyL
 ycA
-xHh
+fRF
 rlb
 rlb
 rlb
@@ -52543,7 +53005,7 @@ ycA
 tCN
 wFq
 wFq
-wFq
+kPG
 yap
 rlb
 rlb
@@ -52800,7 +53262,7 @@ rlb
 uWQ
 xxd
 wFq
-xxd
+lEU
 rQN
 rQN
 rQN
@@ -53057,15 +53519,15 @@ rlb
 uWQ
 xxd
 xxd
-xxd
-rQN
-rQN
-rQN
+kZB
+vQr
+vQr
+vQr
 gfJ
-pme
-gjT
-rQN
-pme
+nQT
+gyc
+vQr
+uVm
 rQN
 rQN
 pme
@@ -53322,7 +53784,7 @@ rQN
 rQN
 rQN
 unm
-rQN
+jYn
 unm
 rQN
 pme
@@ -53572,16 +54034,16 @@ uWQ
 wFq
 wFq
 wFq
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
+cIK
+cIK
+cIK
+cIK
+cIK
+kkS
+kkS
 xaC
-pTQ
-pTQ
+kkS
+kkS
 vpw
 rQN
 ycA
@@ -53829,16 +54291,16 @@ uWQ
 uWQ
 wFq
 wFq
-pTQ
+cIK
 sEO
 qnX
 nsF
-xQj
+cIK
 sBN
 ktE
-oyQ
+uky
 euG
-pTQ
+kkS
 gRe
 jSD
 wFq
@@ -54086,16 +54548,16 @@ rlb
 uWQ
 xHh
 wFq
-pTQ
+cIK
 mNQ
-oyQ
-oyQ
-oyQ
-oyQ
-oyQ
-oyQ
-dvZ
-pTQ
+xjW
+dyD
+cIK
+sBN
+fOY
+xXr
+euG
+kkS
 gRe
 xxd
 het
@@ -54343,16 +54805,16 @@ rlb
 uWQ
 wFq
 wFq
-pTQ
-uVm
+cIK
+cIK
 oRK
-onC
+jGu
+cIK
+sBN
 nlZ
 onC
-nlZ
-onC
-dvZ
-pTQ
+bay
+kkS
 gRe
 ycA
 oSO
@@ -54600,16 +55062,16 @@ rlb
 uWQ
 wFq
 wFq
-pTQ
-phO
-pYz
+cIK
+cIK
+cIK
 qYq
 cIK
 kEK
-kZB
-oyQ
-oSr
+dvZ
 pTQ
+oSr
+kkS
 gRe
 wFq
 mvI
@@ -54857,16 +55319,16 @@ rlb
 uWQ
 wFq
 lfd
-pTQ
+kkS
 lWy
 lxR
 poK
+uZB
 aug
-onC
 aug
 cRk
 dvZ
-pTQ
+kkS
 gZN
 ycA
 ycA
@@ -55114,16 +55576,16 @@ rlb
 uWQ
 wFq
 wFq
-pTQ
+kkS
 cJA
 fjf
 qYQ
+kkS
+kkS
 oyQ
-oyQ
-oyQ
-oyQ
-dvZ
-pTQ
+kkS
+rXH
+kkS
 gZN
 ycA
 wFq
@@ -55371,16 +55833,16 @@ tWC
 rBp
 gLD
 gLD
-pTQ
+kkS
 aqc
 jmv
-gWU
+uKC
 kkS
 kkS
 gWU
 kkS
 uzz
-pTQ
+kkS
 hcQ
 jCW
 hck
@@ -55628,16 +56090,16 @@ rlb
 uWQ
 wFq
 wFq
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
-pTQ
+kkS
+kkS
+kkS
+kkS
+kkS
+kkS
+kkS
+kkS
+kkS
+kkS
 uWQ
 aQP
 gbb
@@ -57942,7 +58404,7 @@ rlb
 rlb
 rlb
 rlb
-rlb
+wmR
 uWQ
 loS
 uWQ

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -472,8 +472,8 @@
 /area/expoutpost/prep)
 "akH" = (
 /obj/structure/stairs/spawner/east,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "ale" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cargo Access"
@@ -1218,17 +1218,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/hos)
 "aFI" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/left/orange{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aFO" = (
 /obj/structure/closet/secure_closet/hos2{
@@ -1935,20 +1925,11 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_10)
 "aYs" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/item/weapon/storage/mre/random,
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Cafeteria East";
-	dir = 8
+/obj/effect/landmark/start{
+	name = "Barista"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "aYt" = (
 /obj/machinery/door/airlock/medical{
 	name = "Autoresleever Access";
@@ -2204,17 +2185,30 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "bhb" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -2817,6 +2811,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/zone_divider,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -3176,12 +3171,11 @@
 /turf/simulated/floor/water,
 /area/surface/outside/plains/outpost)
 "bEe" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lime/border,
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/device/multitool,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/bed/chair/sofa/right/black{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "bEi" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/cable{
@@ -4362,18 +4356,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/security_port)
 "cgQ" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/obj/effect/floor_decal/corner/lime/bordercorner,
-/obj/effect/landmark/start{
-	name = "Botanist"
-	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "cgR" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
@@ -4443,9 +4440,16 @@
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "chN" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "chV" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -4952,12 +4956,15 @@
 	outdoors = -1
 	})
 "cpv" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/item/weapon/deck/cards,
-/obj/random/drinkbottle,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	dir = 8;
+	id = "bar";
+	name = "Bar Shutters"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "cpZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7016,8 +7023,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "daA" = (
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "daI" = (
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
@@ -7191,7 +7198,9 @@
 	})
 "dfl" = (
 /obj/structure/stairs/spawner/east,
-/turf/simulated/floor/outdoors/grass/heavy,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
 /area/surface/outside/plains/outpost)
 "dfM" = (
 /obj/structure/closet/walllocker/emerglocker{
@@ -7344,17 +7353,23 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research_restroom_sc)
 "dhM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "dhN" = (
 /obj/structure/stairs/spawner/south,
 /obj/structure/railing/grey{
@@ -7655,17 +7670,10 @@
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/main/landing/two)
 "dpt" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/structure/bed/chair/sofa/right/orange{
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "dpH" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
@@ -8110,9 +8118,16 @@
 /turf/simulated/floor/carpet,
 /area/security/warden)
 "dxY" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Cafeteria West";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "dyu" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -8391,16 +8406,9 @@
 	},
 /area/surface/outside/plains/outpost)
 "dCB" = (
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Cafeteria Lobby West";
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "dCD" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -8588,7 +8596,7 @@
 	c_tag = "EXT - Civ Bar/Kitchen South 1"
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "dFF" = (
 /obj/structure/cable/green{
 	d1 = 6;
@@ -8992,19 +9000,28 @@
 	outdoors = -1
 	})
 "dNI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/stairs/dark_stairs{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/timeclock/premade/north,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/surface/outside/path/plains)
+/area/crew_quarters/cafeteria)
 "dNV" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/borderfloorblack{
@@ -9285,7 +9302,7 @@
 	c_tag = "EXT - Civ Bar/Kitchen South 2"
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "dRy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9987,18 +10004,15 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7)
 "eir" = (
-/obj/machinery/door/airlock/glass{
-	name = "Bar/Kitchen";
-	req_access = list(28)
+/obj/effect/floor_decal/stairs/wood_stairs{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "eiI" = (
 /obj/machinery/light/no_nightshift{
 	dir = 4
@@ -11253,15 +11267,14 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/civilian/fishing)
 "eFf" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/left/orange,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "bar";
+	name = "Bar Shutters"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "eFk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11570,6 +11583,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
+"eMZ" = (
+/obj/machinery/door/window/northleft{
+	name = "Hydroponics";
+	req_one_access = list(35,28);
+	dir = 2
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "eNc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -11584,13 +11605,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/server)
 "eND" = (
-/obj/structure/table/marble,
-/obj/random/soap,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/mob/living/simple_mob/animal/passive/cat/black,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/area/surface/outside/path/plains)
 "eNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12416,12 +12435,15 @@
 /turf/simulated/floor/bmarble,
 /area/engineering/hallway/engineer_hallway)
 "fdm" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/orange{
-	dir = 1
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "bar";
+	name = "Bar Shutters";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "fdn" = (
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/outdoors/dirt,
@@ -13150,17 +13172,17 @@
 	},
 /area/surface/outside/plains/outpost)
 "fqD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/table/marble,
-/obj/machinery/door/window/eastright{
-	req_access = newlist();
-	req_one_access = list(35,28)
+/obj/item/weapon/stool/baystool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/door/window/eastright{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "fqG" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -13176,17 +13198,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/shuttle)
 "fru" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/bed/chair/bay/chair/padded/red{
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -20
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "fry" = (
 /obj/structure/stairs/spawner/north,
 /obj/structure/railing/grey{
@@ -13340,12 +13364,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
 "ftG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/heavyduty{
 	d1 = 1;
 	d2 = 4;
@@ -13434,16 +13454,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_hallway)
 "fwl" = (
-/obj/machinery/door/firedoor/multi_tile/glass{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor,
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Bar/Lounge"
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/door/firedoor/multi_tile/glass{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "fwr" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 6
@@ -13675,17 +13694,26 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "fBa" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "fBc" = (
 /obj/effect/floor_decal/stairs/dark_stairs{
 	dir = 8
@@ -14556,7 +14584,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "fWw" = (
 /obj/item/weapon/flag,
 /obj/effect/zone_divider,
@@ -15264,6 +15292,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -16303,11 +16335,22 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/engineering/external_lights)
 "gGI" = (
-/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/marble,
-/obj/random/drinkbottle,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/machinery/reagentgrinder{
+	pixel_x = -11;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "gHl" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -16474,14 +16517,15 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/civilian/sauna)
 "gKP" = (
+/obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "gKW" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -18182,17 +18226,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "htV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/bed/chair/bay/chair/padded/red{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "hus" = (
 /turf/simulated/wall/r_wall{
 	cached_rad_resistance = 150
@@ -18770,17 +18810,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "hEZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
+/obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "hFT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18999,17 +19045,17 @@
 /turf/simulated/wall,
 /area/engineering/foyer)
 "hIF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/weapon/material/kitchen/utensil/fork,
+/obj/item/weapon/material/kitchen/utensil/spoon{
+	pixel_x = 2
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "hJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack{
@@ -19945,8 +19991,8 @@
 	},
 /area/surface/outside/plains/outpost)
 "ide" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/bar)
+/turf/simulated/wall,
+/area/crew_quarters/cafeteria)
 "idg" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -20166,21 +20212,17 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/hop/quarters)
 "ihk" = (
-/obj/effect/floor_decal/stairs/dark_stairs{
-	dir = 8
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	dir = 8;
+	id = "bar";
+	name = "Bar Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/cash_register/civilian{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "iiF" = (
 /mob/living/simple_mob/animal/passive/raccoon_ch,
@@ -20484,7 +20526,9 @@
 /area/surface/outside/path/plains)
 "ipR" = (
 /obj/structure/stairs/spawner/north,
-/turf/simulated/floor/outdoors/grass/heavy,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
 /area/surface/outside/plains/outpost)
 "ipS" = (
 /obj/machinery/light/bigfloorlamp{
@@ -20634,14 +20678,43 @@
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "itN" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/disposal/wall{
+	dir = 8;
+	pixel_x = 33
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/lino,
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 23;
+	pixel_y = -11
+	},
+/obj/machinery/button/holosign{
+	id = "baropen";
+	name = "Open Sign";
+	pixel_x = 20;
+	pixel_y = 12
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21;
+	pixel_y = -31
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "itO" = (
 /obj/structure/window/reinforced,
@@ -20944,6 +21017,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/heavyduty{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -22253,14 +22331,26 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "iZM" = (
-/obj/machinery/door/firedoor/multi_tile/glass{
+/obj/machinery/door/window/southright{
+	name = "Bar";
+	req_access = list(25);
 	dir = 8
 	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Bar"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "iZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22276,6 +22366,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"iZV" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "jai" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "E.V.A.";
@@ -22925,21 +23022,12 @@
 	},
 /area/server)
 "jrt" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
-/obj/item/honey_frame/filled,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/material/knife/butch,
+/obj/item/weapon/material/kitchen/rollingpin,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "jto" = (
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -24039,12 +24127,10 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/surface/outpost/wall/checkpoint)
 "jQQ" = (
-/obj/structure/table/marble,
-/obj/random/drinkbottle,
-/obj/machinery/computer/guestpass{
-	pixel_y = 30
+/obj/effect/landmark/start{
+	name = "Bartender"
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "jQV" = (
 /obj/machinery/vending/fitness,
@@ -24510,14 +24596,13 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/path/plains)
 "jZJ" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/right/orange,
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Cafeteria West";
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "kaJ" = (
 /obj/effect/floor_decal/shuttles,
 /obj/effect/zone_divider,
@@ -24639,6 +24724,10 @@
 	},
 /obj/structure/cable/heavyduty{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -24906,6 +24995,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/techmaint,
 /area/surface/outpost/main/gardening_tools)
 "kjI" = (
@@ -25688,15 +25778,12 @@
 	},
 /area/chapel/main)
 "kzR" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar";
-	layer = 3.1;
-	name = "Bar Shutters"
+/obj/effect/floor_decal/stairs/wood_stairs{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "kAl" = (
 /obj/structure/stairs/spawner/south,
 /obj/structure/railing/grey{
@@ -25782,10 +25869,16 @@
 /obj/machinery/station_map{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "kBi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -26393,11 +26486,18 @@
 "kRp" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 32;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "32-8"
 	},
-/turf/simulated/floor/plating{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 8
+	},
+/turf/simulated/open{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -26409,9 +26509,15 @@
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "kRU" = (
-/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "kSn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26532,12 +26638,32 @@
 	outdoors = 1
 	},
 /area/hallway/primary/seconddeck/dockhallway)
+"kUz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "kUB" = (
 /obj/machinery/station_map{
 	pixel_y = 32
 	},
 /turf/simulated/floor/outdoors/grass/heavy,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "kUP" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -26858,15 +26984,15 @@
 	},
 /area/engineering/external_lights)
 "lbF" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/bed/chair/bay/chair/padded/red{
 	dir = 4
 	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "lbN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -27445,6 +27571,10 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -27699,16 +27829,8 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research_restroom_sc)
 "lsh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "lso" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -27976,12 +28098,22 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
 "lxx" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light/no_nightshift{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "lxS" = (
 /obj/machinery/vending/cigarette{
 	dir = 8
@@ -28154,7 +28286,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "lBR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28362,12 +28494,10 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/garage)
 "lFo" = (
-/obj/machinery/camera/network/exterior{
-	c_tag = "EXT - Civ Bar/Kitchen West 1";
-	dir = 8
-	},
-/turf/simulated/floor/outdoors/dirt,
-/area/crew_quarters/bar)
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/appliance/cooker/oven,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "lFF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28878,21 +29008,11 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "lRo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/vending/boozeomat,
-/obj/machinery/button/remote/blast_door{
-	id = "bar";
-	name = "Bar Shutters";
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/dogbed,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "lRs" = (
 /mob/living/simple_mob/animal/sif/glitterfly{
 	desc = "A large, shiny butterfly! The explorer who caught it refused to change the name after learning it was not a moth.";
@@ -29406,11 +29526,15 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_6)
 "meB" = (
-/obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
-/obj/item/device/paicard,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "meE" = (
 /turf/simulated/wall,
 /area/medical/psych)
@@ -30358,12 +30482,11 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outside/plains/outpost)
 "mzt" = (
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/structure/railing,
 /turf/simulated/open{
 	outdoors = 1
 	},
-/area/hydroponics)
+/area/crew_quarters/cafeteria)
 "mzE" = (
 /obj/effect/floor_decal/borderfloorblack,
 /turf/simulated/floor/tiled/old_tile/gray,
@@ -31146,10 +31269,14 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
 "mOK" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/right/orange,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/item/weapon/stool/baystool/padded{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "mOY" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
@@ -31358,13 +31485,14 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "mRO" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	dir = 8;
+	id = "bar";
+	name = "Bar Shutters"
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "mRP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -31415,16 +31543,18 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/crew_quarters/heads/sc/hop)
 "mSU" = (
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Cafeteria Lobby East";
-	dir = 8
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/weapon/reagent_containers/glass/rag{
+	pixel_x = -6
 	},
-/obj/machinery/vending/wallmed1{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = 3
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/turf/simulated/floor/lino,
+/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask,
+/obj/item/weapon/flame/lighter/zippo,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "mTk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -31492,17 +31622,15 @@
 	},
 /area/crew_quarters/heads/sc/hop)
 "mVB" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 8
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Bar";
+	dir = 8
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "mVF" = (
 /obj/machinery/camera/network/exterior{
@@ -32160,13 +32288,13 @@
 "nin" = (
 /obj/effect/floor_decal/stairs/dark_stairs,
 /turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/bar)
+/area/surface/outside/path/plains)
 "nis" = (
 /obj/machinery/holosign/bar{
 	id = "baropen"
 	},
 /turf/simulated/wall,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "niv" = (
 /obj/item/weapon/melee/umbrella/random,
 /obj/item/weapon/melee/umbrella/random,
@@ -32481,6 +32609,13 @@
 "npz" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/sc/cmo/quarters)
+"npP" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/bed/chair/bay/chair/padded/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "nqs" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "ENG - Engineering Break Room";
@@ -32701,10 +32836,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/garage)
 "nvh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/bar)
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/marble,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "nvj" = (
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "lawyer_tint"
@@ -33118,14 +33254,21 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/needle)
 "nGD" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "nGF" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -36918,26 +37061,26 @@
 	},
 /area/surface/outside/plains/outpost)
 "pss" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/computer/timeclock/premade/north,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Bar/Lounge"
+/obj/machinery/computer/guestpass{
+	pixel_y = 30
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "psu" = (
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood/alt/panel,
@@ -37017,7 +37160,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -37083,10 +37226,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37839,7 +37982,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "pJM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -38215,10 +38358,17 @@
 /turf/simulated/wall,
 /area/engineering/engi_restroom)
 "pRp" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/item/weapon/stool/baystool/padded{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "pRr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -38360,7 +38510,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "pTh" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Autoresleeving East 1";
@@ -38407,10 +38557,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "pUn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "pUI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/no_nightshift,
@@ -38441,7 +38593,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "pUV" = (
 /obj/structure/cable/heavyduty{
 	d1 = 1;
@@ -39054,17 +39206,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "qdP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -39471,23 +39618,15 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "qjn" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/structure/bed/chair/sofa/right/black{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "qjM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -39640,10 +39779,10 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "qos" = (
+/obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
-/obj/random/drinkbottle,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "qoB" = (
 /obj/item/weapon/storage/fancy/vials{
 	pixel_x = 5;
@@ -40007,17 +40146,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/heads/sc/chief)
 "qyr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/weapon/stool/baystool/padded{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "qyJ" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -40117,8 +40250,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -40318,7 +40451,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "qHU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40358,16 +40491,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -40613,56 +40741,37 @@
 /turf/simulated/floor/plating/thor/planetuse,
 /area/surface/outside/path/plains)
 "qOK" = (
+/obj/machinery/seed_storage/garden,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"qPa" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"qPb" = (
+/obj/machinery/vending/wardrobe/hydrobe,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/marble,
-/obj/machinery/microwave{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"qPa" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
-"qPb" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/structure/table/marble,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qPd" = (
 /obj/effect/floor_decal/rust,
 /obj/random/tech_supply,
@@ -40692,16 +40801,15 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/engineering/locker_room)
 "qPL" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/biogenerator,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/obj/machinery/appliance/cooker/oven,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qPW" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/fence,
@@ -40713,16 +40821,21 @@
 	},
 /area/lawoffice)
 "qQx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/appliance/cooker/fryer,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qRl" = (
 /obj/structure/disposalpipe/up{
 	dir = 4
@@ -40799,20 +40912,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qSz" = (
-/obj/structure/table/marble,
-/obj/machinery/reagentgrinder,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/weapon/book/manual/hydroponics_pod_people,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/rollingpapers,
+/obj/item/weapon/storage/rollingpapers,
+/obj/item/weapon/storage/rollingpapers/blunt,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Kitchen/Bar"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qSY" = (
 /turf/simulated/wall,
 /area/medical/foyer)
@@ -40847,18 +40959,21 @@
 	},
 /area/crew_quarters/heads/sc/hos)
 "qUg" = (
-/obj/structure/table/marble,
-/obj/item/weapon/material/knife/butch,
-/obj/item/weapon/material/kitchen/rollingpin,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/corner/lime/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qUl" = (
 /obj/effect/floor_decal/chapel,
 /obj/structure/bed/chair/oldsofa/left{
@@ -40933,42 +41048,60 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/security/detectives_office)
 "qVA" = (
-/obj/structure/table/marble,
-/obj/item/weapon/book/manual/chef_recipes,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
+/obj/machinery/vending/wallmed1{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 3
 	},
-/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/engineering/external_lights)
 "qVL" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qVR" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/vending/dinnerware,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/closet/crate/hydroponics{
+	desc = "All you need to start your own honey farm.";
+	name = "beekeeping crate"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/item/beehive_assembly,
+/obj/item/bee_smoker,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/bee_pack,
+/obj/item/weapon/tool/crowbar,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qWe" = (
 /obj/machinery/vending/loadout,
 /obj/machinery/camera/network/medbay{
@@ -40978,16 +41111,23 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
 "qWs" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/no_nightshift{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/newscaster{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "qWz" = (
 /obj/structure/sink{
 	pixel_y = 19
@@ -41061,18 +41201,8 @@
 	},
 /area/surface/outside/path/plains)
 "qYW" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
+/obj/machinery/honey_extractor,
+/turf/simulated/floor/grass,
 /area/hydroponics)
 "qZm" = (
 /obj/machinery/door/firedoor/border_only,
@@ -41221,9 +41351,19 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/medical_lockerroom)
 "rcv" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "rcx" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -41393,20 +41533,19 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/needle)
 "rfp" = (
-/obj/structure/cable/green{
-	d1 = 5;
-	d2 = 6;
-	icon_state = "5-6"
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/appliance/cooker/fryer,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /obj/structure/cable/green{
-	d1 = 6;
-	d2 = 9;
-	icon_state = "6-9"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "rfV" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/wood/alt/panel,
@@ -41701,25 +41840,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "rlT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/computer/timeclock/premade/north,
+/obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Bar/Lounge"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "rmc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -42454,6 +42577,11 @@
 	dir = 2;
 	icon_state = "pipe-j2"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -42911,10 +43039,31 @@
 /turf/simulated/floor/tiled/freezer,
 /area/engineering/engi_restroom)
 "rJw" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/vending/hydronutrients{
+	dir = 4;
+	pixel_x = -5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Hydroponics";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "rJx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -43002,9 +43151,11 @@
 /area/medical/cryo/autoresleeve)
 "rLw" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -43045,13 +43196,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/security/security_bathroom)
 "rLG" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/landmark/start{
+	name = "Botanist"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "rLI" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -43071,19 +43220,20 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
 "rNv" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/landmark/start{
-	name = "Barista"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "rNL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -43121,7 +43271,13 @@
 "rNY" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -43133,15 +43289,17 @@
 /area/maintenance/substation/engineering)
 "rOk" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -43152,15 +43310,21 @@
 	},
 /area/surface/outside/path/plains)
 "rOC" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "rOI" = (
 /obj/item/weapon/stock_parts/manipulator,
 /obj/item/weapon/stock_parts/manipulator,
@@ -43185,18 +43349,15 @@
 /turf/simulated/wall/r_wall,
 /area/surface/outpost/mining_main/refinery)
 "rOZ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"rPc" = (
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/book/manual/hydroponics_pod_people,
-/turf/simulated/floor/tiled/hydro,
+/turf/simulated/floor/grass,
 /area/hydroponics)
+"rPc" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "rPn" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -43242,12 +43403,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "rQR" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Bar Storage"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "rRf" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -43275,19 +43433,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "rRr" = (
-/obj/structure/closet/gmcloset,
-/obj/item/glass_jar,
-/obj/item/device/retail_scanner/civilian,
-/obj/item/device/retail_scanner/civilian,
-/obj/item/clothing/head/that{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "rRL" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -44824,8 +44975,13 @@
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/engineering/workshop)
 "syN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
@@ -44959,37 +45115,41 @@
 	},
 /area/surface/outside/path/plains)
 "sBm" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "sBt" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "sBA" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "sBH" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -45060,26 +45220,33 @@
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
 "sCe" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "sCh" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = -13
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 8
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "sCK" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -45193,13 +45360,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/psych)
 "sEV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sFn" = (
@@ -45213,10 +45383,15 @@
 	},
 /area/surface/outside/path/plains)
 "sFu" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "sGf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -45247,25 +45422,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/cryo/autoresleeve)
 "sHa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/turf/simulated/open{
+	outdoors = 1
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/marble,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3
-	},
-/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sHd" = (
 /obj/machinery/camera/network/exterior{
@@ -45274,11 +45436,13 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outpost/main/gym)
 "sHu" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/chemical_dispenser/bar_soft/full,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/door/airlock/glass{
+	name = "Bar/Lounge"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "sHx" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -45289,13 +45453,8 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "sHE" = (
-/obj/structure/table/marble,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/chemical_dispenser/bar_alc/full,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/appliance/cooker/grill,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sHZ" = (
@@ -45325,20 +45484,15 @@
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/main/landing/one)
 "sIw" = (
-/obj/structure/table/marble,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/table/hardwoodtable,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "bar";
+	name = "Bar Shutters";
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/weapon/reagent_containers/glass/rag{
-	pixel_x = -6
-	},
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "sIA" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -45354,14 +45508,22 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet/firstdeck)
 "sJi" = (
-/obj/structure/table/marble,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/item/weapon/stool/baystool/padded{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Cafeteria North";
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/cafeteria)
 "sJH" = (
 /obj/machinery/door/airlock{
 	id_tag = "unit9";
@@ -45424,10 +45586,13 @@
 	},
 /area/surface/outside/plains/outpost)
 "sMo" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/material/kitchen/utensil/fork,
+/obj/item/weapon/material/kitchen/utensil/spoon{
+	pixel_x = 2
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "sMu" = (
 /obj/structure/closet/crate/medical,
 /obj/item/weapon/surgical/surgicaldrill,
@@ -45451,25 +45616,15 @@
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "sMz" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/wall,
+/area/surface/outside/path/plains)
 "sMO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "sNo" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/microwave{
@@ -45516,49 +45671,52 @@
 /area/rnd/research)
 "sNF" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bed/chair/bay/chair/padded/red,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
+"sNS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+	dir = 10
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
-"sNS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"sOa" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"sOc" = (
+/obj/machinery/button/remote/blast_door{
+	id = "bar";
+	name = "Bar Shutters";
+	pixel_x = -8;
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"sOa" = (
-/obj/machinery/door/airlock{
-	name = "Bar Backroom";
-	req_access = list(25)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/kitchen)
-"sOc" = (
-/obj/structure/table/marble,
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sOg" = (
 /obj/structure/cable/heavyduty{
@@ -45581,6 +45739,12 @@
 	d2 = 9;
 	icon_state = "6-9"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -45598,29 +45762,12 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "sPw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "sPA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/machinery/beehive,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "sPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -45744,22 +45891,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "sQA" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+/obj/structure/bed/chair/sofa/corner/black{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/device/multitool,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "sQD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -45983,13 +46119,28 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/civilian/sauna)
 "sVG" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/light/no_nightshift,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = -12;
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "sVQ" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
@@ -46336,14 +46487,18 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/sauna)
 "tdh" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "tdm" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
@@ -46848,8 +47003,22 @@
 /area/surface/outside/path/plains)
 "tqv" = (
 /obj/structure/railing/grey,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "tqG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46882,7 +47051,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/path/plains)
 "tso" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -46940,19 +47109,13 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_4)
 "ttD" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Maintenance";
-	req_access = list(28)
+	name = "Hydroponics Access";
+	req_access = list(35)
 	},
 /obj/structure/fans/tiny,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 10;
-	icon_state = "4-10"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ttH" = (
 /obj/machinery/mineral/equipment_vendor/survey,
 /obj/effect/floor_decal/borderfloorblack{
@@ -46993,26 +47156,50 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/path/plains)
 "ttU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair/wood,
+/obj/machinery/light/no_nightshift{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30;
+	pixel_x = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "tum" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 5
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = -13;
+	req_access = list(28);
+	pixel_y = -31
+	},
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "tuw" = (
 /obj/structure/target_stake,
@@ -47073,27 +47260,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/debriefing)
 "tve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/mob/living/simple_mob/animal/goat{
-	name = "Pete"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "tvf" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/reinforced,
@@ -47106,38 +47274,34 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "tvn" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/disposal/wall{
+	dir = 1;
+	pixel_y = -33
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/button/holosign{
+	id = "baropen";
+	name = "Open Sign";
+	pixel_x = 13;
+	pixel_y = -21
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "tvo" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen cold room";
-	req_access = list(28)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "tvA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light/small{
@@ -47220,20 +47384,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "tvL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "tvR" = (
 /obj/structure/table/standard,
 /obj/item/clothing/gloves/boxing/blue,
@@ -47283,55 +47438,61 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research_restroom_sc)
 "twk" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "twC" = (
 /turf/simulated/wall,
 /area/medical/cryo/autoresleeve)
 "txp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "txC" = (
-/obj/machinery/appliance/mixer/candy,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"txG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light/no_nightshift{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/woodentable,
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
-/obj/item/weapon/gun/projectile/shotgun/doublebarrel,
-/obj/item/device/retail_scanner/civilian,
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
-"tyv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/hydroponics)
+"txG" = (
+/obj/machinery/door/window/northleft{
+	name = "Hydroponics";
+	req_one_access = list(35,28);
+	dir = 2
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"tyv" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Hydroponics Farm";
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "tyA" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -47353,14 +47514,9 @@
 /turf/simulated/wall,
 /area/lawoffice)
 "tyP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "tyR" = (
 /obj/structure/flora/lily1,
 /turf/simulated/floor/water,
@@ -47384,20 +47540,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "tzn" = (
+/obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access = list(25)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plating,
+/area/hydroponics)
 "tzo" = (
 /obj/structure/table/steel,
 /obj/item/device/integrated_electronics/debugger{
@@ -47418,16 +47564,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
 "tzq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/surface/outside/path/plains)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "tzr" = (
 /obj/machinery/light/no_nightshift,
 /obj/structure/cable/green{
@@ -47455,12 +47609,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "tzW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/heavyduty{
 	d1 = 1;
 	d2 = 2;
@@ -47815,18 +47967,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "tGw" = (
-/obj/effect/floor_decal/techfloor,
+/obj/structure/fans/tiny,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "tGI" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/mining,
@@ -48564,15 +48715,15 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
 "tXH" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+/obj/machinery/media/jukebox,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21;
+	pixel_x = 9
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/obj/machinery/vending/wardrobe/hydrobe,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "tXN" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -48646,17 +48797,14 @@
 	},
 /area/surface/outpost/main/dorms/dorm_2)
 "tYs" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 10
-	},
 /obj/machinery/light/no_nightshift,
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/device/multitool,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	name = "NanoMed Wall";
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "tYx" = (
 /turf/simulated/wall,
 /area/rnd/research)
@@ -48824,11 +48972,6 @@
 	},
 /obj/machinery/computer/timeclock/premade/east,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 5;
-	d2 = 10;
-	icon_state = "5-10"
-	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -48887,30 +49030,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/reception)
 "ufr" = (
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Kitchen Cold Room";
-	dir = 1
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
 	},
-/obj/structure/closet/chefcloset,
-/obj/item/glass_jar,
-/obj/item/device/retail_scanner/civilian,
-/obj/item/weapon/soap/nanotrasen,
-/obj/item/device/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
 	},
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/clothing/gloves/sterile/latex,
-/obj/item/clothing/gloves/sterile/latex,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ufJ" = (
 /obj/structure/flora/lily2,
 /obj/effect/zone_divider,
@@ -48919,13 +49047,11 @@
 	},
 /area/surface/outside/plains/outpost)
 "ufQ" = (
-/obj/structure/kitchenspike,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ufS" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -48984,19 +49110,26 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "uhm" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
-"uhQ" = (
-/obj/machinery/gibber,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21;
-	pixel_y = -31
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/machinery/light/no_nightshift,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"uhQ" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "uhR" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Exploration 7";
@@ -49116,10 +49249,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "ujS" = (
-/obj/machinery/appliance/cooker/grill,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ujU" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -49134,39 +49270,30 @@
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
 "ukA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/stairs/dark_stairs{
+	dir = 8
 	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
+/area/surface/outside/path/plains)
 "ukO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/disposal/wall{
+	dir = 1;
+	pixel_y = -33
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/landmark/start{
-	name = "Bartender"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ulx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/landmark/start{
-	name = "Chef"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "ulD" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -49231,23 +49358,23 @@
 	},
 /area/surface/outside/path/plains)
 "uno" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/vending/cola,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
+"unt" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/disposalpipe/segment,
-/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"unt" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/vending/altevian,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
 "unS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/medical{
@@ -49285,23 +49412,11 @@
 	},
 /area/surface/outside/path/plains)
 "uoe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/vending/altevian,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "uoq" = (
 /obj/structure/marker_beacon{
 	icon_state = "markerburgundy-on";
@@ -49335,10 +49450,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "upx" = (
-/obj/machinery/appliance/mixer/cereal,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "upC" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -50075,16 +50196,15 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "uDD" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/machinery/vending/boozeomat,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "uDP" = (
 /obj/structure/cable/heavyduty{
@@ -50636,11 +50756,12 @@
 /area/engineering/engine_eva)
 "uLl" = (
 /obj/structure/railing/grey,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "uLL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -50996,6 +51117,10 @@
 	icon_state = "1-8"
 	},
 /obj/structure/railing/grey,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -51168,11 +51293,9 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/engineering/external_lights)
 "uVE" = (
-/obj/structure/sign/directions/stairs_down{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/crew_quarters/kitchen)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "uVH" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/foyer)
@@ -51211,21 +51334,35 @@
 	},
 /area/surface/outside/path/plains)
 "uWy" = (
-/obj/machinery/smartfridge/drinks,
-/turf/simulated/wall,
-/area/crew_quarters/kitchen)
-"uWD" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar";
-	layer = 3.1;
-	name = "Bar Shutters"
+/obj/machinery/door/window/northleft{
+	name = "Hydroponics";
+	req_one_access = list(35,28)
 	},
-/obj/item/weapon/flame/lighter/zippo,
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask,
+/obj/item/weapon/book/codex/chef_recipes,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/hydroponics)
+"uWD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = -22;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "uWF" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/zone_divider,
@@ -51272,16 +51409,15 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3)
 "uXm" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar";
-	layer = 3.1;
-	name = "Bar Shutters"
+/obj/effect/floor_decal/stairs/wood_stairs{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "uXy" = (
 /obj/machinery/smartfridge/produce/persistent_lossy,
 /turf/simulated/wall,
@@ -51425,21 +51561,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/foyer)
 "uZH" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar";
-	layer = 3.1;
-	name = "Bar Shutters"
+/obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/civilian{
+	c_tag = "CIV - Kitchen/Bar"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -51476,16 +51606,10 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9)
 "vaB" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "bar";
-	layer = 3.1;
-	name = "Bar Shutters"
-	},
-/obj/random/action_figure/supplypack,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/crew_quarters/cafeteria)
 "vaH" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/outdoors/dirt,
@@ -51907,20 +52031,29 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/emergency_storage)
 "vid" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/obj/item/device/radio/beacon,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "viv" = (
 /obj/structure/cable/heavyduty{
 	d1 = 1;
@@ -52184,7 +52317,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "vmW" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/outdoors/dirt,
@@ -52638,6 +52771,18 @@
 "vtd" = (
 /turf/simulated/wall,
 /area/engineering/workshop)
+"vtl" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/appliance/mixer/cereal,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "vtG" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -53450,20 +53595,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/prep)
 "vKE" = (
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 8;
-	icon_state = "32-8"
-	},
-/obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/railing/grey{
 	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/sign/directions/stairs_down{
+	pixel_y = 25
 	},
 /turf/simulated/open{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/crew_quarters/kitchen)
 "vKF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53547,7 +53691,7 @@
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/crew_quarters/kitchen)
+/area/hydroponics)
 "vNb" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -53555,14 +53699,15 @@
 	},
 /area/chapel/main)
 "vNf" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/media/jukebox,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "vNh" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/atmospherics{
@@ -53586,12 +53731,19 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "vON" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/left/orange{
-	dir = 1
+/obj/structure/table/marble,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 4
+	},
+/obj/item/weapon/material/kitchen/utensil/fork,
+/obj/item/weapon/material/kitchen/utensil/spoon{
+	pixel_x = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "vOV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53600,24 +53752,40 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "vPv" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
-"vPZ" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded,
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/structure/table/marble,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
+"vPZ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "vQb" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "vQm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -53663,18 +53831,21 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9)
 "vRE" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/stool/baystool/padded,
-/turf/simulated/floor/tiled/white,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/exterior{
+	c_tag = "EXT - Civ Bar/Kitchen West 1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
 /area/crew_quarters/bar)
 "vRX" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -53688,18 +53859,12 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/chapel/main)
 "vSA" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/mob/living/simple_mob/vore/redpanda{
+	desc = "It's Nymph, the new bar pet! NT got tired of cloning Pun-Pun, since people kept murdering him.";
+	name = "Nymph"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "vSO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53757,32 +53922,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "vTj" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
-/obj/structure/dogbed,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "vTx" = (
+/obj/structure/railing/grey,
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "vTI" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -53814,24 +53963,10 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "vUe" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 10
-	},
-/obj/machinery/disposal/wall{
-	pixel_y = 33
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/structure/table/hardwoodtable,
+/obj/item/device/paicard,
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "vUk" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light_construct/floortube{
@@ -53842,18 +53977,10 @@
 	},
 /area/surface/outpost/civilian/emergency_storage)
 "vUn" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Gardener"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/crew_quarters/kitchen)
 "vUw" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -53862,23 +53989,20 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/chapel/main)
 "vUD" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Civ Bar/Kitchen East 3";
 	dir = 4
 	},
+/obj/structure/railing/grey,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
-/area/hydroponics)
+/area/crew_quarters/cafeteria)
 "vUR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54406,24 +54530,12 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "wdH" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 4
-	},
+/obj/machinery/vending/fitness,
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/item/weapon/storage/toolbox/hydro,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "wdX" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -54643,7 +54755,9 @@
 /area/medical/medical_lockerroom)
 "wiD" = (
 /obj/structure/stairs/spawner/south,
-/turf/simulated/floor/outdoors/grass/heavy,
+/turf/simulated/floor/tiled/steel_dirty{
+	outdoors = 1
+	},
 /area/expoutpost/prep)
 "wiI" = (
 /obj/structure/disposalpipe/segment{
@@ -55205,6 +55319,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -55339,13 +55454,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "wwJ" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/recharge_station,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "wwL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
@@ -55478,20 +55590,35 @@
 	},
 /area/surface/outside/path/plains)
 "wzB" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/mob/living/simple_mob/vore/redpanda{
-	desc = "It's Nymph, the new bar pet! NT got tired of cloning Pun-Pun, since people kept murdering him.";
-	name = "Nymph"
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -13
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26;
+	dir = 4;
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "wzR" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 2;
-	icon_state = "pipe-j2"
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wzS" = (
 /obj/machinery/door/firedoor/border_only,
@@ -55529,23 +55656,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "wAt" = (
-/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/landmark/start{
+	name = "Chef"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "wAF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55556,11 +55684,11 @@
 /area/surface/outpost/civilian/emergency_storage)
 "wAM" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/stool/baystool/padded{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "wAQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -55597,28 +55725,14 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
 "wBu" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access = newlist();
-	req_one_access = list(35,28)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "wBK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55652,38 +55766,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/main/gym)
 "wDy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
-"wDA" = (
 /obj/effect/landmark/start{
-	name = "Botanist"
+	name = "Chef"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"wDA" = (
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "wDI" = (
 /obj/machinery/button/remote/blast_door{
 	desc = "Controls the E-arm doors. Only use this during code red situations when everyone needs to be armed.";
@@ -55903,11 +56001,26 @@
 /area/surface/outside/path/plains)
 "wIH" = (
 /obj/structure/railing/grey,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "wIP" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/microwave{
@@ -56374,7 +56487,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/bar)
+/area/surface/outside/path/plains)
 "wUw" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -56733,12 +56846,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/external_lights)
 "xcj" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/item/weapon/deck/cards,
-/obj/random/snack,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "xcs" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -57340,8 +57452,8 @@
 /area/quartermaster/delivery)
 "xmc" = (
 /obj/structure/stairs/spawner/west,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "xml" = (
 /obj/effect/map_effect/portal/master/side_a{
 	dir = 4;
@@ -57404,10 +57516,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
 "xnN" = (
+/obj/structure/railing,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/open{
 	outdoors = 1
 	},
-/area/hydroponics)
+/area/crew_quarters/cafeteria)
 "xoq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -57553,24 +57670,24 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
 "xpJ" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/disposal,
-/obj/machinery/light/no_nightshift{
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/appliance/mixer/candy,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
+"xqb" = (
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
-"xqb" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "xqr" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
@@ -57580,29 +57697,34 @@
 /area/surface/outpost/main/dorms/dorm_4)
 "xqP" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/table/marble,
+/obj/random/snack,
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "xqU" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "xrl" = (
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/tiled/steel_dirty{
@@ -57613,14 +57735,17 @@
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3)
 "xrz" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/weapon/stool/baystool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "xrC" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Exploration Medical Storage Room";
@@ -57631,20 +57756,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/prep/recovery)
 "xrI" = (
-/obj/effect/floor_decal/borderfloorblack{
+/obj/structure/table/hardwoodtable,
+/obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "xsk" = (
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/floor_decal/borderfloorblack{
@@ -57676,6 +57796,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
 	},
@@ -58324,18 +58445,21 @@
 /turf/simulated/floor/bmarble,
 /area/chapel/office)
 "xAW" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "xBi" = (
 /obj/machinery/computer/timeclock/premade/north,
 /obj/effect/landmark/vines,
@@ -58627,10 +58751,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/hallway/engineer_hallway)
 "xFG" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/orange,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/table/hardwoodtable,
+/obj/random/drinkbottle,
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "bar";
+	name = "Bar Shutters"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "xFS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58638,10 +58767,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "xFW" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/device/multitool,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "xGd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -58661,16 +58790,9 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "xGB" = (
-/obj/structure/railing/grey,
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/melee/umbrella/random,
-/obj/item/weapon/melee/umbrella/random,
-/obj/item/weapon/melee/umbrella/random,
-/obj/item/weapon/melee/umbrella/random,
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/engineering/external_lights)
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/outdoors/grass/heavy,
+/area/surface/outside/path/plains)
 "xGF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -58706,14 +58828,14 @@
 /area/surface/outpost/main/gym)
 "xHB" = (
 /obj/structure/cable/heavyduty{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/effect/floor_decal/rust,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
@@ -59048,38 +59170,38 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "xMt" = (
-/obj/effect/floor_decal/stairs/dark_stairs{
+/obj/machinery/door/airlock/glass{
+	name = "Bar/Lounge"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_dirty{
-	outdoors = 1
-	},
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/cafeteria)
 "xMw" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/sign/directions/stairs_down{
+	dir = 6;
+	pixel_y = 24
 	},
 /obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Hydroponics";
-	dir = 4
+	c_tag = "CIV - Cafeteria East";
+	dir = 6
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/crew_quarters/cafeteria)
 "xMJ" = (
 /obj/machinery/vending/coffee{
 	dir = 1
@@ -59328,9 +59450,14 @@
 /area/surface/outpost/main/dorms/dorm_3)
 "xRn" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/light/no_nightshift,
+/obj/item/weapon/stool/baystool/padded{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/cafeteria)
 "xRt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -59457,12 +59584,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
 "xTy" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/right/orange{
-	dir = 1
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "xTH" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -60043,10 +60173,18 @@
 	},
 /area/surface/outside/path/plains)
 "ydx" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/sofa/left/orange,
+/obj/structure/table/marble,
+/obj/machinery/cash_register/civilian{
+	dir = 8
+	},
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "ydP" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -87092,7 +87230,7 @@ yeV
 yeV
 tqp
 yeV
-rfp
+hTU
 yeV
 wst
 xnv
@@ -87351,9 +87489,9 @@ tsb
 udl
 fWl
 sOK
-wqX
-wqX
-wqX
+twk
+twk
+twk
 ftG
 yeV
 yeV
@@ -87602,14 +87740,14 @@ kPi
 yeV
 pSe
 yeV
-mpQ
-mpQ
+xCr
+xCr
 ttD
-mpQ
-mpQ
+xCr
+xCr
 kBb
 hTU
-yeV
+eND
 yeV
 vcm
 yeV
@@ -87859,12 +87997,12 @@ kPi
 ygB
 pSe
 yeV
-mpQ
+tzn
 sBm
-ttU
+tve
 ufr
-mpQ
-ydd
+tzn
+cgQ
 vSO
 sul
 vSO
@@ -87872,7 +88010,7 @@ dvO
 vSO
 vSO
 vSO
-vSO
+lNy
 vSO
 vnQ
 vSO
@@ -88116,17 +88254,17 @@ pZR
 yeV
 pSe
 yeV
-mpQ
+tzn
 sBt
-tum
+tve
 ufQ
-uVE
+tzn
 kRp
 mCZ
 ybp
-yeV
+bvO
 waG
-hvF
+vRE
 hvF
 hvF
 rxJ
@@ -88373,22 +88511,22 @@ kPi
 yeV
 pSe
 xVT
-mpQ
-sBA
+tzn
+sBt
 tve
 uhm
+xCr
+vUn
 mpQ
-kRp
-fAd
-mCZ
-bvO
-ybp
-ybp
-ybp
-yeV
+vUn
+mpQ
+vUn
+mpQ
+vUn
+mpQ
 dNI
-yeV
-xke
+kMd
+qVA
 xke
 xke
 yeV
@@ -88630,22 +88768,22 @@ kPi
 yeV
 psQ
 myw
-mpQ
+xCr
 sCe
-tvn
+tve
 uhQ
-mpQ
+xCr
 vKE
-xpb
-rLe
-rLe
-ybp
+sHa
+wzB
+rfp
+sHE
 lFo
-azS
-xGB
+vtl
+mpQ
 xMt
-kMd
-xke
+vaB
+ide
 ide
 ide
 kUB
@@ -88886,24 +89024,24 @@ yeV
 kPi
 pse
 pTd
-mpQ
-mpQ
-mpQ
+xCr
+xCr
+rNv
 tvo
+ufQ
+xCr
+uZH
+qnH
+rNY
+wAt
+wDy
+unt
+tum
 mpQ
-mpQ
-iRX
-iRX
-rLe
-eiZ
-eiZ
-ide
-swv
-swv
 pss
-swv
-nvh
-swv
+dCB
+dxY
+ide
 ide
 xke
 yeV
@@ -89142,22 +89280,22 @@ yeV
 yeV
 kPi
 psQ
-mpQ
-mpQ
+xCr
+xCr
 rJw
 sCh
 sNS
-ujQ
-mpQ
-swv
-swv
+uWD
+rOC
+nGD
+rLw
+sEV
 nvh
-nvh
-nvh
-swv
-swv
+jrt
+wwJ
+rOk
 xAW
-fBa
+tzq
 dCB
 lbF
 ide
@@ -89399,25 +89537,25 @@ yeV
 yeV
 kPi
 psQ
-mpQ
+xCr
 qOK
-qnH
-sEV
+sBA
+xGM
 tvL
 ujS
-pUn
+uXy
 vNf
-wwJ
+ujQ
 xpJ
 jZJ
 gGI
 dpt
-swv
-eND
+tvn
+mpQ
 fBa
-daA
+dCB
 qos
-nvh
+vaB
 eiZ
 qaW
 yeV
@@ -89656,25 +89794,25 @@ yeV
 yeV
 kPi
 vNa
-mpQ
+xCr
 qPb
-qnH
-sMO
-twk
-ukA
+tve
+xGM
+tve
+ujS
 uWy
 kRU
-kRU
-wAM
-xFG
 xcj
-fdm
-nvh
+xcj
+xcj
+xcj
+xcj
+xTy
 sFu
-lsh
-daA
+dhM
+dCB
 fru
-nvh
+ide
 eiZ
 lCs
 yeV
@@ -89913,25 +90051,25 @@ yeV
 ydd
 sAS
 psQ
-pUn
+tzn
 qPL
-rLw
-sHa
-qnH
+tve
+tve
+tve
 ukO
-uWD
+xCr
 vPv
-kRU
-wAM
+meB
+meB
 ydx
 meB
 vON
-nvh
-rcv
-fBa
-tqv
+meB
+sFu
+dhM
+vTx
 xmc
-swv
+ide
 gGs
 gbZ
 yeV
@@ -90170,21 +90308,21 @@ yeV
 kPi
 oPZ
 psQ
-pUn
+tzn
 qQx
-qnH
-sHu
-qnH
-ulx
-kzR
-vPZ
-wzB
-wAM
-kRU
-kRU
+rLG
+tve
+xFW
+chN
+ide
+sJi
 xRn
-nis
-unt
+wAM
+wAM
+xRn
+xRn
+wAM
+wAM
 hEZ
 uLl
 daA
@@ -90427,24 +90565,24 @@ nCx
 exs
 nCx
 ptg
-pUn
+qkp
 qSz
 rLG
-sHE
+tve
 txp
 uno
 uXm
-vQb
-wzR
-xqb
-xFW
-xFW
-xFW
-iZM
-dxY
+dCB
+dCB
+dCB
+dCB
+dCB
+dCB
+dCB
+dCB
 dhM
-daA
-daA
+dCB
+dCB
 fwl
 nin
 toD
@@ -90686,21 +90824,21 @@ nEV
 puM
 pUn
 qUg
-rNv
-sIw
-rLw
+tve
+tve
+txp
 uoe
-uZH
-vRE
-wAt
+kzR
+dCB
+sNF
 xqP
-sNF
-sNF
+npP
+dCB
 sNF
 hIF
 htV
 vid
-gKP
+vQb
 gKP
 tGw
 wUt
@@ -90941,25 +91079,25 @@ yeV
 pZR
 oQe
 puU
-pUn
-qVA
-rNY
-sJi
-qnH
+tzn
+qVL
+tve
+tve
+eMZ
 ulx
-vaB
+kzR
 vPZ
-vSA
+upx
 xqU
-kRU
-kRU
-sVG
-swv
+lxx
+xqb
+lxx
+kUz
 lxx
 bhb
 wIH
-daA
-swv
+wDA
+ide
 dFz
 qOf
 yeV
@@ -91198,25 +91336,25 @@ yeV
 hrE
 lFF
 puU
-pUn
+tzn
 qVL
-rOk
-sMo
-qnH
-ukO
+tve
+tve
+txp
+ulx
 kzR
-vPv
-vSA
-kRU
+vTj
+wDA
+rcv
 mOK
 pRp
-xTy
-nvh
-chN
+qyr
+mOK
+mOK
 qyr
 tqv
 akH
-swv
+ide
 qiD
 xke
 yeV
@@ -91455,25 +91593,25 @@ yeV
 yeV
 kPi
 lBs
-mpQ
+xCr
 qVR
-rOC
-sMz
-qnH
+tve
+tve
+txp
 lRo
-mpQ
+kzR
 vTj
 vSA
-kRU
+xrz
 xFG
 cpv
-fdm
-nvh
 mRO
-qyr
-daA
+ihk
+mRO
+mRO
+iZM
 uDD
-nvh
+ide
 eiZ
 xke
 yeV
@@ -91712,25 +91850,25 @@ yeV
 yeV
 kPi
 puU
-mpQ
+xCr
 qWs
-qnH
-sMO
-qnH
+txG
+qPa
+syN
 tdh
 eir
-vTx
-qPa
+vTj
+wDA
 xrz
 eFf
 aYs
 aFI
-swv
 jQQ
-qyr
-daA
+jQQ
+lsh
+wzR
 sOc
-nvh
+ide
 eiZ
 gbZ
 yeV
@@ -91969,22 +92107,22 @@ yeV
 yeV
 kPi
 psQ
-mpQ
-mpQ
+xCr
+xCr
 rOZ
 sMO
 txC
-upx
-mpQ
-uXy
+xCr
+ide
+sVG
 wBu
 fqD
-qkp
-qkp
-xCr
-swv
+eFf
+fdm
+sIw
+iZV
 mVB
-qyr
+xrI
 mSU
 itN
 ide
@@ -92227,24 +92365,24 @@ yeV
 kPi
 puZ
 pUS
-mpQ
-mpQ
+tzn
+uVE
 sOa
-mpQ
+qYW
 xCr
-xCr
+ttU
 vUe
-wDy
-xrI
-nGD
+wDA
+wDA
+wDA
 tYs
-xCr
-swv
 swv
 rlT
+rlT
+rlT
+rlT
 swv
-nvh
-swv
+ide
 ide
 yeV
 yeV
@@ -92484,22 +92622,22 @@ yeV
 kPi
 yeV
 puU
-mpQ
+tzn
 rQR
 tyP
-txG
+rQR
 xCr
 xMw
-vUn
 wDA
-syN
-xGM
+wDA
+wDA
+sMo
 bEe
-qkp
-rLe
+vaB
+xke
 xGB
-ihk
-kMd
+xke
+xGB
 ybp
 ide
 ide
@@ -92741,28 +92879,28 @@ yeV
 kPi
 yeV
 puU
-mpQ
+tzn
 rRr
 sPw
 tyv
 xCr
 xnN
 rPc
-qYW
-cgQ
+wDA
+wDA
 qjn
 sQA
-qkp
+vaB
 sPH
 yeV
-dNh
+yeV
 yeV
 yeV
 vmN
 yeV
 kdZ
 wrY
-wEw
+scm
 giY
 ujd
 yeV
@@ -92998,18 +93136,18 @@ yeV
 pZR
 yeV
 puU
-mpQ
-mpQ
+xCr
+xCr
 sPA
-tyP
+sPA
 xCr
 mzt
 wdH
-jrt
+wDA
 tXH
-xCr
-xCr
-xCr
+ide
+vaB
+ide
 ifH
 vfM
 qIv
@@ -93022,11 +93160,11 @@ yeV
 yeV
 lnd
 buI
-wEw
-wEw
+scm
+scm
 xsw
-wEw
-wEw
+scm
+scm
 qBP
 yeV
 yeV
@@ -93256,15 +93394,15 @@ lrn
 ujd
 hcF
 lru
-mpQ
-mpQ
+xCr
+xCr
 tzn
 xCr
-xCr
-xCr
-qkp
-qkp
-xCr
+ide
+nis
+sHu
+vaB
+ide
 ujd
 efZ
 nfu
@@ -93515,12 +93653,12 @@ pUV
 yeV
 tGh
 sPE
-tzq
+yeV
 uqj
 jhI
 vUD
-wEw
-xsw
+ukA
+kMd
 xHB
 wEw
 wEw
@@ -93777,8 +93915,8 @@ uqD
 uqD
 qdP
 izx
-yeV
-yeV
+kZI
+vWk
 tmx
 pwt
 iGn
@@ -94284,7 +94422,7 @@ aUl
 pva
 yeV
 yeV
-yeV
+sMz
 wEa
 hra
 yeV
@@ -100167,9 +100305,9 @@ rLe
 rLe
 rLe
 ucD
-rLe
-rLe
-rLe
+hZu
+hZu
+hZu
 vlU
 rLe
 hZu
@@ -101978,7 +102116,7 @@ hcr
 wwo
 sJV
 ipR
-rLe
+hZu
 lgs
 lgs
 dkT
@@ -102235,7 +102373,7 @@ hcr
 hcr
 sJV
 ipR
-rLe
+hZu
 lgs
 lgs
 dFF
@@ -102492,7 +102630,7 @@ hcr
 hcr
 sJV
 ipR
-rLe
+hZu
 lgs
 lfc
 lfc
@@ -113557,7 +113695,7 @@ rLe
 wEa
 rLe
 rLe
-rLe
+hZu
 wiD
 dqg
 oJV
@@ -113814,7 +113952,7 @@ rLe
 rLe
 rLe
 rLe
-rLe
+hZu
 wiD
 dqg
 dqg

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -5679,15 +5679,12 @@
 /area/quartermaster/storage)
 "eXU" = (
 /obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/crew_quarters/cafeteria)
 "eXV" = (
 /obj/machinery/fusion_fuel_injector/mapped{
 	dir = 1;
@@ -6217,18 +6214,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
-"fyc" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost)
 "fyv" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -8406,6 +8391,12 @@
 	outdoors = 1
 	},
 /area/surface/outpost/main/landing)
+"hqv" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "hqF" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -9905,6 +9896,17 @@
 	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
+"iMj" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/crew_quarters/cafeteria)
 "iMR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -14552,11 +14554,13 @@
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "mFz" = (
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/crew_quarters/cafeteria)
 "mFN" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -20416,11 +20420,10 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/sc/sd)
 "qUx" = (
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/crew_quarters/cafeteria)
 "qUz" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/device/gps/security,
@@ -24281,13 +24284,17 @@
 	},
 /area/crew_quarters/cafeteria)
 "ugJ" = (
-/obj/structure/railing{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost/sky)
+/area/surface/outside/plains/outpost)
 "ugQ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -24640,14 +24647,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
-"utA" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint{
-	outdoors = 1
-	},
-/area/surface/outside/plains/outpost/sky)
 "utW" = (
 /obj/structure/toilet{
 	dir = 1
@@ -56856,14 +56855,14 @@ lCw
 mmR
 dwp
 qeQ
-utA
-umZ
-umZ
-umZ
-umZ
 mFz
 qUx
-fyc
+qUx
+qUx
+qUx
+ueR
+hqv
+ugJ
 gZN
 osy
 pur
@@ -57113,14 +57112,14 @@ sHq
 fsZ
 uWp
 qeQ
-utA
-umZ
-umZ
-umZ
-umZ
-npA
+mFz
 qUx
-fyc
+qUx
+qUx
+qUx
+npA
+hqv
+ugJ
 eJM
 aLG
 tBg
@@ -57370,11 +57369,11 @@ qeQ
 qeQ
 qeQ
 qeQ
+iMj
 eXU
-ugJ
-ugJ
-ugJ
-ugJ
+eXU
+eXU
+eXU
 aLG
 aHc
 jZj

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -599,7 +599,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "avC" = (
 /obj/machinery/status_display{
 	pixel_x = 30
@@ -3986,7 +3986,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "dFk" = (
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outside/plains/outpost)
@@ -5265,7 +5265,7 @@
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/atmos/storage)
 "eEV" = (
 /obj/structure/cable/green{
 	d1 = 32;
@@ -5368,7 +5368,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/crew_quarters/cafeteria)
@@ -5678,24 +5678,16 @@
 	},
 /area/quartermaster/storage)
 "eXU" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/plains/outpost/sky)
 "eXV" = (
 /obj/machinery/fusion_fuel_injector/mapped{
 	dir = 1;
@@ -6225,6 +6217,18 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
+"fyc" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost)
 "fyv" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -7030,11 +7034,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/reinforced{
 	outdoors = 1
@@ -8626,7 +8625,7 @@
 /turf/simulated/floor/plating{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/engine_monitoring)
 "hAJ" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/simulated/floor/tiled/dark{
@@ -10565,15 +10564,10 @@
 	c_tag = "CIV - Hangar Pad 4 Southwest";
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "jnG" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/clothing/suit/storage/hazardvest/green,
@@ -14558,20 +14552,11 @@
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "mFz" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/plains/outpost/sky)
 "mFN" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -15476,7 +15461,7 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/turf/simulated/open{
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/crew_quarters/cafeteria)
@@ -15851,7 +15836,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "nJo" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -20431,16 +20416,8 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/sc/sd)
 "qUx" = (
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on";
-	picked_color = "Burgundy"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/reinforced{
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
 /area/surface/outside/plains/outpost)
@@ -21495,11 +21472,6 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
@@ -22239,7 +22211,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "ssj" = (
 /obj/structure/bed/double/padded,
 /obj/machinery/light_switch{
@@ -24309,24 +24281,13 @@
 	},
 /area/crew_quarters/cafeteria)
 "ugJ" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/surface/outside/plains/outpost/sky)
 "ugQ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -24679,6 +24640,14 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/milspec,
 /area/surface/outpost/civilian/emergency_storage)
+"utA" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint{
+	outdoors = 1
+	},
+/area/surface/outside/plains/outpost/sky)
 "utW" = (
 /obj/structure/toilet{
 	dir = 1
@@ -26470,7 +26439,7 @@
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "vTu" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "Xenobotany Rooftop East Exterior Camera";
@@ -26849,23 +26818,14 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Hangar Pad 4 Southeast";
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "wqZ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -29021,15 +28981,10 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techmaint{
 	outdoors = 1
 	},
-/area/surface/outside/plains/outpost)
+/area/engineering/external_lights)
 "ylo" = (
 /turf/simulated/open,
 /area/surface/outpost/civilian/emergency_storage)
@@ -56901,15 +56856,15 @@ lCw
 mmR
 dwp
 qeQ
-uPP
-pur
-pur
-pur
-pur
-uUk
-bxY
-fGn
-uPP
+utA
+umZ
+umZ
+umZ
+umZ
+mFz
+qUx
+fyc
+gZN
 osy
 pur
 pur
@@ -57158,14 +57113,14 @@ sHq
 fsZ
 uWp
 qeQ
-uPP
-pur
-pur
-pur
-pur
+utA
+umZ
+umZ
+umZ
+umZ
 npA
-bxY
-fGn
+qUx
+fyc
 eJM
 aLG
 tBg
@@ -57415,11 +57370,11 @@ qeQ
 qeQ
 qeQ
 qeQ
-sAW
-jZD
-jZD
-jZD
-jZD
+eXU
+ugJ
+ugJ
+ugJ
+ugJ
 aLG
 aHc
 jZj
@@ -73320,11 +73275,11 @@ ppQ
 ppQ
 ppQ
 ppQ
-eXU
-ugJ
-ugJ
-ugJ
-ugJ
+ppQ
+ppQ
+ppQ
+ppQ
+ppQ
 ykZ
 wjN
 wjN
@@ -73582,7 +73537,7 @@ vQW
 lJN
 lJN
 xbk
-qUx
+dpI
 jlL
 uPP
 pur
@@ -73840,7 +73795,7 @@ dEO
 lJN
 bMb
 jar
-mFz
+oXm
 uPP
 pur
 pur
@@ -74097,7 +74052,7 @@ lJN
 lJN
 jar
 mBG
-mFz
+oXm
 uPP
 pur
 pur
@@ -74354,7 +74309,7 @@ czv
 czv
 jar
 lcW
-mFz
+oXm
 uPP
 pur
 pur
@@ -74868,7 +74823,7 @@ lJN
 lJN
 arW
 jar
-mFz
+oXm
 uPP
 pur
 pur
@@ -75125,7 +75080,7 @@ vQW
 czv
 jdQ
 utZ
-mFz
+oXm
 uPP
 pur
 pur
@@ -75382,7 +75337,7 @@ lJN
 czv
 jar
 lcW
-mFz
+oXm
 uPP
 pur
 pur
@@ -75639,7 +75594,7 @@ lJN
 lJN
 nOS
 mBG
-mFz
+oXm
 uPP
 pur
 pur
@@ -75896,7 +75851,7 @@ vxs
 lJN
 jar
 jar
-mFz
+oXm
 uPP
 pur
 pur


### PR DESCRIPTION

## About The Pull Request

A remap for the service gathering area was requested so here's my attempt. I don't think I missed anything but if I did, let me know and I can add either pre or post merge. The main goals requested were
- Move hydroponics upstairs so service workers are not hidden away when gathering ingredients
- Give the bar it's separate identity from the diner for a different vibe whilst keeping the diner
I think I just about achieved that... more or less.

## Changelog
:cl:
add: Added a missing emergency shutter on the garden storage (oops)
del: Removed a redundant APC in an area that should be unpowered (outpost perimeter - let me know if this breaks anything I missed)
fix: Fixed a few lights not in powered areas that weren't working
fix: Fixed an incorrectly coloured cable end
fix: Replaced some grass tiles with steel tiles that were under stairs to hopefully prevent weird flora spawn inside staircases
maptweak: Reworked the whole Diner and hydroponics area
maptweak: Diner entrances reworked. No lobby anymore, with entrances moved to be more friendly to the new layout. Old lobby area is now part of the main area
maptweak: Hydroponics moved to the ground floor where the kitchen used to be. Added a farm and beehive area.
maptweak: Bar split off from Diner. Diner area on the west side and bar on the east side. Changed the shutters to be more like shop shutters
maptweak: Freezer and Bar Backroom storage moves downstairs
maptweak: Added a downstairs public restroom area under the bar.
maptweak: Added some more roofing upstairs past the balconies to cover the extended bar and diner area
maptweak: Moved a few objects around outside and re-jigged some atmos and power grids to account for the new layout
/:cl:
