### PR TITLE
Some more tweaks

### DIFF
--- a/maps/relic_base/relicbase-12.dmm
+++ b/maps/relic_base/relicbase-12.dmm
@@ -4527,9 +4527,6 @@
 /turf/simulated/floor/tiled/old_tile/white,
 /area/centcom/medical)
 "dZq" = (
-/obj/machinery/vending/medical{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -15934,6 +15931,10 @@
 	icon_state = "dark"
 	},
 /area/centcom/creed)
+"rMF" = (
+/obj/machinery/vending/medical,
+/turf/simulated/wall/bay/r_wall/black,
+/area/centcom/medical)
 "rMY" = (
 /turf/simulated/shuttle/floor/red,
 /area/shuttle/response_ship{
@@ -33409,7 +33410,7 @@ wWS
 wWS
 wWS
 wWS
-wWS
+rMF
 dZq
 xdP
 hGO

--- a/maps/relic_base/relicbase-2.dmm
+++ b/maps/relic_base/relicbase-2.dmm
@@ -4397,6 +4397,15 @@
 /area/maintenance/firstdeck/foreport{
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
+"dSj" = (
+/obj/machinery/vending/wardrobe/bardrobe,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "dSm" = (
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/fueltank,
@@ -6717,7 +6726,7 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 	})
 "fXY" = (
-/obj/machinery/computer/cloning/resleeving,
+/obj/machinery/computer/transhuman/resleeving,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -14425,11 +14434,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -54806,7 +54810,7 @@ uWQ
 wFq
 wFq
 cIK
-cIK
+dSj
 oRK
 jGu
 cIK

--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -159,6 +159,10 @@
 /obj/structure/fence,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/surface/outside/plains/outpost)
+"ado" = (
+/obj/machinery/vending/cart,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/engineering/external_lights)
 "adz" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1929,7 +1933,7 @@
 	name = "Barista"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/cafeteria)
+/area/crew_quarters/bar)
 "aYt" = (
 /obj/machinery/door/airlock/medical{
 	name = "Autoresleever Access";
@@ -3384,6 +3388,10 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/crew_quarters/heads/sc/hos)
+"bIu" = (
+/obj/machinery/vending/giftvendor,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/engineering/external_lights)
 "bIz" = (
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -3679,6 +3687,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
+"bQb" = (
+/obj/machinery/door/blast/gate/thin{
+	layer = 3.1;
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/structure/table/marble,
+/obj/machinery/door/firedoor/border_only,
+/obj/item/device/juke_remote,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "bQd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -4652,9 +4672,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4)
 "clS" = (
@@ -4779,9 +4796,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_6)
@@ -4963,8 +4977,9 @@
 	id = "bar";
 	name = "Bar Shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood,
-/area/crew_quarters/cafeteria)
+/area/crew_quarters/bar)
 "cpZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9819,6 +9834,10 @@
 /area/surface/outpost/main/landing/two)
 "eda" = (
 /obj/structure/closet/crate/freezer,
+/obj/machinery/alarm/freezer{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "edc" = (
@@ -11273,8 +11292,9 @@
 	id = "bar";
 	name = "Bar Shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood,
-/area/crew_quarters/cafeteria)
+/area/crew_quarters/bar)
 "eFk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11342,9 +11362,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_10)
@@ -12435,15 +12452,9 @@
 /turf/simulated/floor/bmarble,
 /area/engineering/hallway/engineer_hallway)
 "fdm" = (
-/obj/structure/table/hardwoodtable,
-/obj/machinery/door/blast/gate/thin{
-	layer = 3.1;
-	id = "bar";
-	name = "Bar Shutters";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/cafeteria)
+/obj/machinery/vending/loadout/gadget,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/engineering/external_lights)
 "fdn" = (
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/outdoors/dirt,
@@ -18603,6 +18614,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/holodeck_control)
+"hzq" = (
+/obj/machinery/lapvend,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/engineering/external_lights)
 "hzs" = (
 /obj/structure/hull_corner,
 /turf/simulated/floor/outdoors/grass/heavy,
@@ -20222,6 +20237,7 @@
 /obj/machinery/cash_register/civilian{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "iiF" = (
@@ -20546,6 +20562,7 @@
 "ipX" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/pink/border,
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "iqf" = (
@@ -22185,9 +22202,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7)
@@ -23955,6 +23969,7 @@
 	},
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/engineering/workshop)
 "jNR" = (
@@ -24222,6 +24237,9 @@
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre Storage";
 	req_access = list(45)
+	},
+/obj/structure/fans/hardlight/colorable{
+	light_color = "#D7D7D7"
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery_storage)
@@ -24753,6 +24771,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/surgery2)
+"kej" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "keA" = (
 /obj/machinery/door/airlock/engineering{
 	name = "SMES Room";
@@ -24780,9 +24803,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_1)
@@ -26902,6 +26922,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "kZX" = (
@@ -29483,6 +29509,7 @@
 	c_tag = "EXT - Gateway/Cryo West 2";
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/hallway/primary/thirddeck/stationgateway)
 "mdI" = (
@@ -29533,6 +29560,7 @@
 	name = "Kitchen Shutters";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "meE" = (
@@ -29797,7 +29825,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/machinery/cell_charger,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "mku" = (
@@ -31492,6 +31520,8 @@
 	id = "bar";
 	name = "Bar Shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/device/juke_remote,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "mRP" = (
@@ -38123,9 +38153,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2)
 "pMp" = (
@@ -42128,9 +42155,6 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9)
 "rqi" = (
@@ -44581,8 +44605,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5)
@@ -44662,9 +44687,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3)
@@ -45370,6 +45392,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/vending/wardrobe/chefdrobe,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sFn" = (
@@ -45390,6 +45413,7 @@
 	dir = 2
 	},
 /obj/structure/table/marble,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "sGf" = (
@@ -45491,6 +45515,7 @@
 	name = "Bar Shutters";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "sIA" = (
@@ -49388,6 +49413,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/fans/hardlight/colorable{
+	light_color = "#D7D7D7"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/surgery_storage)
 "unW" = (
@@ -51049,9 +51077,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_8)
@@ -53742,6 +53767,7 @@
 /obj/item/weapon/material/kitchen/utensil/spoon{
 	pixel_x = 2
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "vOV" = (
@@ -53765,6 +53791,7 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
 	pixel_x = 3
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "vPZ" = (
@@ -55455,7 +55482,7 @@
 /area/medical/foyer)
 "wwJ" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "wwL" = (
@@ -55544,6 +55571,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/prep/recovery)
+"wyu" = (
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/hydro,
+/area/hydroponics)
 "wyC" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Tool Storage South"
@@ -58758,8 +58793,9 @@
 	id = "bar";
 	name = "Bar Shutters"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood,
-/area/crew_quarters/cafeteria)
+/area/crew_quarters/bar)
 "xFS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59502,7 +59538,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/cell_charger,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "xSu" = (
@@ -60183,6 +60219,7 @@
 	name = "Kitchen Shutters";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "ydP" = (
@@ -88527,8 +88564,8 @@ mpQ
 dNI
 kMd
 qVA
-xke
-xke
+xGB
+xGB
 yeV
 yeV
 yeV
@@ -89028,7 +89065,7 @@ xCr
 xCr
 rNv
 tvo
-ufQ
+wyu
 xCr
 uZH
 qnH
@@ -89048,11 +89085,11 @@ yeV
 yeV
 rLe
 pvD
-hra
-rLe
-rLe
+eiZ
+eiZ
+eiZ
 mda
-rLe
+eiZ
 qfb
 qfb
 nKF
@@ -89556,7 +89593,7 @@ fBa
 dCB
 qos
 vaB
-eiZ
+hzq
 qaW
 yeV
 yeV
@@ -89808,12 +89845,12 @@ xcj
 xcj
 xcj
 xTy
-sFu
+bQb
 dhM
 dCB
 fru
 ide
-eiZ
+ado
 lCs
 yeV
 yeV
@@ -91351,7 +91388,7 @@ pRp
 qyr
 mOK
 mOK
-qyr
+wDA
 tqv
 akH
 ide
@@ -91605,14 +91642,14 @@ vSA
 xrz
 xFG
 cpv
-mRO
+cpv
 ihk
 mRO
-mRO
+kej
 iZM
 uDD
 ide
-eiZ
+fdm
 xke
 yeV
 yeV
@@ -91869,7 +91906,7 @@ lsh
 wzR
 sOc
 ide
-eiZ
+bIu
 gbZ
 yeV
 yeV
@@ -92118,7 +92155,7 @@ sVG
 wBu
 fqD
 eFf
-fdm
+sIw
 sIw
 iZV
 mVB
@@ -92636,7 +92673,7 @@ bEe
 vaB
 xke
 xGB
-xke
+xGB
 xGB
 ybp
 ide

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -2683,6 +2683,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "czd" = (
@@ -3002,6 +3005,10 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
@@ -3762,6 +3769,9 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_10/upstairs)
@@ -4549,6 +4559,9 @@
 /area/quartermaster/warehouse)
 "ecc" = (
 /obj/structure/toilet,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_10/upstairs)
 "eck" = (
@@ -5641,6 +5654,10 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_1/upstairs)
 "eVr" = (
@@ -5904,6 +5921,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
 "ffP" = (
@@ -5970,6 +5991,10 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
@@ -9025,6 +9050,9 @@
 /area/security/prison)
 "hXX" = (
 /obj/structure/toilet,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
 "hYm" = (
@@ -10409,6 +10437,9 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "jhz" = (
@@ -10990,6 +11021,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "jLf" = (
@@ -11528,6 +11562,10 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "khA" = (
@@ -11992,6 +12030,10 @@
 	icon_state = "freezer"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_isolation)
 "kyA" = (
@@ -14275,6 +14317,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
 "mxB" = (
@@ -15273,6 +15318,9 @@
 /area/surface/outpost/civilian/pool)
 "nji" = (
 /obj/structure/toilet,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_9/upstairs)
 "njs" = (
@@ -15564,6 +15612,9 @@
 /area/library_conference_room)
 "ntf" = (
 /obj/structure/toilet,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "nvF" = (
@@ -15861,6 +15912,10 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
@@ -17139,6 +17194,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "oLm" = (
@@ -17929,6 +17988,9 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_8/upstairs)
 "pmB" = (
@@ -18103,6 +18165,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
 "ptm" = (
@@ -19521,10 +19587,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -20552,6 +20616,10 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_5/upstairs)
 "rap" = (
@@ -20994,6 +21062,10 @@
 "rtc" = (
 /obj/structure/toilet{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_4/upstairs)
@@ -21766,6 +21838,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "rYS" = (
@@ -23584,6 +23660,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_3/upstairs)
 "tCj" = (
@@ -23735,6 +23815,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open{
 	outdoors = 1
 	},
@@ -24651,6 +24735,10 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "utZ" = (
@@ -25233,6 +25321,10 @@
 "uSK" = (
 /obj/structure/toilet{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/main/dorms/dorm_2/upstairs)
@@ -26264,6 +26356,10 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_1/upstairs)
 "vOl" = (
@@ -26292,6 +26388,10 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_1/upstairs)
@@ -26498,6 +26598,9 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_7/upstairs)
 "vZt" = (
@@ -27279,6 +27382,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/wood,
 /area/surface/outpost/main/dorms/dorm_6/upstairs)
 "wPm" = (
@@ -27825,6 +27932,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xnr" = (
@@ -28556,6 +28667,9 @@
 /obj/structure/table/woodentable,
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/open,
 /area/surface/outpost/main/dorms/dorm_10/upstairs)
 "xTj" = (

--- a/maps/relic_base/relicbase-4.dmm
+++ b/maps/relic_base/relicbase-4.dmm
@@ -3082,9 +3082,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
 "cOU" = (
@@ -4365,10 +4362,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 9;
-	name = "Reinforced Window Nugget"
 	},
 /obj/structure/catwalk,
 /obj/item/device/geiger/wall/east,


### PR DESCRIPTION
## About The Pull Request

Making a few requested adjustments suggested by a few people, including adding the jukeboxes to allow the jukebox music to travel should the bartender want to listen in etc. I tried var-editing the jukeboxes to be mapped in paired but BYOND wasn't having it, so they need to be manually paired each round unless someone else can figure out how to do that. Also fixed a few other small mapping issues that I've spotted since and added a couple of small nice things.

## Changelog
:cl:
add: Added uniform vendors to bar storage and kitchen
add: Added sugar and flour locker to kitchen that was previously missed (replacing the extra meat locker)
add: Added a drinks fridge to the bar
add: Added emergency shutters to teh bar and kitchen counters
add: Added a box of masks and gloves outside of surgery so medical don't have to borrow viro's boxes anymore
add: Added boomboxes to the bar and kitchen to pair with the jukebox so that the service members aren't left out
add: Added a sink to hydroponics
add: Added air alamrs to areas that were previously missing them: Dorms and Xenobotany
add: Added some tech vendors outside the bar that were previously missing from the map (as far as I can see)
del: Removed dormitory spawns for assistants (I don't think these could crash into a dorms scene but there's plenty of other assisstant spawns so I just nixxed these)
del: Removed the corner window nuggets around the stairs on the upper floor engine entrance (these were preventing interactions with neighbouring tiles for some reason, preventing clicking the door etc)
fix: Replace the maints resleeving console with a functional one
maptweak: Extended the bar area to cover the full counter
maptweak: Moved the CentCom level NanoMed Plus so it's not blocking the tile in front of it
maptweak: Replace medical's chargers with basic (the correct) chargers so that defibs can be recharged (was previously heavy duty). Added a basic charging station to engineering storage.
/:cl:
