### PR TITLE
Fixes ores not spawning in the surface mines

### DIFF
--- a/maps/relic_base/relicbase-10.dmm
+++ b/maps/relic_base/relicbase-10.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/simulated/mineral/cave,
+/turf/simulated/mineral/sif,
 /area/surface/outside/wilderness/mountains)
 "ad" = (
 /obj/machinery/light{
@@ -152,7 +152,7 @@
 	name = "Surface Mines Operations Pad"
 	})
 "ox" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/surface/outside/path)
 "oT" = (
 /obj/machinery/light{

--- a/maps/relic_base/relicbase_defines.dm
+++ b/maps/relic_base/relicbase_defines.dm
@@ -251,9 +251,15 @@
 	base_turf = /turf/simulated/floor/outdoors/rocks
 */
 
-/datum/map_z_level/relicbase/surface_mine
+/datum/map_z_level/relicbase/undeground_mine
 	z = Z_LEVEL_UNDERMINES
 	name = "Underground Mines"
+	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
+	base_turf = /turf/simulated/floor/outdoors/rocks
+
+/datum/map_z_level/relicbase/surface_mine
+	z = Z_LEVEL_SURFACE_MINES
+	name = "Surface Mines"
 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 


### PR DESCRIPTION

## About The Pull Request
Changed the surface mines turfs so they no longer accidentally change to ignore_mapgen. I have also properly defined the surface mine z-level flags.
## Changelog
:cl:

fix: Fixes ores not spawning in the surface mines
/:cl:
