### PR TITLE
Manual Port of #9657 - prvents ghosts from leaving / getting tossed out bellies in areas with BLOCK ghosts flag

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -211,7 +211,7 @@ Works together with spawning an observer, noted above.
 	if(!isturf(loc))
 		return
 	var/area/A = get_area(src)
-	if(A.flag_check(AREA_BLOCK_GHOSTS))
+	if(A.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(loc))
 		to_chat(src, span_warning("Ghosts can't enter this location."))
 		return_to_spawn()
 
@@ -469,7 +469,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//RS Port #658 Start
 	var/area/A = get_area(destination)
-	if(A.flag_check(AREA_BLOCK_GHOSTS))
+	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination) && !admin_ghosted)
 		to_chat(src,span_warning("Sorry, that area does not allow ghosts."))
 		if(following)
 			stop_following()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -469,7 +469,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//RS Port #658 Start
 	var/area/A = get_area(destination)
-	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination) && !admin_ghosted)
+	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination))
 		to_chat(src,span_warning("Sorry, that area does not allow ghosts."))
 		if(following)
 			stop_following()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -364,14 +364,15 @@
 	return Move(n, direct, movetime)
 
 
-//ChompEDIT START
 //Set your incorporeal movespeed
 //Important to note: world.time is always in deciseconds. Higher tickrates mean more subdivisions of world.time (20fps = 0.5, 40fps = 0.25)
 /client
-	var/incorporeal_speed = 0.5
+	var/is_leaving_belly = FALSE
+	var/incorporeal_speed = 0.5 // CHOMPAdd
 
+//ChompEDIT START
 /client/verb/set_incorporeal_speed()
-	set category = "OOC.Game Settings" //CHOMPEdit
+	set category = "OOC.Game Settings"
 	set name = "Set Incorporeal Speed"
 
 	var/input = tgui_input_number(usr, "Set an incorporeal movement delay between 0 (fastest) and 5 (slowest)", "Incorporeal movement speed", (0.5/world.tick_lag), 5, 0)
@@ -382,6 +383,14 @@
 ///Called by client/Move()
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
+	if(isbelly(mob.loc) && isobserver(mob))
+		if(is_leaving_belly)
+			return
+		is_leaving_belly = TRUE
+		if(tgui_alert(mob, "Do you want to leave your predator's belly?", "Leave belly?", list("Yes", "No")) != "Yes")
+			is_leaving_belly = FALSE
+			return
+		is_leaving_belly = FALSE
 	var/turf/mobloc = get_turf(mob)
 
 	//ChompEDIT START
@@ -410,10 +419,10 @@
 				if(isliving(mob) && A.flag_check(AREA_BLOCK_PHASE_SHIFT))
 					to_chat(mob, span_warning("Something blocks you from entering this location while phased out."))
 					return
-				if(isobserver(mob) && A.flag_check(AREA_BLOCK_GHOSTS))
+				if(isobserver(mob) && A.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(mob.loc))
 					to_chat(mob, span_warning("Ghosts can't enter this location."))
 					var/area/our_area = mobloc.loc
-					if(our_area.flag_check(AREA_BLOCK_GHOSTS))
+					if(our_area.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(mob.loc))
 						var/mob/observer/dead/D = mob
 						D.return_to_spawn()
 					return


### PR DESCRIPTION

## About The Pull Request
Manual port of https://github.com/CHOMPStation2/CHOMPStation2/pull/9657 because the bot missed it.
Original PR: https://github.com/VOREStation/VOREStation/pull/16726
## Changelog
:cl:
fix:fixes an issue where ghosts got kicked out of bellies in no ghost areas and prevents them from just jumping out while the pred is in that area
add: popup for ghosts upon leaving a belly to prevent accidental leaving
/:cl:
