### PR TITLE
Disable surface mines

### DIFF
--- a/maps/relic_base/relicbase-3.dmm
+++ b/maps/relic_base/relicbase-3.dmm
@@ -5213,7 +5213,8 @@
 /area/rnd/research)
 "cud" = (
 /obj/machinery/door/airlock/voidcraft{
-	name = "Wilderness Containment"
+	name = "Wilderness Containment";
+	locked = 1
 	},
 /obj/structure/cable/heavyduty{
 	d1 = 4;
@@ -16551,12 +16552,6 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/surface/outpost/main/dorms/dorm_8)
-"gKX" = (
-/obj/effect/map_effect/portal/line/side_a{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/surface/outpost/wall/checkpoint)
 "gLq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -16839,12 +16834,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/chapel/office)
-"gRP" = (
-/obj/effect/map_effect/portal/line/side_a{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/surface/outpost/wall/checkpoint)
 "gRR" = (
 /obj/machinery/camera/network/exterior{
 	c_tag = "EXT - Research South 5"
@@ -32566,6 +32555,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/debriefing)
+"nnB" = (
+/obj/machinery/door/airlock/voidcraft{
+	name = "Wilderness Containment";
+	locked = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/surface/outpost/wall/checkpoint)
 "nnE" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -52970,9 +52966,6 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/civilian/fishing)
 "vwo" = (
-/obj/effect/map_effect/portal/line/side_a{
-	dir = 4
-	},
 /turf/unsimulated/wall/planetary/normal/thor,
 /area/surface/outpost/wall/checkpoint)
 "vwr" = (
@@ -57486,13 +57479,6 @@
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/cafeteria)
-"xml" = (
-/obj/effect/map_effect/portal/master/side_a{
-	dir = 4;
-	portal_id = "outpost_to_mines"
-	},
-/turf/unsimulated/wall/planetary/normal/thor,
-/area/surface/outpost/wall/checkpoint)
 "xmn" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -60814,13 +60800,13 @@ tMO
 tUG
 dJR
 vwo
-gKX
-gRP
-gRP
-gRP
-gRP
-gKX
-xml
+aBh
+abg
+abg
+abg
+abg
+aBh
+vwo
 tMO
 tMO
 tMO
@@ -61589,7 +61575,7 @@ acm
 cud
 jQM
 cPd
-adb
+nnB
 acm
 isN
 isN

--- a/maps/relic_base/relicbase.dm
+++ b/maps/relic_base/relicbase.dm
@@ -53,7 +53,7 @@
 	#include "relicbase-7.dmm"	//Wilderness - Z7
 	// #include "relicbase-8.dmm"  //Wilderness sky - Z8
 	#include "relicbase-9.dmm" //Ocean/Plains - Z9
-	#include "relicbase-10.dmm" //Surface Mines - Z10
+	// #include "relicbase-10.dmm" //Surface Mines - Z10
 	#include "relicbase-11.dmm" //Explo carrier - Z11
 	#include "relicbase-12.dmm" //CC - Z12
 	#include "relicbase-13.dmm" //Transit - Z13

--- a/maps/relic_base/relicbase_defines.dm
+++ b/maps/relic_base/relicbase_defines.dm
@@ -9,16 +9,16 @@
 #define Z_LEVEL_SURFACE_WILDS			7
 // #define Z_LEVEL_WILDERNESS_SKY			8
 #define Z_LEVEL_SURFACE_OCEAN			8
-#define Z_LEVEL_SURFACE_MINES			9
-#define Z_LEVEL_CARRIER 				10
-#define Z_LEVEL_CENTCOM					11
-#define Z_LEVEL_TRANSIT					12
+// #define Z_LEVEL_SURFACE_MINES			9
+#define Z_LEVEL_CARRIER 				9
+#define Z_LEVEL_CENTCOM					10
+#define Z_LEVEL_TRANSIT					11
 
 
 
-#define Z_LEVEL_FUELDEPOT				13
-#define Z_LEVEL_GATEWAY					14
-#define Z_LEVEL_REDGATE					15
+#define Z_LEVEL_FUELDEPOT				12
+#define Z_LEVEL_GATEWAY					13
+#define Z_LEVEL_REDGATE					14
 
 // Camera Network Additions
 #define NETWORK_EXTERIOR "Exterior" // Exterior Cameras
@@ -103,7 +103,7 @@
 			Z_LEVEL_UPPER_FLOORS,
 			Z_LEVEL_UNDERMINES,
 			Z_LEVEL_SURFACE_WILDS,
-			Z_LEVEL_SURFACE_MINES,
+			// Z_LEVEL_SURFACE_MINES,
 			// Z_LEVEL_WILDERNESS_SKY,
 			Z_LEVEL_SURFACE_OCEAN,
 			Z_LEVEL_THE_SKY,
@@ -179,7 +179,7 @@
 	// Cave submaps are first.
 	seed_submaps(list(Z_LEVEL_UNDERMINES), 140, /area/surface/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
 	seed_submaps(list(Z_LEVEL_UNDERMINES), 140, /area/surface/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)
-	seed_submaps(list(Z_LEVEL_SURFACE_MINES), 140, /area/surface/outside/wilderness/mountains, /datum/map_template/surface/mountains/normal)
+	// seed_submaps(list(Z_LEVEL_SURFACE_MINES), 140, /area/surface/outside/wilderness/mountains, /datum/map_template/surface/mountains/normal)
 	// Plains to make them less plain.
 	seed_submaps(list(Z_LEVEL_SURFACE), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Both of these will need a massive POI overhaul. The framework is in, and tiles will be mass-edited to match, but better POIs are wanted.
 	seed_submaps(list(Z_LEVEL_SURFACE_OCEAN), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Both of these will need a massive POI overhaul. The framework is in, and tiles will be mass-edited to match, but better POIs are wanted.
@@ -192,8 +192,8 @@
 	// Now for the tunnels. (This decides the load order of ore generation and cave generation. Check Random_Map to see % )
 	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_UNDERMINES, world.maxx, world.maxy) // Create the mining Z-level.
 	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_UNDERMINES, 64, 64)         // Create the mining ore distribution map.
-	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_SURFACE_MINES, world.maxx, world.maxy) // Create the mining Z-level.
-	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_SURFACE_MINES, 64, 64)
+	// new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_SURFACE_MINES, world.maxx, world.maxy) // Create the mining Z-level.
+	// new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_SURFACE_MINES, 64, 64)
 	// Todo: Forest generation.
 	return 1
 
@@ -257,11 +257,11 @@
 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
-/datum/map_z_level/relicbase/surface_mine
-	z = Z_LEVEL_SURFACE_MINES
-	name = "Surface Mines"
-	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
-	base_turf = /turf/simulated/floor/outdoors/rocks
+// /datum/map_z_level/relicbase/surface_mine
+// 	z = Z_LEVEL_SURFACE_MINES
+// 	name = "Surface Mines"
+// 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
+// 	base_turf = /turf/simulated/floor/outdoors/rocks
 
 /datum/map_z_level/relicbase/surface_wild
 	z = Z_LEVEL_SURFACE_WILDS
@@ -340,7 +340,7 @@
 		Z_LEVEL_UNDERGROUND,
 		Z_LEVEL_UPPER_FLOORS,
 		Z_LEVEL_SURFACE_WILDS,
-		Z_LEVEL_SURFACE_MINES,
+		// Z_LEVEL_SURFACE_MINES,
 		// Z_LEVEL_WILDERNESS_SKY,
 		Z_LEVEL_UNDERMINES,
 		Z_LEVEL_SURFACE_OCEAN,

--- a/maps/relic_base/turfs/outdoors.dm
+++ b/maps/relic_base/turfs/outdoors.dm
@@ -330,7 +330,7 @@
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
 
-// #ifdef Z_LEVEL_SURFACE_MINES
+#ifdef Z_LEVEL_UNDERMINES
 //Dealing with having mining POIs spawn on different Z levels
 /turf/simulated/mineral/Initialize()
 	. = ..()
@@ -346,7 +346,7 @@
 			ChangeTurf(/turf/simulated/mineral/thor/ignore_mapgen)
 		else
 			ChangeTurf(/turf/simulated/mineral/thor/floor/ignore_mapgen)
-// #endif
+#endif
 
 /turf/unsimulated/wall/planetary/normal/thor
 	oxygen		= MOLES_O2SIF

--- a/maps/relic_base/turfs/outdoors.dm
+++ b/maps/relic_base/turfs/outdoors.dm
@@ -330,23 +330,23 @@
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
 
-#ifdef Z_LEVEL_SURFACE_MINES
+// #ifdef Z_LEVEL_SURFACE_MINES
 //Dealing with having mining POIs spawn on different Z levels
 /turf/simulated/mineral/Initialize()
 	. = ..()
 	if(istype(src, /turf/simulated/mineral/thor) || istype(src, /turf/simulated/mineral/sif) || istype(src, /turf/simulated/mineral/floor/sif) || istype(src, /turf/simulated/mineral/ignore_mapgen/sif) || istype(src, /turf/simulated/mineral/floor/ignore_mapgen/sif))
 		return
-	if(src.z == Z_LEVEL_SURFACE_MINES)
-		if(density)
-			ChangeTurf(/turf/simulated/mineral/ignore_mapgen/sif)
-		else
-			ChangeTurf(/turf/simulated/mineral/floor/ignore_mapgen/sif)
+	// if(src.z == Z_LEVEL_SURFACE_MINES)
+	// 	if(density)
+	// 		ChangeTurf(/turf/simulated/mineral/ignore_mapgen/sif)
+	// 	else
+	// 		ChangeTurf(/turf/simulated/mineral/floor/ignore_mapgen/sif)
 	if(src.z == Z_LEVEL_UNDERMINES)
 		if(density)
 			ChangeTurf(/turf/simulated/mineral/thor/ignore_mapgen)
 		else
 			ChangeTurf(/turf/simulated/mineral/thor/floor/ignore_mapgen)
-#endif
+// #endif
 
 /turf/unsimulated/wall/planetary/normal/thor
 	oxygen		= MOLES_O2SIF


### PR DESCRIPTION

## About The Pull Request
Similar to the recent wilderness sky z-level PR, this PR disables the surface mines to improve initialization and restart times and reduce memory usage. 

This should also be test merged first.
## Changelog
:cl:
del: Disables the surface mines z-level to improve performance
/:cl:
